### PR TITLE
Fix mobile PDP flash: remove negative altviews margins

### DIFF
--- a/template_266.html
+++ b/template_266.html
@@ -6976,7 +6976,8 @@ table.colors_pricebox:nth-child(5) > tbody:nth-child(1) > tr:nth-child(1) > td:n
       outer.appendChild(thumbs);
     }
 
-    thumbs.style.cssText = 'display:ruby block!important;flex-flow:wrap!important;justify-content:center!important;align-items:center!important;gap:10px!important;width:286px!important;max-width:300px!important;margin:8px auto -100px -50px!important;padding:0!important;float:none!important;clear:both!important;position:static!important;left:auto!important;right:auto!important;transform:none!important;box-sizing:border-box!important;text-align:center!important;';
+    /* No negative margins: they yank price/options under the hero and flash/jump when this runs (observer + interval). */
+    thumbs.style.cssText = 'display:flex!important;flex-wrap:wrap!important;justify-content:center!important;align-items:center!important;gap:10px!important;width:100%!important;max-width:100%!important;margin:8px auto 12px auto!important;padding:0!important;float:none!important;clear:both!important;position:static!important;left:auto!important;right:auto!important;transform:none!important;box-sizing:border-box!important;text-align:center!important;';
 
     var allLinks = thumbs.querySelectorAll('a');
     for (var i = 0; i < allLinks.length; i++) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
On mobile PDPs, `syncAltviewsToMainImage` in `template_266.html` set `margin: 8px auto -100px -50px` on `#altviews`. That pulled the price/options block (everything under the hero) upward by ~100px whenever `forceProductFixes` ran—on load, on a 400ms interval (25 times), and after DOM mutations—causing a visible jump/flash.

## Change
- Replace that inline style with a centered `flex` + `flex-wrap` layout, full width, and **non-negative** vertical margins (`8px auto 12px auto`).

## Testing
Not run (Volusion template; verify on a real product page in mobile viewport after deploy).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c11ddf15-92cf-48f6-a07a-c2ccab04b0f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c11ddf15-92cf-48f6-a07a-c2ccab04b0f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

