### PR TITLE
Deploy template 266 assets (template.css + JS) with theme SFTP uploads

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,15 @@ jobs:
             echo "::error::Missing vspfiles/templates/266/css/mccabe-overrides.css (template links it after template.css)."
             exit 1
           fi
+          for f in \
+            vspfiles/templates/266/css/template.css \
+            vspfiles/templates/266/js/min/design-toolkit.min.js \
+            vspfiles/templates/266/js/min/template.min.js; do
+            if [ ! -f "$f" ]; then
+              echo "::error::Missing $f (linked from template_266.html)."
+              exit 1
+            fi
+          done
 
           sudo apt-get update -qq
           sudo apt-get install -y -qq sshpass python3-pip
@@ -194,12 +203,18 @@ jobs:
 
           try_put_pair() {
             local title="$1" tpath="$2" cpath="$3"
-            local mpath
+            local mpath tcss tjs
             mpath="$(mccabe_remote_for_css "${cpath}")"
+            tcss="${mpath%/*}/template.css"
+            tjs="${mpath/\/css\//\/js\/min\/}"
+            tjs="${tjs%mccabe-overrides.css}"
             try_batch "${title}" \
               "put template_266.html ${tpath}" \
               "put vspfiles/css/custom-safe.css ${cpath}" \
               "put vspfiles/templates/266/css/mccabe-overrides.css ${mpath}" \
+              "put vspfiles/templates/266/css/template.css ${tcss}" \
+              "put vspfiles/templates/266/js/min/design-toolkit.min.js ${tjs}design-toolkit.min.js" \
+              "put vspfiles/templates/266/js/min/template.min.js ${tjs}template.min.js" \
               "bye"
           }
 
@@ -228,6 +243,9 @@ jobs:
               "put template_266.html template_266.html" \
               "put vspfiles/css/custom-safe.css vspfiles/css/custom-safe.css" \
               "put vspfiles/templates/266/css/mccabe-overrides.css vspfiles/templates/266/css/mccabe-overrides.css" \
+              "put vspfiles/templates/266/css/template.css vspfiles/templates/266/css/template.css" \
+              "put vspfiles/templates/266/js/min/design-toolkit.min.js vspfiles/templates/266/js/min/design-toolkit.min.js" \
+              "put vspfiles/templates/266/js/min/template.min.js vspfiles/templates/266/js/min/template.min.js" \
               "bye"; then ok=1; fi
           fi
 
@@ -269,6 +287,33 @@ jobs:
           try_put_mccabe_only "mccabe-overrides → domain v/" "/mccabestheaterandliving.com/v/vspfiles/templates/266/css/mccabe-overrides.css"
           try_put_mccabe_only "mccabe-overrides → domain legacy" "/mccabestheaterandliving.com/vspfiles/templates/266/css/mccabe-overrides.css"
           try_put_mccabe_only "mccabe-overrides → relative" "vspfiles/templates/266/css/mccabe-overrides.css"
+          echo "::endgroup::"
+
+          try_put_template_css_only() {
+            local title="$1" rpath="$2"
+            try_batch "${title}" \
+              "put vspfiles/templates/266/css/template.css ${rpath}" \
+              "bye" || true
+          }
+          try_put_template266_js_only() {
+            local title="$1" dir="$2"
+            try_batch "${title}" \
+              "put vspfiles/templates/266/js/min/design-toolkit.min.js ${dir}/design-toolkit.min.js" \
+              "put vspfiles/templates/266/js/min/template.min.js ${dir}/template.min.js" \
+              "bye" || true
+          }
+          echo "::group::Best-effort: template.css + template JS (template_266.html links v/vspfiles/templates/266/…)"
+          try_put_template_css_only "template.css → /v/vspfiles/templates/266/css/" "/v/vspfiles/templates/266/css/template.css"
+          try_put_template_css_only "template.css → v/vspfiles/templates/266/css/" "v/vspfiles/templates/266/css/template.css"
+          try_put_template_css_only "template.css → /vspfiles/templates/266/css/" "/vspfiles/templates/266/css/template.css"
+          try_put_template_css_only "template.css → domain v/" "/mccabestheaterandliving.com/v/vspfiles/templates/266/css/template.css"
+          try_put_template_css_only "template.css → domain legacy" "/mccabestheaterandliving.com/vspfiles/templates/266/css/template.css"
+          try_put_template_css_only "template.css → relative" "vspfiles/templates/266/css/template.css"
+          try_put_template266_js_only "JS → /v/vspfiles/templates/266/js/min" "/v/vspfiles/templates/266/js/min"
+          try_put_template266_js_only "JS → v/vspfiles/templates/266/js/min" "v/vspfiles/templates/266/js/min"
+          try_put_template266_js_only "JS → /vspfiles/templates/266/js/min" "/vspfiles/templates/266/js/min"
+          try_put_template266_js_only "JS → domain v/" "/mccabestheaterandliving.com/v/vspfiles/templates/266/js/min"
+          try_put_template266_js_only "JS → domain legacy" "/mccabestheaterandliving.com/vspfiles/templates/266/js/min"
           echo "::endgroup::"
 
           echo "::notice::Upload finished. Next step re-downloads template via SFTP and may check the public template URL (HTTP); storefront cache can still lag what you see in a browser."

--- a/scripts/volusion_sftp_deploy.py
+++ b/scripts/volusion_sftp_deploy.py
@@ -6,6 +6,7 @@ Template + CSS use different remote paths (Volusion):
   template → /template_266.html first (SFTP root), then fallbacks under /v/, etc.
   CSS      → /vspfiles/css/custom-safe.css and /v/vspfiles/css/custom-safe.css (File Editor: wwwroot/v/vspfiles/css/).
   mccabe   → parallel to CSS under .../templates/266/css/mccabe-overrides.css (linked from template).
+  theme    → template.css + js/min/*.js under .../templates/266/ (same href/src as template).
 
 Override with SFTP_TEMPLATE_REMOTE / SFTP_CSS_REMOTE_FILE (full paths).
 """
@@ -37,6 +38,28 @@ def _mccabe_remote_for_css(c_path: str) -> str:
         "vspfiles/css/custom-safe.css": "vspfiles/templates/266/css/mccabe-overrides.css",
     }
     return mapping.get(c_path, "/v/vspfiles/templates/266/css/mccabe-overrides.css")
+
+
+def _template266_theme_tail_paths() -> list[str]:
+    """Paths under …/vspfiles/ linked from template_266.html (same tree as mccabe-overrides)."""
+    return [
+        "templates/266/css/template.css",
+        "templates/266/js/min/design-toolkit.min.js",
+        "templates/266/js/min/template.min.js",
+    ]
+
+
+def _theme_asset_remote(mccabe_path: str, tail: str) -> str:
+    """Derive remote path for template.css / JS from the mccabe-overrides.css path for this deploy pair."""
+    suffix = "mccabe-overrides.css"
+    name = tail.split("/")[-1]
+    if mccabe_path.endswith(suffix):
+        prefix = mccabe_path[: -len(suffix)]
+        if tail.startswith("templates/266/css/"):
+            return prefix + name
+        js_prefix = prefix.replace("/css/", "/js/min/", 1)
+        return js_prefix + name
+    return f"{mccabe_path.rstrip('/')}/{tail.removeprefix('templates/266/').lstrip('/')}"
 
 
 def _template_css_pairs(c_remote: str) -> list[tuple[str, str]]:
@@ -89,6 +112,15 @@ def _try_pair(sftp, t_path: str, c_path: str) -> None:
     sftp.put("template_266.html", t_path)
     sftp.put("vspfiles/css/custom-safe.css", c_path)
     sftp.put("vspfiles/templates/266/css/mccabe-overrides.css", m_path)
+    for tail in _template266_theme_tail_paths():
+        local = f"vspfiles/{tail}"
+        if not os.path.isfile(local):
+            continue
+        remote = _theme_asset_remote(m_path, tail)
+        try:
+            sftp.put(local, remote)
+        except Exception as exc:  # noqa: BLE001
+            print(f"PARAMIKO_TRY_PAIR_THEME_SKIP {local!r}→{remote!r}: {exc}", flush=True)
 
 
 def _mirror_template_to_canonical_paths(sftp) -> None:
@@ -139,6 +171,29 @@ def _mirror_mccabe_to_canonical_paths(sftp) -> None:
             print(f"::warning::PARAMIKO_MIRROR_SKIP mccabe {rel}: {exc}", flush=True)
 
 
+def _mirror_template266_theme_assets(sftp) -> None:
+    bases = (
+        "/v/vspfiles/",
+        "v/vspfiles/",
+        "/vspfiles/",
+        "vspfiles/",
+        "/mccabestheaterandliving.com/v/vspfiles/",
+        "/mccabestheaterandliving.com/vspfiles/",
+    )
+    for tail in _template266_theme_tail_paths():
+        local = f"vspfiles/{tail}"
+        if not os.path.isfile(local):
+            print(f"::warning::PARAMIKO_MIRROR_SKIP missing local {local}", flush=True)
+            continue
+        for base in bases:
+            rel = base + tail
+            try:
+                sftp.put(local, rel, confirm=False)
+                print(f"::notice::PARAMIKO_MIRROR_OK template266 → {rel}", flush=True)
+            except Exception as exc:  # noqa: BLE001
+                print(f"::warning::PARAMIKO_MIRROR_SKIP template266 {rel}: {exc}", flush=True)
+
+
 def _try_home_relative(sftp) -> bool:
     try:
         sftp.put("template_266.html", "template_266.html")
@@ -147,6 +202,10 @@ def _try_home_relative(sftp) -> bool:
             "vspfiles/templates/266/css/mccabe-overrides.css",
             "vspfiles/templates/266/css/mccabe-overrides.css",
         )
+        for tail in _template266_theme_tail_paths():
+            local = f"vspfiles/{tail}"
+            if os.path.isfile(local):
+                sftp.put(local, tail)
         return True
     except Exception:  # noqa: BLE001
         return False
@@ -188,6 +247,7 @@ def main() -> int:
                 _mirror_template_to_canonical_paths(sftp)
                 _mirror_css_to_canonical_paths(sftp)
                 _mirror_mccabe_to_canonical_paths(sftp)
+                _mirror_template266_theme_assets(sftp)
                 print("PARAMIKO_OK (one or more path pairs succeeded)", flush=True)
                 return 0
             if _try_home_relative(sftp):
@@ -195,6 +255,7 @@ def main() -> int:
                 _mirror_template_to_canonical_paths(sftp)
                 _mirror_css_to_canonical_paths(sftp)
                 _mirror_mccabe_to_canonical_paths(sftp)
+                _mirror_template266_theme_assets(sftp)
                 return 0
             return 1
         finally:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The live `template_266.html` references theme files under `v/vspfiles/templates/266/` (`template.css`, `design-toolkit.min.js`, `template.min.js`). The deploy workflow already uploaded `custom-safe.css`, `mccabe-overrides.css`, and the HTML template, but not those linked assets—so changes in-repo could fail to reach Volusion.

## Changes

- **`.github/workflows/deploy.yml`**: Require the three theme files at checkout; extend each successful `try_put_pair` batch to upload them next to `mccabe-overrides.css` (CSS sibling + `js/min/` derived from the mccabe path); extend the login-relative batch; add best-effort mirrors to the same canonical paths used for mccabe-overrides.
- **`scripts/volusion_sftp_deploy.py`**: On each Paramiko pair, upload the same files using `_theme_asset_remote()`; mirror them after mccabe mirroring; include them in the home-relative fallback.

Merge to `main` triggers the existing deploy workflow; no new secrets required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fd8c362-1af1-4624-8590-dfcfcccb7192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fd8c362-1af1-4624-8590-dfcfcccb7192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

