### PR TITLE
fix(pdp): stop product options from flashing on load

### DIFF
--- a/template_266.html
+++ b/template_266.html
@@ -606,6 +606,32 @@ document.addEventListener("DOMContentLoaded", function () {
   } catch (e) {}
 })();
 </script>
+<script>
+(function () {
+  try {
+    var b = document.body;
+    if (!b) return;
+    var p = (location.pathname || '').toLowerCase();
+    var pcEl =
+      document.querySelector('input[name="ProductCode"]') ||
+      document.querySelector('input[name="productcode"]');
+    var pc = String((pcEl && pcEl.value) || '').trim();
+    var isBean =
+      /^BB/i.test(pc) ||
+      /\/bean-bag-seating-s\//.test(p) ||
+      /product-p\/bb-/i.test(p);
+    if (isBean) {
+      b.classList.add('mc-bean-bag-pdp');
+      return;
+    }
+    var looksPdp =
+      !!pcEl ||
+      !!document.getElementById('v65-product-parent') ||
+      (b.classList && b.classList.contains('productdetails'));
+    if (looksPdp) b.classList.add('mc-hide-native-options-until-mc');
+  } catch (e2) {}
+})();
+</script>
 <!-- MC_TEMPLATE: header-critical-bar-20260401q -->
 <!-- Do not override window.location.reload: CAPTCHA / bot checks (Cloudflare, etc.) call reload to finish; blocking it causes verify loops. -->
 <a class="mc-cart-float" href="/shoppingcart.asp" aria-label="Cart" rel="nofollow">
@@ -4989,9 +5015,19 @@ body.mc-product-page #content_area #mcLeatherSwatchStrip img {
   color: #111 !important;
 }
 
-/* Hide all options tables visually - but keep functional for Volusion form submission */
-body.mc-product-page #content_area #options_table,
-body.mc-product-page #content_area table[id*="options_table"] {
+/* Hide native options until custom PDP UI is active (avoids flash before body.mc-product-page / late Volusion inject). Bean bags keep native options. */
+body.mc-product-page:not(.mc-bean-bag-pdp) #content_area #options_table,
+body.mc-product-page:not(.mc-bean-bag-pdp) #content_area table[id*="options_table"],
+body.mc-product-page:not(.mc-bean-bag-pdp) #v65-product-parent #options_table,
+body.mc-product-page:not(.mc-bean-bag-pdp) #v65-product-parent table[id*="options_table"],
+body.mc-hide-native-options-until-mc:not(.mc-bean-bag-pdp) #content_area #options_table,
+body.mc-hide-native-options-until-mc:not(.mc-bean-bag-pdp) #content_area table[id*="options_table"],
+body.mc-hide-native-options-until-mc:not(.mc-bean-bag-pdp) #v65-product-parent #options_table,
+body.mc-hide-native-options-until-mc:not(.mc-bean-bag-pdp) #v65-product-parent table[id*="options_table"],
+body.productdetails:not(.mc-bean-bag-pdp) #content_area #options_table,
+body.productdetails:not(.mc-bean-bag-pdp) #content_area table[id*="options_table"],
+body.productdetails:not(.mc-bean-bag-pdp) #v65-product-parent #options_table,
+body.productdetails:not(.mc-bean-bag-pdp) #v65-product-parent table[id*="options_table"] {
   position: absolute !important;
   left: -9999px !important;
   opacity: 0 !important;
@@ -6725,6 +6761,7 @@ table.colors_pricebox:nth-child(5) > tbody:nth-child(1) > tr:nth-child(1) > td:n
       document.querySelector('.colors_pricebox');
     if (!hasMarker) return false;
     document.body.classList.add('mc-product-page');
+    try { document.body.classList.remove('mc-hide-native-options-until-mc'); } catch (eMcH) {}
     try { document.body.classList.remove('is-home'); } catch (eH) {}
     try {
       if (typeof isBeanBagProductPage === 'function' && isBeanBagProductPage()) {
@@ -7730,6 +7767,17 @@ table.colors_pricebox:nth-child(5) > tbody:nth-child(1) > tr:nth-child(1) > td:n
     var mo = new MutationObserver(function(){
       clearTimeout(deb);
       deb = setTimeout(function(){
+        try {
+          var ca = document.getElementById('content_area');
+          if (
+            ca &&
+            ca.querySelector('#options_table, table[id*="options_table"]') &&
+            !document.body.classList.contains('mc-product-page') &&
+            !document.body.classList.contains('mc-bean-bag-pdp')
+          ) {
+            document.body.classList.add('mc-hide-native-options-until-mc');
+          }
+        } catch (eObs) {}
         if (markProductPage()) forceProductFixes();
       }, 50);
     });

--- a/vspfiles/css/custom-safe.css
+++ b/vspfiles/css/custom-safe.css
@@ -2183,6 +2183,27 @@ nav.push-menu .push-menu__close-btn::before {
    PRODUCT PAGE FIXES (Volusion 266)
 ========================================= */
 
+/* Match template_266: hide native #options_table until mc-product-page (early class mc-hide-native-options-until-mc). Bean bags keep native UI. */
+body.mc-product-page:not(.mc-bean-bag-pdp) #content_area #options_table,
+body.mc-product-page:not(.mc-bean-bag-pdp) #content_area table[id*="options_table"],
+body.mc-product-page:not(.mc-bean-bag-pdp) #v65-product-parent #options_table,
+body.mc-product-page:not(.mc-bean-bag-pdp) #v65-product-parent table[id*="options_table"],
+body.mc-hide-native-options-until-mc:not(.mc-bean-bag-pdp) #content_area #options_table,
+body.mc-hide-native-options-until-mc:not(.mc-bean-bag-pdp) #content_area table[id*="options_table"],
+body.mc-hide-native-options-until-mc:not(.mc-bean-bag-pdp) #v65-product-parent #options_table,
+body.mc-hide-native-options-until-mc:not(.mc-bean-bag-pdp) #v65-product-parent table[id*="options_table"],
+body.productdetails:not(.mc-bean-bag-pdp) #content_area #options_table,
+body.productdetails:not(.mc-bean-bag-pdp) #content_area table[id*="options_table"],
+body.productdetails:not(.mc-bean-bag-pdp) #v65-product-parent #options_table,
+body.productdetails:not(.mc-bean-bag-pdp) #v65-product-parent table[id*="options_table"] {
+  position: absolute !important;
+  left: -9999px !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
+  height: 0 !important;
+  overflow: hidden !important;
+}
+
 /* Remove italic styling on product headings/tabs */
 body.mc-product-page #content_area h1,
 body.mc-product-page #content_area h2,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Native Volusion `#options_table` was visible until `body.mc-product-page` was applied and/or until late-injected content arrived, so users saw options appear then disappear (or flicker as scripts re-ran).

## Changes
- **Early body classes**: Right after `<body>`, detect PDP vs bean-bag (BB codes / paths) and either add `mc-bean-bag-pdp` or `mc-hide-native-options-until-mc` so the native options table can be hidden before the rest of the PDP scripts run.
- **CSS**: Broaden the “hide native options table” rules to include `body.productdetails`, `#v65-product-parent`, and `mc-hide-native-options-until-mc`, while excluding `mc-bean-bag-pdp`. Duplicated the same block in `vspfiles/css/custom-safe.css` for stores that load that file without the full inline template block.
- **JS**: `markProductPage()` removes `mc-hide-native-options-until-mc` once `mc-product-page` is set. The `#content_area` mutation observer re-adds the hide class if the options table appears before markers are ready.

## Testing
Not run (Volusion template/CSS only; verify on a live PDP and a bean-bag PDP).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f51e0a9-d045-4bf4-b831-0917f705199f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f51e0a9-d045-4bf4-b831-0917f705199f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

