### PR TITLE
Fix missing mobile cart icon

### DIFF
--- a/template_266.html
+++ b/template_266.html
@@ -1666,7 +1666,7 @@ html.mc-mahjong-pdp-init:not(.mc-mahjong-pdp-ready) #mc-pdp-accordion{
 })(window, document);
   </script>
   <script id="mc-plp-enforcer-bridge">
-(function(g,d){var W="20260716freeship1",vn=function(v){var n=parseInt(String(v||"").replace(/\D/g,""),10);return isNaN(n)?0:n;};
+(function(g,d){var W="20260719cart1",vn=function(v){var n=parseInt(String(v||"").replace(/\D/g,""),10);return isNaN(n)?0:n;};
 
 function cat(){try{var p=String(g.location.pathname||"").toLowerCase();
 var isHome =
@@ -2577,44 +2577,51 @@ document.addEventListener("DOMContentLoaded", function () {
   <!--[if IE 9]><script>"searchresults.asp"===PageName()&&!function(e){e(document).ready(function(){var r,t=0,n=0,i=new Array,h=0;e(".v-product").each(function(){if(r=e(this),h=r.position().top,n!=h){for(currentDiv=0;currentDiv<i.length;currentDiv++)i[currentDiv].height(t);i.length=0,n=h,t=r.height(),i.push(r)}else i.push(r),t=t<r.height()?r.height():t;for(currentDiv=0;currentDiv<i.length;currentDiv++)i[currentDiv].height(t)})})}($jQueryModern);</script><![endif]-->
 
   <script src="v/vspfiles/templates/266/js/min/template.min.js?v=20260706cart1"></script>
-  <script id="mc-cart-float-finalizer-20260706">
+  <script id="mc-cart-float-finalizer-20260719cart1">
   (function(w,d){
     "use strict";
+    /* Do NOT use [class*='mc-cart-float'] — that also matches the inner svg
+       (mc-cart-float__icon), which template.min.js already hijacks. Hide the
+       svg and paint the glyph on the anchor only. */
+    var GLYPH='url("data:image/svg+xml;utf8,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 24 24\' fill=\'%23111111\'%3E%3Cpath d=\'M7 18c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm10 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zM6.2 6l.4 2h12.2c.5 0 .9.2 1.2.6.3.4.3.9.2 1.4l-1.2 5.2c-.2.7-.8 1.2-1.6 1.2H8.1c-.8 0-1.4-.5-1.6-1.2L4.3 4H2V2h3.1c.7 0 1.3.5 1.4 1.2L6.2 6zm1.3 9h9.8l1.1-5H6.6l.9 5z\'/%3E%3C/svg%3E")';
     function fix(){
-      var nodes=d.querySelectorAll(".mc-cart-float,#mc-cart-float,a.mc-cart-float,[class*='mc-cart-float']");
-      for(var i=0;i<nodes.length;i++){
-        var el=nodes[i];
-        try{
-          el.style.setProperty("display","flex","important");
-          el.style.setProperty("align-items","center","important");
-          el.style.setProperty("justify-content","center","important");
-          el.style.setProperty("width","52px","important");
-          el.style.setProperty("height","52px","important");
-          el.style.setProperty("min-width","52px","important");
-          el.style.setProperty("max-width","52px","important");
-          el.style.setProperty("min-height","52px","important");
-          el.style.setProperty("max-height","52px","important");
-          el.style.setProperty("padding","0","important");
-          el.style.setProperty("border-radius","999px","important");
-          el.style.setProperty("overflow","hidden","important");
-          el.style.setProperty("line-height","0","important");
-        }catch(e){}
-        var svg=el.querySelector&&el.querySelector("svg");
-        if(svg){try{
-          svg.style.setProperty("position","static","important");
-          svg.style.setProperty("display","block","important");
-          svg.style.setProperty("width","20px","important");
-          svg.style.setProperty("height","20px","important");
-          svg.style.setProperty("margin","0","important");
-          svg.style.setProperty("transform","none","important");
-        }catch(e2){}}
-      }
+      var el=d.querySelector("a.mc-cart-float")||d.querySelector(".mc-cart-float");
+      if(!el)return;
+      try{
+        el.style.setProperty("display","flex","important");
+        el.style.setProperty("visibility","visible","important");
+        el.style.setProperty("opacity","1","important");
+        el.style.setProperty("align-items","center","important");
+        el.style.setProperty("justify-content","center","important");
+        el.style.setProperty("background-image",GLYPH,"important");
+        el.style.setProperty("background-repeat","no-repeat","important");
+        el.style.setProperty("background-position","center center","important");
+        el.style.setProperty("background-size","20px 20px","important");
+      }catch(e){}
+      var svg=el.querySelector&&el.querySelector("svg.mc-cart-float__icon,svg");
+      if(svg){try{
+        svg.style.setProperty("display","none","important");
+        svg.style.setProperty("visibility","hidden","important");
+        svg.style.setProperty("opacity","0","important");
+        svg.style.setProperty("width","0","important");
+        svg.style.setProperty("height","0","important");
+      }catch(e2){}}
+    }
+    var scheduled=false;
+    function schedule(){
+      if(scheduled)return;
+      scheduled=true;
+      w.setTimeout(function(){scheduled=false;fix();},50);
     }
     fix();
     if(d.readyState==="loading")d.addEventListener("DOMContentLoaded",fix);
     w.addEventListener("load",fix);
     [100,400,900,1600,2800,5000].forEach(function(ms){w.setTimeout(fix,ms);});
-    w.setInterval(fix,500);
+    if(w.MutationObserver){
+      try{
+        new MutationObserver(schedule).observe(d.documentElement,{childList:true,subtree:true});
+      }catch(e3){}
+    }
   })(window,document);
   </script>
 
@@ -14624,7 +14631,7 @@ s0.parentNode.insertBefore(s1,s0);
 })();
 </script>
 <!--End of Tawk.to Script-->
-  <script id="mc-plp-enforcer-js" src="/v/vspfiles/js/mc-plp-enforcer.js?v=20260716freeship1"></script>
+  <script id="mc-plp-enforcer-js" src="/v/vspfiles/js/mc-plp-enforcer.js?v=20260719cart1"></script>
  
   <script id="mc-my-boards-template-boot">
 (function () {

--- a/vspfiles/css/custom-safe.css
+++ b/vspfiles/css/custom-safe.css
@@ -20629,7 +20629,8 @@ html body a.mc-cart-float svg.mc-cart-float__icon {
   display: none !important;
 }
 html body a.mc-cart-float, html body .mc-cart-float {
-  background-image: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22%2523111111%22%3E%3Cpath%20d%3D%22M7%2018c-1.1%200-2%20.9-2%202s.9%202%202%202%202-.9%202-2-.9-2-2-2zm10%200c-1.1%200-2%20.9-2%202s.9%202%202%202%202-.9%202-2-.9-2-2-2zM6.2%206l.4%202h12.2c.5%200%20.9.2%201.2.6.3.4.3.9.2%201.4l-1.2%205.2c-.2.7-.8%201.2-1.6%201.2H8.1c-.8%200-1.4-.5-1.6-1.2L4.3%204H2V2h3.1c.7%200%201.3.5%201.4%201.2L6.2%206zm1.3%209h9.8l1.1-5H6.6l.9%205z%22%2F%3E%3C%2Fsvg%3E") !important;
+  /* fill must be %23111111 (#111111). %2523 double-encodes and blanks the glyph. */
+  background-image: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22%23111111%22%3E%3Cpath%20d%3D%22M7%2018c-1.1%200-2%20.9-2%202s.9%202%202%202%202-.9%202-2-.9-2-2-2zm10%200c-1.1%200-2%20.9-2%202s.9%202%202%202%202-.9%202-2-.9-2-2-2zM6.2%206l.4%202h12.2c.5%200%20.9.2%201.2.6.3.4.3.9.2%201.4l-1.2%205.2c-.2.7-.8%201.2-1.6%201.2H8.1c-.8%200-1.4-.5-1.6-1.2L4.3%204H2V2h3.1c.7%200%201.3.5%201.4%201.2L6.2%206zm1.3%209h9.8l1.1-5H6.6l.9%205z%22%2F%3E%3C%2Fsvg%3E") !important;
   background-repeat: no-repeat !important;
   background-position: center center !important;
   background-size: 20px 20px !important;
@@ -23778,3 +23779,26 @@ html body.mc-saranoni-pdp .mc-saranoni-scroll-arrow[disabled] {
   pointer-events: none !important;
 }
 /* END REMOVABLE: Saranoni variant scroll arrows (20260718) */
+
+/* BEGIN REMOVABLE: mobile cart glyph visible (20260719cart1)
+   Inner svg is hijacked by template.min.js; keep it hidden and paint the
+   glyph on the anchor. Correct fill encoding is %23111111 (not %2523…). */
+html body a.mc-cart-float,
+html body .mc-cart-float {
+  display: flex !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+  background-image: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22%23111111%22%3E%3Cpath%20d%3D%22M7%2018c-1.1%200-2%20.9-2%202s.9%202%202%202%202-.9%202-2-.9-2-2-2zm10%200c-1.1%200-2%20.9-2%202s.9%202%202%202%202-.9%202-2-.9-2-2-2zM6.2%206l.4%202h12.2c.5%200%20.9.2%201.2.6.3.4.3.9.2%201.4l-1.2%205.2c-.2.7-.8%201.2-1.6%201.2H8.1c-.8%200-1.4-.5-1.6-1.2L4.3%204H2V2h3.1c.7%200%201.3.5%201.4%201.2L6.2%206zm1.3%209h9.8l1.1-5H6.6l.9%205z%22%2F%3E%3C%2Fsvg%3E") !important;
+  background-repeat: no-repeat !important;
+  background-position: center center !important;
+  background-size: 20px 20px !important;
+}
+html body a.mc-cart-float svg.mc-cart-float__icon,
+html body .mc-cart-float svg.mc-cart-float__icon {
+  display: none !important;
+  visibility: hidden !important;
+  opacity: 0 !important;
+  width: 0 !important;
+  height: 0 !important;
+}
+/* END REMOVABLE: mobile cart glyph visible (20260719cart1) */

--- a/vspfiles/js/mc-plp-enforcer.js
+++ b/vspfiles/js/mc-plp-enforcer.js
@@ -1,13 +1,13 @@
 /**
  * PLP fixes — DOM-driven, scoped to inspected Volusion markup.
- * MC_PLP_ENFORCER_20260706c — all-category meta wrapper, cart float repair
+ * MC_PLP_ENFORCER_20260719cart1 — cart float glyph via inline background-image
  *
  * Thumbnails: .mc-plp-image-box; image element sized to the wrapper, object-fit: contain (no crop).
  */
 (function (global) {
   "use strict";
 
-  var VERSION = "20260716freeship1";
+  var VERSION = "20260719cart1";
 
   function plpVerNum(v) {
     var n = parseInt(String(v || "").replace(/\D/g, ""), 10);
@@ -145,32 +145,36 @@
     document.documentElement.classList.remove("mc-allow-home-hero");
   }
 
+  /* template.min.js matches [class*=mc-cart-float] and also styles the inner
+     svg (mc-cart-float__icon) as a second fixed 42px box — ripping the glyph
+     out / blanking it. Do not fight its position/size. Hide the hijacked svg
+     and paint the cart glyph as an inline background-image on the anchor. */
+  var MC_CART_GLYPH_BG =
+    'url("data:image/svg+xml;utf8,' +
+    "%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23111111'%3E" +
+    "%3Cpath d='M7 18c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm10 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zM6.2 6l.4 2h12.2c.5 0 .9.2 1.2.6.3.4.3.9.2 1.4l-1.2 5.2c-.2.7-.8 1.2-1.6 1.2H8.1c-.8 0-1.4-.5-1.6-1.2L4.3 4H2V2h3.1c.7 0 1.3.5 1.4 1.2L6.2 6zm1.3 9h9.8l1.1-5H6.6l.9 5z'/%3E" +
+    '%3C/svg%3E")';
+
   function repairCartFloatIcon() {
     var cart = document.querySelector("a.mc-cart-float");
     if (!cart) return;
     cart.style.setProperty("display", "flex", "important");
+    cart.style.setProperty("visibility", "visible", "important");
+    cart.style.setProperty("opacity", "1", "important");
     cart.style.setProperty("align-items", "center", "important");
     cart.style.setProperty("justify-content", "center", "important");
-    cart.style.setProperty("width", "52px", "important");
-    cart.style.setProperty("height", "52px", "important");
-    cart.style.setProperty("min-width", "52px", "important");
-    cart.style.setProperty("max-width", "52px", "important");
-    cart.style.setProperty("min-height", "52px", "important");
-    cart.style.setProperty("max-height", "52px", "important");
-    cart.style.setProperty("padding", "0", "important");
-    cart.style.setProperty("overflow", "hidden", "important");
+    cart.style.setProperty("background-image", MC_CART_GLYPH_BG, "important");
+    cart.style.setProperty("background-repeat", "no-repeat", "important");
+    cart.style.setProperty("background-position", "center center", "important");
+    cart.style.setProperty("background-size", "20px 20px", "important");
     var svg = cart.querySelector("svg.mc-cart-float__icon");
     if (!svg) return;
-    svg.style.setProperty("position", "static", "important");
-    svg.style.setProperty("display", "block", "important");
-    svg.style.setProperty("width", "20px", "important");
-    svg.style.setProperty("height", "20px", "important");
-    svg.style.setProperty("min-width", "20px", "important");
-    svg.style.setProperty("max-width", "20px", "important");
-    svg.style.setProperty("min-height", "20px", "important");
-    svg.style.setProperty("max-height", "20px", "important");
-    svg.style.setProperty("margin", "0 auto", "important");
-    svg.style.setProperty("transform", "none", "important");
+    svg.style.setProperty("display", "none", "important");
+    svg.style.setProperty("visibility", "hidden", "important");
+    svg.style.setProperty("opacity", "0", "important");
+    svg.style.setProperty("width", "0", "important");
+    svg.style.setProperty("height", "0", "important");
+    svg.style.setProperty("overflow", "hidden", "important");
   }
 
   function isLegacySubcatChromeTable(tbl) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The mobile cart button was showing as an empty white circle.

**Cause**
- The inner cart SVG is hijacked by `template.min.js` (`[class*=mc-cart-float]` also matches `mc-cart-float__icon`), so CSS correctly hides that SVG.
- The fallback cart glyph on the anchor used a double-encoded fill (`%2523…`), so the background-image painted nothing.

**Fix**
- Correct the data-URI fill to `%23111111` (`#111111`).
- Paint the glyph via inline `background-image` on `a.mc-cart-float` (template finalizer + plp enforcer).
- Stop the cart finalizer from selecting/restyling the inner SVG.

**Files**
- `template_266.html`
- `vspfiles/css/custom-safe.css`
- `vspfiles/js/mc-plp-enforcer.js`

Deploy these three files to Volusion for the fix to show live.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f782e-2d7f-77bd-ac55-8d037b3bb65d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f782e-2d7f-77bd-ac55-8d037b3bb65d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

