### PR TITLE
Mahjong 201.htm: use JPG lifestyle image URLs

### DIFF
--- a/.github/scripts/deploy-volusion.sh
+++ b/.github/scripts/deploy-volusion.sh
@@ -389,6 +389,12 @@ maybe_put_primary "vspfiles/css/mc-plp-body-last.css" "mc-plp-body-last" \
   "/vspfiles/css/mc-plp-body-last.css" \
   "vspfiles/css/mc-plp-body-last.css"
 
+# Mahjong landing category page (baked HTML; JPG lifestyle image refs)
+maybe_put_primary "vspfiles/mahjong/mahjong-s-201.htm" "mahjong-s-201" \
+  "/mahjong-s/201.htm" \
+  "/v/mahjong-s/201.htm" \
+  "mahjong-s/201.htm"
+
 if command -v node >/dev/null 2>&1 && [[ -f scripts/sanitize-boards-css.mjs ]]; then
   node scripts/sanitize-boards-css.mjs || true
 fi

--- a/scripts/deploy_volusion_assets.py
+++ b/scripts/deploy_volusion_assets.py
@@ -50,6 +50,13 @@ OPTIONAL = (
     "vspfiles/windsor.mp4",
     "vspfiles/category-landings/cat142-bedroom.html",
     "vspfiles/landing/mc-luxe-comforts-saranoni-hero.jpg",
+    "vspfiles/mahjong/hero-community.jpg",
+    "vspfiles/mahjong/category-tiles.jpg",
+    "vspfiles/mahjong/category-travel.jpg",
+    "vspfiles/mahjong/category-mat.jpg",
+    "vspfiles/mahjong/category-racks.jpg",
+    "vspfiles/mahjong/category-accessories.jpg",
+    "vspfiles/mahjong/mahjong-s-201.htm",
 )
 
 CHUNKED_JS_OVER_CAP = (
@@ -124,6 +131,13 @@ def _remotes(rel: str) -> list[str]:
         paths = [f"/v/vspfiles/{sub}", f"/vspfiles/{sub}", f"/v/{rel}", rel, f"/{rel}"]
     else:
         paths = [rel, f"/{rel}", f"/v/{rel}"]
+    if rel.endswith("mahjong-s-201.htm"):
+        paths = [
+            "/mahjong-s/201.htm",
+            "/v/mahjong-s/201.htm",
+            "mahjong-s/201.htm",
+            "/mccabestheaterandliving.com/mahjong-s/201.htm",
+        ] + paths
     if rel.startswith("vspfiles/templates/266/js/min/"):
         name = rel.rsplit("/", 1)[-1]
         paths.append(f"/vspfiles/templates/266/js/min/{name}")

--- a/vspfiles/mahjong/mahjong-s-201.htm
+++ b/vspfiles/mahjong/mahjong-s-201.htm
@@ -1,0 +1,19121 @@
+<!-- VOLUSION_EDITOR_MANUAL_MARKER_20260430**** -->
+<!DOCTYPE html>
+<!-- FINAL TEMPLATE TEST 20260428-HARDVERIFY -->
+<!--[if lte IE 9]><html class="no-js lt-ie10 mc-member-plp-price-pending" lang="en" data-category-scroll="true" data-product-reviews="true" data-enable-vol-cart="true" ><![endif]-->
+<!--[if gt IE 9]><!--><html class="no-js mc-member-plp-price-pending" lang="en" data-category-scroll="true" data-product-reviews="true" data-enable-vol-cart="true" data-mc-search-fix="*DEPLOYTEST20260401q"><!--<![endif]-->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<title>American Mahjong Tiles &amp; Sets | McCabe's</title>
+<meta name="description" content="Shop colorful American Mahjong tile sets for home and travel, explore coordinating play pieces and practice with the interactive Mahjong tile trainer." />
+<meta name="keywords" content="American Mahjong, Mahjong tiles, Mahjong tile sets, travel Mahjong sets, colorful Mahjong tiles, modern Mahjong sets, Mahjong game, Mahjong trainer, The Mahjong House" />
+<meta name="robots" content="index, follow" />
+<meta name="GOOGLEBOT" content="INDEX, FOLLOW" />
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-36981515-1', 'auto');
+  ga('send', 'pageview');
+
+</script>
+ <meta name="globalsign-domain-verification" content="JocwlSwbFzQdmDQX883pwgrYuSFs3GhephlucrnOKA" /> 
+
+<link rel="canonical" href="https://www.mccabestheaterandliving.com/mahjong-s/201.htm" />
+		
+<link type="text/css" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.4/themes/base/jquery-ui.css" rel="stylesheet" />
+<link type="text/css" href="/a/c/default.css" rel="stylesheet" />
+
+
+
+
+
+<script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script type="text/javascript" src="/a/j/jquery-migrate-merged.js"></script>
+<script type="text/javascript">
+	jQuery.curCSS = function(element, prop, val) {
+		return jQuery(element).css(prop, val);
+	};
+</script>
+
+<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.4/jquery-ui.min.js"></script>
+
+
+
+
+<script type="text/javascript">
+	var Config_VCompare_MaxProducts = '3';
+	var PageText_783 = "Compare";
+	var PageText_784 = "Change Selections";
+	var PageText_785 = "You've attempted to select more than {0} items. Click {1} to continue with your initial {0} items or {2} to change your selections.";
+	var PageText_819 = "Product Comparison";
+    var PageText_822 = "Compare";
+    var PageText_840 = "Create Password";
+    var PageText_841 = "Retype Password";
+    var PageText_842 = "Added to cart";
+    var PageText_843 = "Subtotal";
+    var PageText_844 = "items in cart";
+</script>
+<script type="text/javascript" src="/a/j/volusion.js?8b74a71d50408016320bcb24becaf016c366dd18"></script>
+<script type="text/javascript">
+    (function ($) {
+        volusion.ready(function () {
+            if (volusion.cart.isObservingCount()) {
+                var ts = new Date().getTime();
+                $.getJSON('/AjaxCart.asp?Action=itemCount&cachebust=' + ts, function (data) {
+                    var quantityTotal = 0;
+                    $.each(data.Products, function (key, val) {
+                        if (val.IsProduct === 'Y') {
+                            quantityTotal += parseInt(val.Quantity);
+                        } else if (val.IsAccessory === 'Y') {
+                            quantityTotal += parseInt(val.Quantity);
+                        }
+                    });
+                    quantityTotal = quantityTotal || '0';
+                    volusion.cart.itemCount(quantityTotal);
+                });
+            }
+        });
+    } (jQuery));
+</script>
+<link type="text/css" rel="stylesheet" href="/a/contentbuilder/assets/default/content.css"/>
+<script type="text/javascript" src="/a/j/paypal-rest-default-buttons.js"></script>
+
+	<script type="text/javascript" src="/a/j/soft_add.js"></script>
+
+	<!-- Support for multi-product add to soft cart missing from product details page and possibly others -->
+	<script type="text/javascript" src="/a/j/soft_add_mult.js"></script>
+
+
+<link type="text/css" rel="stylesheet" href="/a/c/soft_add.css"/>
+<script type="text/javascript">
+	var global_Config_EnableDisplayOptionProducts = 'False';
+	var global_Config_ForceSecureShoppingCartPage = false;
+	var global_PageText_OtherItemsAdded = '(All other items have been added to the cart)';
+	var Config_EnableSoftAddToCart = true;
+</script>
+
+<script type="text/javascript" src="/a/j/soft_add_mult.js"></script>
+
+	<script type="text/javascript" src="/a/j/javascripts.js?6_5_8b74a71d50408016320bcb24becaf016c366dd18"></script>
+
+<script type="text/javascript" src="/a/j/VCompare.js"></script>
+<link type="text/css" rel="stylesheet" href="/a/c/VCompare.css"/>
+
+<script type="text/javascript">
+	var Config_Search_Auto_Complete = false;
+</script>
+
+    <script src="https://js.stripe.com/v3/"></script>
+
+
+<script>
+(function(){try{var p=String(location.pathname||"").toLowerCase();if(/-s\//.test(p)&&/\.html?/i.test(p)){var h=document.documentElement;if(h){h.classList.add("category");h.setAttribute("data-mc-category-plp","1");h.classList.remove("mc-allow-home-hero");}if(document.body){document.body.classList.remove("is-home");document.body.classList.add("category");}}}catch(e){}})();
+</script>
+<style id="mc-live-patch-inline">
+header.header #display_homepage_title,header.header #display_homepage_title *,#display_homepage_title,#display_homepage_title *{display:none!important;visibility:hidden!important;height:0!important;width:0!important;margin:0!important;padding:0!important;overflow:hidden!important;opacity:0!important;pointer-events:none!important;font-size:0!important}
+header.header .header__section>.col-xs-6.col-sm-8.col-md-9.col-lg-3:first-child{display:none!important;width:0!important;padding:0!important;margin:0!important;overflow:hidden!important}
+
+/* Hide homepage hero on category/PLP pages ONLY when the body is not the actual homepage */
+html[data-mc-category-plp="1"] body:not(.is-home) #if_homepage,
+html[data-mc-category-plp="1"] body:not(.is-home) #slideshow-container,
+html[data-mc-category-plp="1"] body:not(.is-home) #slideshow-container .mc-hero-video,
+html.category body:not(.is-home) #if_homepage,
+html.category body:not(.is-home) #slideshow-container,
+html.category body:not(.is-home) #slideshow-container .mc-hero-video,
+body.category:not(.is-home) #if_homepage,
+body.category:not(.is-home) #slideshow-container{display:none!important;visibility:hidden!important;height:0!important;min-height:0!important;max-height:0!important;margin:0!important;padding:0!important;overflow:hidden!important;opacity:0!important;background:transparent!important}
+html.category #slideshow-container,html[data-mc-category-plp="1"] #slideshow-container,body.category #slideshow-container{display:none!important;visibility:hidden!important;height:0!important;min-height:0!important;max-height:0!important;margin:0!important;padding:0!important;overflow:hidden!important;opacity:0!important;background:transparent!important}
+
+/* Homepage desktop navigation must remain above landing-page category tabs. */
+@media (min-width:992px){
+html.home body.is-home header.header{position:relative!important;z-index:2001!important}
+html.home body.is-home #slideshow-container .hero-menu,html.home body.is-home #slideshow-container .hero-nav{z-index:2002!important;pointer-events:auto!important}
+}
+
+html[data-mc-category-plp="1"] .v-product-grid a.v-product__img.mc-plp-image-box,html.category .v-product-grid a.v-product__img.mc-plp-image-box{display:flex!important;align-items:flex-end!important;justify-content:center!important;width:100%!important;height:260px!important;overflow:visible!important;background:transparent!important;box-sizing:border-box!important;padding:0!important}
+html[data-mc-category-plp="1"] .v-product-grid a.v-product__img.mc-plp-image-box>img,html.category .v-product-grid a.v-product__img.mc-plp-image-box>img{width:auto!important;height:auto!important;max-width:none!important;max-height:none!important;object-fit:contain!important;object-position:center bottom!important;transform:none!important;display:block!important}
+
+body.productdetails span[itemprop="name"],body.mc-product-page span[itemprop="name"]{font-size:13px!important;font-weight:400!important;line-height:1.2!important;letter-spacing:.16em!important;text-transform:uppercase!important;color:#777!important}
+body.productdetails #options_table select:not(.mc-native-leather),body.mc-product-page #options_table select:not(.mc-native-leather),body.productdetails #options_table td[align="right"],body.productdetails #options_table .productoptionname,body.mc-product-page #options_table td[align="right"],body.mc-product-page #options_table .productoptionname{font-size:13px!important;font-weight:400!important;line-height:1.2!important;letter-spacing:.16em!important;text-transform:uppercase!important;color:#777!important}
+body.productdetails #options_table select:not(.mc-native-leather),body.mc-product-page #options_table select:not(.mc-native-leather){text-transform:none!important;color:#444!important}
+body.productdetails .mc-pdp-retail-label,
+body.mc-product-page .mc-pdp-retail-label,
+body.productdetails .mc-pdp-member-line,
+body.mc-product-page .mc-pdp-member-line,
+body.productdetails .mc-pdp-member-line__label,
+body.mc-product-page .mc-pdp-member-line__label,
+body.productdetails .mc-pdp-member-line__amount,
+body.mc-product-page .mc-pdp-member-line__amount,
+body.productdetails .mc-pdp-top-price-label,
+body.mc-product-page .mc-pdp-top-price-label,
+body.productdetails .mc-pdp-top-member-row,
+body.mc-product-page .mc-pdp-top-member-row{
+display:none!important;visibility:hidden!important;height:0!important;max-height:0!important;margin:0!important;padding:0!important;overflow:hidden!important;opacity:0!important;pointer-events:none!important
+}
+
+body.productdetails .mc-pdp-retail-row .product_list_price,
+body.mc-product-page .mc-pdp-retail-row .product_list_price,
+body.productdetails .mc-pdp-stack-retail-amt,
+body.mc-product-page .mc-pdp-stack-retail-amt{
+font-size:20px!important;letter-spacing:.02em!important;text-transform:none!important;color:#222!important;white-space:normal!important
+}
+
+body.productdetails .mc-pdp-retail-row .product_sale_price,
+body.mc-product-page .mc-pdp-retail-row .product_sale_price,
+body.productdetails .mc-pdp-retail-row .product_saleprice,
+body.mc-product-page .mc-pdp-retail-row .product_saleprice,
+body.productdetails .mtl-product-price-block .product_sale_price,
+body.mc-product-page .mtl-product-price-block .product_saleprice{
+display:none!important;visibility:hidden!important;height:0!important;max-height:0!important;margin:0!important;padding:0!important;overflow:hidden!important;opacity:0!important;pointer-events:none!important
+}
+
+</style>
+<link rel="stylesheet" href="/v/vspfiles/css/mc-live-patch.css" id="mc-live-patch-css">
+<script>
+(function () {
+  function apply() {
+    try {
+      var h = document.documentElement;
+      if (!h) return;
+      var p = String(location.pathname || "").toLowerCase();
+      var s = String(location.search || "");
+      var looksPdp = false;
+      if (/\/product-p\//i.test(p) || /\/-p\//i.test(p)) looksPdp = true;
+      if (!looksPdp && /-p\/[^/]+\.html?(\?.*)?$/i.test(p)) looksPdp = true;
+      if (!looksPdp && /\/productdetails\.asp/i.test(p)) looksPdp = true;
+      if (!looksPdp && /\/product\.asp/i.test(p) && /productcode=/i.test(s)) looksPdp = true;
+      if (!looksPdp && /-p\//i.test(p) && /\.html?(\?|$)/i.test(p)) looksPdp = true;
+      if (!looksPdp && /\/p\//i.test(p) && /[a-z0-9_-]/i.test(p)) looksPdp = true;
+      if (!looksPdp && /\/product\//i.test(p)) looksPdp = true;
+      if (!looksPdp && document.body) {
+        try {
+          if (document.getElementById("v65-product-parent")) looksPdp = true;
+          else if (
+            document.querySelector("[class*=\"cartqty__wrap\"]") &&
+            document.querySelector('input[name="ProductCode"]')
+          ) {
+            looksPdp = true;
+          }
+        } catch (eDomPdp) {}
+      }
+      if (!looksPdp) {
+        var m = s.match(/(?:^|[?&])productcode=([^&]*)/i);
+        if (m && String(decodeURIComponent(String(m[1] || "").replace(/\+/g, " "))).trim()) looksPdp = true;
+      }
+      if (looksPdp) {
+        h.classList.add("mc-url-looks-like-pdp");
+        h.classList.remove("mc-allow-home-hero");
+        var mPar = s.match(/(?:^|[?&])productcode=([^&]*)/i);
+        var pcPar = mPar
+          ? String(decodeURIComponent(String(mPar[1] || "").replace(/\+/g, " "))).trim()
+          : "";
+        if (pcPar === "41417" || /\bparagon\b/i.test(p)) h.classList.add("mc-paragon-pdp");
+        else h.classList.remove("mc-paragon-pdp");
+        return;
+      }
+      h.classList.remove("mc-url-looks-like-pdp");
+      h.classList.remove("mc-paragon-pdp");
+      /* Category PLP (-s/177.htm etc.): never allow homepage hero; flag PLP for CSS before <body> exists. */
+      if (/-s\//i.test(p) && /\.html?(\?|$)/i.test(p)) {
+        h.classList.remove("mc-allow-home-hero");
+        h.classList.add("category");
+        h.setAttribute("data-mc-category-plp", "1");
+        return;
+      }
+      if (/\/searchresults\.asp/i.test(p)) {
+        h.classList.remove("mc-allow-home-hero");
+        h.setAttribute("data-mc-category-plp", "1");
+        return;
+      }
+      var raw = p.replace(/\/+/g, "/");
+      while (raw.length > 1 && raw.charAt(raw.length - 1) === "/") raw = raw.slice(0, -1);
+      var isHomePath =
+        raw === "" ||
+        raw === "/" ||
+        /\/(default|index)\.asp$/i.test(raw) ||
+        /\/(index|default)\.html?$/i.test(raw) ||
+        /\/(welcome|home)\.asp$/i.test(raw) ||
+        /\/(home|index)\.htm$/i.test(raw);
+      if (isHomePath) h.classList.add("mc-allow-home-hero");
+      else h.classList.remove("mc-allow-home-hero");
+    } catch (eMcUrlPdp) {}
+  }
+  window.mcApplyUrlHeroClassHints = apply;
+  apply();
+  try {
+    document.addEventListener("DOMContentLoaded", function () {
+      try {
+        apply();
+        var he = document.documentElement;
+        var inp = document.querySelector('input[name="ProductCode"]');
+        var v = inp && String(inp.value || "").trim();
+        if (v === "41417") he.classList.add("mc-paragon-pdp");
+        if (/\bparagon\b/i.test(String(location.pathname || ""))) he.classList.add("mc-paragon-pdp");
+      } catch (eDomPar) {}
+    });
+  } catch (eDomPar2) {}
+  try {
+    window.addEventListener("popstate", apply);
+    window.addEventListener("pageshow", function (ev) {
+      if (ev.persisted) apply();
+    });
+  } catch (ePopHint) {}
+})();
+</script>
+<script>
+(function () {
+  try {
+    var h0 = document.documentElement;
+    var p0 = (location.pathname || '').toLowerCase();
+    var q0 = (window.location.search || '').toLowerCase();
+    if (/\/product-p\//i.test(p0) || /productdetail/i.test(p0)) {
+      h0.classList.remove('mc-member-plp-price-pending');
+      return;
+    }
+    if (
+      p0 === '/' ||
+      /\/default\.asp/i.test(p0) ||
+      /^\/index\.htm/i.test(p0) ||
+      /^\/index\.html/i.test(p0)
+    ) {
+      h0.classList.remove('mc-member-plp-price-pending');
+      return;
+    }
+    if (/shoppingcart|onepagecheckout|checkout|orderconfirm|myaccount/i.test(p0)) {
+      h0.classList.remove('mc-member-plp-price-pending');
+      return;
+    }
+    var l1030 =
+      /(?:\?|&)cat=103(?:&|$)/i.test(q0) ||
+      /\/category-s\/103\.html?$/i.test(p0) ||
+      /\/[^\/]*-s\/103\.html?$/i.test(p0) ||
+      /-s\/103\.html?/i.test(p0);
+    if (l1030) h0.classList.remove('mc-member-plp-price-pending');
+  } catch (e0) {}
+})();
+</script>
+<script>
+(function () {
+  function mcApplyCategoryPlpThumbMat() {
+    try {
+      if (typeof window.mcPlpEnforcerRun === 'function') {
+        window.mcPlpEnforcerRun();
+        return;
+      }
+    } catch (eMcPlpMat) {}
+  }
+
+  window.mcApplyCategoryPlpThumbMat = mcApplyCategoryPlpThumbMat;
+  if (/-s\//.test(String(location.pathname || '').toLowerCase())) {
+    mcApplyCategoryPlpThumbMat();
+    document.addEventListener('DOMContentLoaded', mcApplyCategoryPlpThumbMat);
+  }
+})();
+</script>
+<script>
+(function () {
+  function mcHideVolusionHeaderTextLogo() {
+    try {
+      var el = document.getElementById('display_homepage_title');
+      if (!el) return;
+      el.setAttribute('aria-hidden', 'true');
+      el.style.setProperty('display', 'none', 'important');
+      el.style.setProperty('visibility', 'hidden', 'important');
+      el.style.setProperty('height', '0', 'important');
+      el.style.setProperty('overflow', 'hidden', 'important');
+    } catch (eHideLogo) {}
+  }
+  mcHideVolusionHeaderTextLogo();
+  document.addEventListener('DOMContentLoaded', mcHideVolusionHeaderTextLogo);
+  window.addEventListener('load', mcHideVolusionHeaderTextLogo);
+  try {
+    document.addEventListener('DOMContentLoaded', function () {
+      var el = document.getElementById('display_homepage_title');
+      if (!el || typeof MutationObserver === 'undefined') return;
+      var mo = new MutationObserver(mcHideVolusionHeaderTextLogo);
+      mo.observe(el, { childList: true, subtree: true, characterData: true });
+    });
+  } catch (eMoLogo) {}
+})();
+</script>
+<script>
+(function () {
+  function markCategoryListing() {
+    try {
+      var p = (location.pathname || '').toLowerCase();
+      var h = document.documentElement;
+      var b = document.body;
+
+      var isHomePath =
+        p === '/' ||
+        /\/default\.asp$/i.test(p) ||
+        /\/default\.html?$/i.test(p) ||
+        /\/index\.html?$/i.test(p);
+
+      if (isHomePath) {
+        h.classList.remove('category');
+        h.classList.remove('is-category-or-listing-page');
+        h.classList.add('home');
+        h.classList.add('mc-allow-home-hero');
+        h.setAttribute('data-mc-category-plp', '0');
+
+        if (b) {
+          b.classList.remove('category');
+          b.classList.remove('is-category-or-listing-page');
+          b.classList.remove('productdetails');
+          b.classList.remove('mc-product-page');
+          b.classList.add('is-home');
+        }
+
+        return;
+      }
+
+      var pathMatch = /-s\//.test(p) || (h.classList && h.classList.contains('vol-list'));
+      var gridMatch = false;
+
+      if (b && !b.classList.contains('productdetails')) {
+        var isCart = /shoppingcart|onepagecheckout|checkout|orderconfirm/i.test(p);
+
+        if (!isCart) {
+          var ulGrid = document.querySelector('#content_area ul.v-product-grid');
+
+          if (ulGrid && ulGrid.querySelector('li')) {
+            gridMatch = true;
+          } else {
+            var divGrid = document.querySelector('#content_area .v-product-grid');
+
+            if (
+              divGrid &&
+              (divGrid.querySelector('.v-product') || divGrid.querySelector('li.v-product'))
+            ) {
+              gridMatch = true;
+            }
+          }
+        }
+      }
+
+      if (pathMatch || gridMatch) {
+        h.classList.add('category');
+        h.classList.add('is-category-or-listing-page');
+        h.classList.remove('mc-allow-home-hero');
+        h.setAttribute('data-mc-category-plp', '1');
+
+        if (b) {
+          b.classList.remove('is-home');
+          b.classList.add('category');
+          b.classList.add('is-category-or-listing-page');
+        }
+
+        if (typeof window.mcApplyCategoryPlpThumbMat === 'function') {
+          window.mcApplyCategoryPlpThumbMat();
+        }
+      }
+
+      h.classList.remove('mc-member-plp-price-pending');
+      h.classList.remove('mc-cat157-plp-pricing-pending');
+    } catch (e) {}
+  }
+
+  markCategoryListing();
+  document.addEventListener('DOMContentLoaded', markCategoryListing);
+  window.addEventListener('load', markCategoryListing);
+  setTimeout(markCategoryListing, 0);
+  setTimeout(markCategoryListing, 2200);
+})();
+</script>
+<script>
+(function () {
+  /**
+   * True homepage URL — #if_homepage / hero exist in HTML on every Volusion page; body.is-home toggles visibility.
+   * Match store root and common Volusion entry paths (including subdirectory stores).
+   */
+  function mcPathLooksLikeProductOrInteriorUrl() {
+    try {
+      var p = String(location.pathname || "").toLowerCase();
+      var s = String(location.search || "");
+      /* Category / PLP (Volusion often leaves body.is-home on these) */
+      if (/-s\//i.test(p) && /\.html?(\?|$)/i.test(p)) return true;
+      if (/(?:^|[?&])categoryid=/i.test(s)) return true;
+      if (/\/searchresults\.asp/i.test(p)) return true;
+      if (/\/product-p\//i.test(p) || /\/-p\//i.test(p)) return true;
+      if (/-p\/[^/]+\.html?(\?.*)?$/i.test(p)) return true;
+      if (/\/productdetails\.asp/i.test(p)) return true;
+      if (/\/product\.asp/i.test(p) && /productcode=/i.test(s)) return true;
+      if (/-p\//i.test(p) && /\.html?(\?|$)/i.test(p)) return true;
+      var m = s.match(/(?:^|[?&])productcode=([^&]*)/i);
+      if (m && String(decodeURIComponent(String(m[1] || "").replace(/\+/g, " "))).trim()) return true;
+    } catch (eU) {}
+    return false;
+  }
+
+  function mcDomLooksLikeProductPage() {
+    try {
+      if (document.getElementById("v65-product-parent")) return true;
+      if (document.body && document.body.classList.contains("productdetails")) return true;
+      var pc = document.querySelector('input[name="ProductCode"]');
+      if (pc && String(pc.value || "").trim()) return true;
+    } catch (eD) {}
+    return false;
+  }
+
+  window.mcPathIsHomepage = function mcPathIsHomepage() {
+    try {
+      /* Never treat real PDP / product chrome as homepage (prevents hero + duplicate nav). */
+      if (mcDomLooksLikeProductPage()) return false;
+      if (mcPathLooksLikeProductOrInteriorUrl()) return false;
+      try {
+        if (document.documentElement && document.documentElement.classList.contains("mc-url-looks-like-pdp"))
+          return false;
+      } catch (eHtmlPdp) {}
+
+      var raw = String(location.pathname || "").replace(/\\/g, "/");
+      var p = raw.toLowerCase();
+      p = p.replace(/\/+/g, "/");
+      while (p.length > 1 && p.charAt(p.length - 1) === "/") {
+        p = p.slice(0, -1);
+      }
+      if (p === "" || p === "/") return true;
+      if (/\/(default|index)\.asp$/i.test(p)) return true;
+      if (/\/(index|default)\.html?$/i.test(p)) return true;
+      if (/\/(welcome|home)\.asp$/i.test(p)) return true;
+      if (/\/(home|index)\.htm$/i.test(p)) return true;
+    } catch (e) {}
+    return false;
+  };
+
+  window.mcSyncHomeBodyClass = function mcSyncHomeBodyClass() {
+    try {
+      if (typeof window.mcApplyUrlHeroClassHints === "function") window.mcApplyUrlHeroClassHints();
+      var root = document.documentElement;
+      if (!document.body) return;
+      if (mcDomLooksLikeProductPage() || mcPathLooksLikeProductOrInteriorUrl()) {
+        document.body.classList.remove("is-home");
+        try {
+          if (root) root.classList.remove("mc-allow-home-hero");
+        } catch (eAhh) {}
+        return;
+      }
+      if (typeof window.mcPathIsHomepage === "function" && window.mcPathIsHomepage()) {
+        document.body.classList.add("is-home");
+        try {
+          if (root) root.classList.add("mc-allow-home-hero");
+        } catch (eAhh2) {}
+      } else {
+        document.body.classList.remove("is-home");
+        try {
+          if (root) root.classList.remove("mc-allow-home-hero");
+        } catch (eAhh3) {}
+      }
+    } catch (e2) {}
+  };
+
+  try {
+    window.addEventListener("popstate", function () {
+      window.mcSyncHomeBodyClass();
+    });
+    window.addEventListener("pageshow", function (ev) {
+      if (ev.persisted) window.mcSyncHomeBodyClass();
+    });
+  } catch (ePop) {}
+  try {
+    if (document.body && typeof window.mcSyncHomeBodyClass === "function") window.mcSyncHomeBodyClass();
+  } catch (eEarlyHome) {}
+})();
+</script>
+<script>
+(function () {
+  function mcCategoryVisibilitySafetyReset() {
+    var p = (location.pathname || '').toLowerCase();
+    var q = (location.search || '').toLowerCase();
+    var isCategory = /-s\/\d+\.html?/i.test(p) || /(?:\?|&)categoryid=\d+/i.test(q);
+    if (!isCategory) return;
+
+    document.documentElement.classList.remove('mc-member-plp-price-pending');
+    document.documentElement.classList.remove('mc-cat157-plp-pricing-pending');
+
+    if (document.body) {
+      document.body.classList.remove('productdetails');
+      document.body.classList.remove('mc-product-page');
+      document.body.classList.remove('mc-bean-bag-pdp');
+      document.body.classList.remove('is-home');
+      document.body.classList.add('category');
+    }
+    document.documentElement.classList.remove('mc-allow-home-hero');
+    document.documentElement.setAttribute('data-mc-category-plp', '1');
+    document.documentElement.classList.add('category');
+
+    /* Category path (-s/###.htm): remove PDP-only planner/summary if mis-mounted (no product chrome). */
+    if (!document.getElementById("v65-product-parent") && /-s\/\d+\.html?/i.test(p)) {
+      try {
+        ["mc-inline-config", "mcProductSummaryRowStandalone"].forEach(function (cid) {
+          var el = document.getElementById(cid);
+          if (el && el.parentNode) el.parentNode.removeChild(el);
+        });
+      } catch (eStripMc) {}
+    }
+
+    var area = document.getElementById('content_area');
+    if (!area) return;
+
+    var nodes = area.querySelectorAll('li.v-product, .v-product, td, .v65-productDisplay-cell, a[href*="product-p/"], a[href*="-p/"]');
+    var i;
+    for (i = 0; i < nodes.length; i++) {
+      var n = nodes[i];
+      if (!n || !n.style) continue;
+      n.style.removeProperty('display');
+      n.style.removeProperty('visibility');
+      n.style.removeProperty('opacity');
+      n.style.removeProperty('height');
+      n.style.removeProperty('max-height');
+      n.style.removeProperty('overflow');
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', mcCategoryVisibilitySafetyReset);
+  } else {
+    mcCategoryVisibilitySafetyReset();
+  }
+  window.addEventListener('load', mcCategoryVisibilitySafetyReset);
+})();
+</script>
+<script>
+(function () {
+  var FRAG_URL = '/v/vspfiles/category-landings/cat142-bedroom.html?v=20260620';
+
+  function mcCat142Page1() {
+    try {
+      var path = (location.pathname || '').toLowerCase();
+      if (!/-s\/142\.html?$/i.test(path)) return false;
+      var q = location.search || '';
+      if (/(?:^|[?&])page=(?!1(?:&|$))[^&]+/i.test(q)) return false;
+      var scripts = document.querySelectorAll('#content_area script');
+      var i;
+      for (i = 0; i < scripts.length; i++) {
+        var t = scripts[i].textContent || '';
+        if (/SearchParams\s*=/.test(t) && /cat=142/i.test(t)) {
+          if (/page=\d+/i.test(t) && !/page=1(?:&|'|"|\s|;|$)/i.test(t)) return false;
+          break;
+        }
+      }
+      var pageInp = document.querySelector('input[title="Go to page"]');
+      if (pageInp && String(pageInp.value || '1').trim() !== '1') return false;
+      return true;
+    } catch (eCat142) {
+      return false;
+    }
+  }
+
+  function mcInsertCat142Bedroom(html) {
+    if (!html || document.getElementById('mc-cat-bedroom')) return true;
+    var form = document.getElementById('MainForm');
+    if (!form || !form.parentNode) return false;
+    var mount = document.createElement('div');
+    mount.innerHTML = html;
+    while (mount.firstChild) {
+      form.parentNode.insertBefore(mount.firstChild, form);
+    }
+    return true;
+  }
+
+  var fetchStarted = false;
+  function mcLoadCat142Bedroom() {
+    if (!mcCat142Page1() || document.getElementById('mc-cat-bedroom')) return;
+    if (fetchStarted) return;
+    fetchStarted = true;
+    fetch(FRAG_URL, { credentials: 'same-origin' })
+      .then(function (res) {
+        return res.ok ? res.text() : '';
+      })
+      .then(function (html) {
+        mcInsertCat142Bedroom(html);
+      })
+      .catch(function () {
+        fetchStarted = false;
+      });
+  }
+
+  function mcTryCat142Bedroom() {
+    if (!mcCat142Page1()) return;
+    if (document.getElementById('mc-cat-bedroom')) return;
+    mcLoadCat142Bedroom();
+    var tries = 0;
+    var timer = setInterval(function () {
+      tries += 1;
+      if (document.getElementById('mc-cat-bedroom') || !mcCat142Page1()) {
+        clearInterval(timer);
+        return;
+      }
+      if (!fetchStarted) mcLoadCat142Bedroom();
+      if (tries > 50) clearInterval(timer);
+    }, 100);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', mcTryCat142Bedroom);
+  } else {
+    mcTryCat142Bedroom();
+  }
+  window.addEventListener('load', mcTryCat142Bedroom);
+})();
+</script>
+<!-- MC_DEPLOY_VERIFY_20260607revertplpmat: reverted gray PLP thumb mats from 7516154 -->
+<!-- MC_CSS_DEPLOY_VERIFY_20260607memberpricing: same token as /v/vspfiles/css/custom-safe.css line 1 -->
+<meta name="mc-deploy-verify" content="20260630catnav1">
+<meta name="mc-pdp-cache-buster" content="20260630catnav1">
+<meta name="mc-live-deploy-check" content="20260630-cat-nav-overlap-fix">
+<style type="text/css">@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/cyrillic-ext/wght/normal.woff2);unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/greek/wght/normal.woff2);unicode-range:U+0370-0377,U+037A-037F,U+0384-038A,U+038C,U+038E-03A1,U+03A3-03FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/greek-ext/wght/normal.woff2);unicode-range:U+1F00-1FFF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/latin/wght/normal.woff2);unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/cyrillic/wght/normal.woff2);unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/latin-ext/wght/normal.woff2);unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/vietnamese/wght/normal.woff2);unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/vietnamese/wght/normal.woff2);unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/cyrillic-ext/wght/normal.woff2);unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/cyrillic/wght/normal.woff2);unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/greek/wght/normal.woff2);unicode-range:U+0370-0377,U+037A-037F,U+0384-038A,U+038C,U+038E-03A1,U+03A3-03FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/greek-ext/wght/normal.woff2);unicode-range:U+1F00-1FFF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/latin-ext/wght/normal.woff2);unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/latin/wght/normal.woff2);unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/vietnamese/wght/normal.woff2);unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/greek/wght/normal.woff2);unicode-range:U+0370-0377,U+037A-037F,U+0384-038A,U+038C,U+038E-03A1,U+03A3-03FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/cyrillic-ext/wght/normal.woff2);unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/cyrillic/wght/normal.woff2);unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/greek-ext/wght/normal.woff2);unicode-range:U+1F00-1FFF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/latin/wght/normal.woff2);unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/latin-ext/wght/normal.woff2);unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/greek/wght/normal.woff2);unicode-range:U+0370-0377,U+037A-037F,U+0384-038A,U+038C,U+038E-03A1,U+03A3-03FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/latin/wght/normal.woff2);unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/cyrillic-ext/wght/normal.woff2);unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/cyrillic/wght/normal.woff2);unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/greek-ext/wght/normal.woff2);unicode-range:U+1F00-1FFF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/latin-ext/wght/normal.woff2);unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/vietnamese/wght/normal.woff2);unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-display:swap;}</style>
+<style type="text/css">@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:300;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/latin/wght/normal.woff2);unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-display:swap;}@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:300;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/vietnamese/wght/normal.woff2);unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-display:swap;}@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:300;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/cyrillic/wght/normal.woff2);unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-display:swap;}@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:300;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/latin-ext/wght/normal.woff2);unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-display:swap;}@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:300;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/cyrillic-ext/wght/normal.woff2);unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-display:swap;}@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:400;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/cyrillic/wght/normal.woff2);unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-display:swap;}@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:400;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/vietnamese/wght/normal.woff2);unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-display:swap;}@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:400;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/latin/wght/normal.woff2);unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-display:swap;}@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:400;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/cyrillic-ext/wght/normal.woff2);unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-display:swap;}@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:400;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/latin-ext/wght/normal.woff2);unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-display:swap;}@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:500;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/cyrillic-ext/wght/normal.woff2);unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-display:swap;}@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:500;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/latin/wght/normal.woff2);unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-display:swap;}@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:500;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/latin-ext/wght/normal.woff2);unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-display:swap;}@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:500;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/vietnamese/wght/normal.woff2);unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-display:swap;}@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:500;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/cyrillic/wght/normal.woff2);unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-display:swap;}@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:600;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/cyrillic/wght/normal.woff2);unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-display:swap;}@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:600;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/latin-ext/wght/normal.woff2);unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-display:swap;}@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:600;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/latin/wght/normal.woff2);unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-display:swap;}@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:600;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/cyrillic-ext/wght/normal.woff2);unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-display:swap;}@font-face {font-family:Cormorant Garamond;font-style:normal;font-weight:600;src:url(/cf-fonts/v/cormorant-garamond/5.2.11/vietnamese/wght/normal.woff2);unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-display:swap;}</style>
+<script>
+(function () {
+  try {
+    var p = (typeof location !== "undefined" && location.pathname ? location.pathname : "").toLowerCase();
+    if (/shoppingcart|onepagecheckout|checkout|orderconfirm|myaccount|login\.asp/i.test(p)) {
+      document.documentElement.classList.add("mc-commerce-surface");
+    }
+  } catch (e) {}
+})();
+</script>
+<script src="/v/vspfiles/js/mc-cart-checkout-fix.js?v=20260620cart3"></script><!-- MC_CART_CHECKOUT_FIX -->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1"> 
+  <meta id="v65-layout-mode" data-cart="storedot" data-checkout="storedot" data-use-simplified-checkout="true">
+
+  <!-- LOGO UPLOAD TOOL *** SET HEIGHT & WIDTH *** -->
+  <meta id="v65-logo-dimensions" data-width="250" data-height="70">
+
+  <link href="/v/vspfiles/templates/266/css/template.css?v=20260302b" rel="stylesheet">
+  <link href="/v/vspfiles/templates/266/css/mccabe-overrides.css?v=20260518plp-mat" rel="stylesheet">
+  <script src="/v/vspfiles/js/mc-windsor-hero-fix.js?v=20260620windsor1"></script><!-- MC_WINDSOR_HERO_FIX -->
+  <style id="mc-plp-url-critical">
+  /* Category PLP: applies via data-mc-category-plp on &lt;html&gt; before body.category exists */
+  html[data-mc-category-plp="1"] .v-product-grid .v-product > a.v-product__img,
+  html[data-mc-category-plp="1"] .v-product-grid .v-product a.v-product__img,
+  html.category .v-product-grid .v-product > a.v-product__img,
+  html.category .v-product-grid .v-product a.v-product__img {
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    width: 100% !important;
+    height: 280px !important;
+    min-height: 280px !important;
+    max-height: 280px !important;
+    margin: 0 !important;
+    padding: 14px !important;
+    overflow: visible !important;
+    box-sizing: border-box !important;
+    background: #ffffff !important;
+    line-height: 0 !important;
+    text-decoration: none !important;
+  }
+  html[data-mc-category-plp="1"] .v-product-grid .v-product > a.v-product__img > img,
+  html[data-mc-category-plp="1"] .v-product-grid .v-product a.v-product__img > img,
+  html.category .v-product-grid .v-product > a.v-product__img > img,
+  html.category .v-product-grid .v-product a.v-product__img > img {
+  width: auto !important;
+  height: auto !important;
+  max-width: 100% !important;
+  max-height: 240px !important;
+  object-fit: contain !important;
+  object-position: center center !important;
+  margin: 0 auto !important;
+  border: 0 !important;
+  display: block !important;
+  box-sizing: border-box !important;
+  }
+  @media (max-width: 991px) {
+    html[data-mc-category-plp="1"] .v-product-grid .v-product > a.v-product__img,
+    html[data-mc-category-plp="1"] .v-product-grid .v-product a.v-product__img,
+    html.category .v-product-grid .v-product > a.v-product__img,
+    html.category .v-product-grid .v-product a.v-product__img {
+      height: 220px !important;
+      min-height: 220px !important;
+      max-height: 220px !important;
+      padding: 12px !important;
+    }
+    html[data-mc-category-plp="1"] .v-product-grid .v-product > a.v-product__img > img,
+    html[data-mc-category-plp="1"] .v-product-grid .v-product a.v-product__img > img,
+    html.category .v-product-grid .v-product > a.v-product__img > img,
+    html.category .v-product-grid .v-product a.v-product__img > img {
+      height: auto !important;
+      max-height: 196px !important;
+    }
+  }
+  </style>
+  <style id="mc-category-pager-critical">
+    /* Category Next/Prev: must work even when custom-safe.css does not load */
+    #mc-category-pager.mc-category-pager {
+      display: flex !important;
+      flex-wrap: wrap !important;
+      align-items: center !important;
+      justify-content: space-between !important;
+      gap: 12px !important;
+      margin: 28px auto 20px !important;
+      padding: 12px !important;
+      clear: both !important;
+      width: 100% !important;
+      max-width: 100% !important;
+      box-sizing: border-box !important;
+      visibility: visible !important;
+      opacity: 1 !important;
+      position: relative !important;
+      z-index: 2 !important;
+    }
+    #mc-category-pager .mc-category-pager__btn {
+      transition: none !important;
+      display: inline-flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+      min-width: 7.5rem !important;
+      padding: 10px 20px !important;
+      font: 600 12px/1.2 Inter, system-ui, -apple-system, sans-serif !important;
+      letter-spacing: 0.1em !important;
+      text-transform: uppercase !important;
+      text-decoration: none !important;
+      color: #1a1a1a !important;
+      background: #fff !important;
+      border: 1px solid #1a1a1a !important;
+      border-radius: 2px !important;
+      box-sizing: border-box !important;
+      cursor: pointer !important;
+    }
+    #mc-category-pager .mc-category-pager__btn:hover {
+      background: #1a1a1a !important;
+      color: #fff !important;
+    }
+    #mc-category-pager-top.mc-category-pager-page-row {
+      display: flex !important;
+      flex-wrap: wrap !important;
+      align-items: center !important;
+      justify-content: space-between !important;
+      gap: 12px !important;
+      width: 100% !important;
+      max-width: 100% !important;
+      box-sizing: border-box !important;
+      margin: 0 0 14px 0 !important;
+      padding: 0 max(12px, 2vw) !important;
+    }
+    /* Volusion “Page N of M” row hidden via data-mc-pager-hidden when custom pager is active */
+    [data-mc-pager-hidden="1"] {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      margin: 0 !important;
+      padding: 0 !important;
+      overflow: hidden !important;
+      clip: rect(0, 0, 0, 0) !important;
+      border: 0 !important;
+    }
+    .mc-category-pager__page-of {
+      display: none !important;
+    }
+    #mc-category-pager.mc-category-pager:not(:has(.mc-category-pager__btn--prev)) {
+      justify-content: flex-end !important;
+    }
+    #mc-category-pager .mc-category-pager__btn--next {
+      margin-left: 0 !important;
+    }
+    #mc-category-pager .mc-category-pager__btn--prev {
+      margin-right: 0 !important;
+    }
+    #mc-category-pager-top .mc-category-pager__btn {
+      transition: none !important;
+    }
+    #mc-category-pager-top .mc-category-pager__btn--next {
+      margin-left: 0 !important;
+    }
+    #mc-category-pager-sticky.mc-category-pager-sticky {
+      position: fixed !important;
+      left: 0 !important;
+      right: 0 !important;
+      bottom: 0 !important;
+      z-index: 1600 !important;
+      display: flex !important;
+      align-items: flex-end !important;
+      justify-content: space-between !important;
+      padding: 10px 14px calc(12px + env(safe-area-inset-bottom)) !important;
+      pointer-events: none !important;
+      box-sizing: border-box !important;
+    }
+    #mc-category-pager-sticky.mc-category-pager-sticky a {
+      pointer-events: auto !important;
+    }
+    #mc-category-pager-sticky.mc-category-pager-sticky:not(:has(.mc-category-pager-sticky__prev)) {
+      justify-content: flex-end !important;
+    }
+    #mc-category-pager-sticky .mc-category-pager-sticky__prev {
+      margin-right: 0 !important;
+    }
+    #mc-category-pager-sticky .mc-category-pager-sticky__next {
+      margin-left: 0 !important;
+    }
+  </style>
+  <style id="mc-header-search-critical">
+    /* One interior header column stack — no separate theater/Paragon positioning. */
+    body:not(.is-home) header.header,
+    body.category header.header,
+    html.category body header.header,
+    body.productdetails header.header,
+    body.mc-product-page header.header,
+    body.mc-theater-seating-pdp header.header {
+      display: flex !important;
+      flex-direction: column !important;
+      flex-wrap: nowrap !important;
+      align-items: stretch !important;
+    }
+    body:not(.is-home) header.header > .header__section:not(.header__section--middle),
+    body.category header.header > .header__section:not(.header__section--middle),
+    html.category body header.header > .header__section:not(.header__section--middle),
+    body.productdetails header.header > .header__section:not(.header__section--middle),
+    body.mc-product-page header.header > .header__section:not(.header__section--middle),
+    body.mc-theater-seating-pdp header.header > .header__section:not(.header__section--middle) {
+      order: 1 !important;
+      width: 100% !important;
+      max-width: 100% !important;
+    }
+    body:not(.is-home) header.header > .mc-header-desktop-bar,
+    body:not(.is-home) header.header > .hidden-xs.col-xs-12,
+    body:not(.is-home) header.header > .col-xs-12.hidden-xs,
+    body.category header.header > .mc-header-desktop-bar,
+    body.category header.header > .hidden-xs.col-xs-12,
+    body.category header.header > .col-xs-12.hidden-xs,
+    html.category body header.header > .mc-header-desktop-bar,
+    html.category body header.header > .hidden-xs.col-xs-12,
+    html.category body header.header > .col-xs-12.hidden-xs,
+    body.productdetails header.header > .mc-header-desktop-bar,
+    body.productdetails header.header > .hidden-xs.col-xs-12,
+    body.productdetails header.header > .col-xs-12.hidden-xs,
+    body.mc-product-page header.header > .mc-header-desktop-bar,
+    body.mc-product-page header.header > .hidden-xs.col-xs-12,
+    body.mc-product-page header.header > .col-xs-12.hidden-xs,
+    body.mc-theater-seating-pdp header.header > .mc-header-desktop-bar,
+    body.mc-theater-seating-pdp header.header > .hidden-xs.col-xs-12,
+    body.mc-theater-seating-pdp header.header > .col-xs-12.hidden-xs {
+      order: 2 !important;
+      width: 100% !important;
+      max-width: 100% !important;
+      position: relative !important;
+      z-index: 3 !important;
+    }
+    body:not(.is-home) header.header > .header__section--middle,
+    body:not(.is-home) header.header > .mc-header-search-below-nav,
+    body.category header.header > .header__section--middle,
+    body.category header.header > .mc-header-search-below-nav,
+    html.category body header.header > .header__section--middle,
+    html.category body header.header > .mc-header-search-below-nav,
+    body.productdetails header.header > .header__section--middle,
+    body.productdetails header.header > .mc-header-search-below-nav,
+    body.mc-product-page header.header > .header__section--middle,
+    body.mc-product-page header.header > .mc-header-search-below-nav,
+    body.mc-theater-seating-pdp header.header > .header__section--middle,
+    body.mc-theater-seating-pdp header.header > .mc-header-search-below-nav {
+      order: 20 !important;
+      width: 100% !important;
+      max-width: 100% !important;
+      flex: 0 0 auto !important;
+      margin-top: 0 !important;
+    }
+    body:not(.is-home) header.header > .mc-header-cart,
+    body.category header.header > .mc-header-cart,
+    html.category body header.header > .mc-header-cart,
+    body.productdetails header.header > .mc-header-cart,
+    body.mc-product-page header.header > .mc-header-cart,
+    body.mc-theater-seating-pdp header.header > .mc-header-cart {
+      order: 30 !important;
+    }
+    html.mc-search-open header.header .collapsing-search,
+    body.mc-search-open header.header .collapsing-search {
+      transform: none !important;
+    }
+    /* Hero block exists in HTML on every page — default collapsed; only html.mc-allow-home-hero + is-home may open it */
+    #if_homepage {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      min-height: 0 !important;
+      max-height: 0 !important;
+      overflow: hidden !important;
+      margin: 0 !important;
+      padding: 0 !important;
+      pointer-events: none !important;
+      border: 0 !important;
+    }
+    html.mc-allow-home-hero body.is-home #if_homepage {
+      display: block !important;
+      visibility: visible !important;
+      height: auto !important;
+      min-height: 0 !important;
+      max-height: none !important;
+      overflow: visible !important;
+      pointer-events: auto !important;
+    }
+    meta[itemprop="name"] {
+      display: none !important;
+    }
+    /* Volusion fills #display_homepage_title with text logo — hide on all pages (hero overlay is homepage logo) */
+    header.header #display_homepage_title,
+    header.header #display_homepage_title *,
+    #display_homepage_title,
+    #display_homepage_title * {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      width: 0 !important;
+      margin: 0 !important;
+      padding: 0 !important;
+      overflow: hidden !important;
+      opacity: 0 !important;
+      pointer-events: none !important;
+    }
+    header.header .header__section > .col-xs-6.col-sm-8.col-md-9.col-lg-3:first-child {
+      display: none !important;
+      width: 0 !important;
+      padding: 0 !important;
+      margin: 0 !important;
+      overflow: hidden !important;
+    }
+    html.mc-allow-home-hero body.is-home header.header > .header__section,
+    html.mc-allow-home-hero body.is-home header.header {
+      min-height: 0 !important;
+      padding: 0 !important;
+      margin: 0 !important;
+      background: transparent !important;
+    }
+    html:not(.mc-allow-home-hero) body:not(.is-home) #slideshow-container .hero-menu,
+html[data-mc-category-plp="1"] body:not(.is-home) #slideshow-container .hero-menu,
+html.category body:not(.is-home) #slideshow-container .hero-menu {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      pointer-events: none !important;
+    }
+    /* Raw template often includes #if_homepage on every page — hide when URL is not homepage */
+    html:not(.mc-allow-home-hero) body #if_homepage,
+    body:not(.is-home) #if_homepage,
+    body.category #if_homepage,
+    html.category body #if_homepage,
+    body.productdetails #if_homepage,
+    body.mc-product-page #if_homepage,
+    html.mc-paragon-pdp body #if_homepage,
+    html.mc-url-looks-like-pdp body.is-home #if_homepage {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      min-height: 0 !important;
+      overflow: hidden !important;
+      margin: 0 !important;
+      padding: 0 !important;
+      pointer-events: none !important;
+    }
+    /* URL-only PDP hint (runs before body exists): beats body.is-home + allow glitches */
+    html.mc-url-looks-like-pdp #if_homepage,
+    html.mc-url-looks-like-pdp body #if_homepage,
+    html.mc-url-looks-like-pdp body.is-home #if_homepage {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      min-height: 0 !important;
+      max-height: 0 !important;
+      overflow: hidden !important;
+      margin: 0 !important;
+      padding: 0 !important;
+      pointer-events: none !important;
+      border: 0 !important;
+    }
+    /* Category PLP: always hide collapsed homepage hero (beats body.is-home + mc-allow-home-hero glitches). */
+    html.category body:not(.is-home) #if_homepage,
+body.category:not(.is-home) #if_homepage,
+html.category body:not(.is-home) #slideshow-container,
+body.category:not(.is-home) #slideshow-container,
+html.category body:not(.is-home) #slideshow-container .mc-hero-video,
+body.category:not(.is-home) #slideshow-container .mc-hero-video {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      min-height: 0 !important;
+      max-height: 0 !important;
+      margin: 0 !important;
+      padding: 0 !important;
+      overflow: hidden !important;
+      opacity: 0 !important;
+      pointer-events: none !important;
+      border: 0 !important;
+      background: transparent !important;
+    }
+    /* Hero overlay search only (desktop nav bar has no visible in-flow search — .mc-search-float) */
+    #mcHeroSearchOverlay .header__section--middle,
+    #mcHeroSearchOverlay .mc-header-search-below-nav {
+      display: block !important;
+      visibility: visible !important;
+      opacity: 1 !important;
+      width: 100% !important;
+      max-width: 100% !important;
+      box-sizing: border-box !important;
+    }
+    #mcHeroSearchOverlay .collapsing-search {
+      display: block !important;
+      visibility: visible !important;
+      opacity: 1 !important;
+      position: relative !important;
+      width: 100% !important;
+      max-width: 100% !important;
+      box-sizing: border-box !important;
+    }
+    #mcHeroSearchOverlay .collapsing-search,
+    #mcHeroSearchOverlay #collapsingSearch {
+      border-bottom: none !important;
+      padding: 4px 12px 10px !important;
+    }
+    #mcHeroSearchOverlay .collapsing-search__form .row {
+      border-bottom: 1px solid rgba(255, 255, 255, 0.5) !important;
+      padding-bottom: 6px !important;
+    }
+    html.mc-search-open #mcHeroSearchOverlay .collapsing-search__form .row,
+    body.mc-search-open #mcHeroSearchOverlay .collapsing-search__form .row,
+    #mcHeroSearchOverlay .collapsing-search:focus-within .collapsing-search__form .row {
+      border-bottom-color: rgba(255, 255, 255, 0.92) !important;
+      border-bottom-width: 0px !important;
+    }
+    @media (min-width: 992px) {
+      body:not(.is-home) header.header .mc-header-desktop-bar[data-mc-header-bar],
+      body.category header.header .mc-header-desktop-bar[data-mc-header-bar],
+      html.category body header.header .mc-header-desktop-bar[data-mc-header-bar],
+      body.productdetails header.header .mc-header-desktop-bar[data-mc-header-bar],
+      body.mc-product-page header.header .mc-header-desktop-bar[data-mc-header-bar],
+      body.mc-theater-seating-pdp header.header .mc-header-desktop-bar[data-mc-header-bar] {
+        position: relative !important;
+        display: flex !important;
+        justify-content: center !important;
+        align-items: center !important;
+        height: 48px !important;
+        min-height: 48px !important;
+        margin: 0 !important;
+        padding: 0 96px !important;
+        top: 0 !important;
+        transform: none !important;
+        box-sizing: border-box !important;
+      }
+      body:not(.is-home) header.header .microblock.main-menu,
+      body.category header.header .microblock.main-menu,
+      html.category body header.header .microblock.main-menu,
+      body.productdetails header.header .microblock.main-menu,
+      body.mc-product-page header.header .microblock.main-menu,
+      body.mc-theater-seating-pdp header.header .microblock.main-menu {
+        position: relative !important;
+        display: flex !important;
+        justify-content: center !important;
+        align-items: center !important;
+        margin: 0 auto !important;
+        padding: 0 !important;
+        top: 0 !important;
+        transform: none !important;
+      }
+      body:not(.is-home) header.header .mc-header-search-cart-wrap,
+      body.category header.header .mc-header-search-cart-wrap,
+      html.category body header.header .mc-header-search-cart-wrap,
+      body.productdetails header.header .mc-header-search-cart-wrap,
+      body.mc-product-page header.header .mc-header-search-cart-wrap,
+      body.mc-theater-seating-pdp header.header .mc-header-search-cart-wrap {
+        display: none !important;
+      }
+      html.mc-search-open body:not(.is-home) header.header .mc-header-search-cart-wrap,
+      html.mc-search-open body.category header.header .mc-header-search-cart-wrap,
+      html.mc-search-open.category body header.header .mc-header-search-cart-wrap,
+      html.mc-search-open body.productdetails header.header .mc-header-search-cart-wrap,
+      html.mc-search-open body.mc-product-page header.header .mc-header-search-cart-wrap,
+      html.mc-search-open body.mc-theater-seating-pdp header.header .mc-header-search-cart-wrap {
+        display: flex !important;
+        position: fixed !important;
+        top: 72px !important;
+        right: 200px !important;
+        left: auto !important;
+        transform: none !important;
+        z-index: 10075 !important;
+        flex-direction: row !important;
+        align-items: center !important;
+        flex-wrap: nowrap !important;
+        gap: 8px !important;
+        width: auto !important;
+        max-width: min(92vw, 380px) !important;
+        margin: 0 !important;
+        padding: 10px 12px !important;
+        background: #fff !important;
+        box-shadow: 0 8px 28px rgba(0, 0, 0, 0.14) !important;
+        border-radius: 4px !important;
+        border: 0 !important;
+        box-sizing: border-box !important;
+      }
+      html.mc-search-open header.header .mc-header-search-cart-wrap .mc-header-cart,
+      body.mc-search-open header.header .mc-header-search-cart-wrap .mc-header-cart {
+        display: none !important;
+      }
+      header.header .mc-header-search-cart-wrap,
+      header.header .mc-header-search-below-nav,
+      header.header .header__section--middle,
+      header.header .collapsing-search,
+      header.header #collapsingSearch,
+      header.header .collapsing-search__form,
+      header.header .collapsing-search__form .container,
+      header.header .collapsing-search__form .row {
+        border: 0 !important;
+        border-bottom: 0 !important;
+        box-shadow: none !important;
+      }
+      header.header .mc-header-search-below-nav input,
+      header.header .collapsing-search input,
+      header.header #collapsingSearch input,
+      header.header input[type="search"],
+      header.header input[type="text"][name*="search"],
+      header.header input[type="text"][name*="Search"],
+      header.header #search,
+      header.header .collapsing-search__input {
+        display: none !important;
+        width: 0 !important;
+        opacity: 0 !important;
+        max-width: 0 !important;
+        visibility: hidden !important;
+        border: 0 !important;
+        border-bottom: 0 !important;
+        box-shadow: none !important;
+      }
+      html.mc-search-open header.header .mc-header-search-cart-wrap #search,
+      html.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search__input,
+      body.mc-search-open header.header .mc-header-search-cart-wrap #search,
+      body.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search__input {
+        display: inline-block !important;
+        width: 200px !important;
+        max-width: 100% !important;
+        min-width: 0 !important;
+        opacity: 1 !important;
+        visibility: visible !important;
+        height: auto !important;
+        padding: 6px 8px !important;
+        border: 0 !important;
+        border-bottom: 0px solid #bdbdbd !important;
+        box-sizing: border-box !important;
+      }
+      html.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search__submit {
+        display: inline-flex !important;
+        width: auto !important;
+        opacity: 1 !important;
+        visibility: visible !important;
+        pointer-events: auto !important;
+      }
+      body:not(.is-home) header.header > .mc-header-search-below-nav,
+      body:not(.is-home) header.header > .header__section.header__section--middle,
+      body.category header.header > .mc-header-search-below-nav,
+      body.category header.header > .header__section.header__section--middle,
+      html.category body header.header > .mc-header-search-below-nav,
+      html.category body header.header > .header__section.header__section--middle,
+      body.productdetails header.header > .mc-header-search-below-nav,
+      body.productdetails header.header > .header__section.header__section--middle,
+      body.productdetails header.header > .header__section--middle,
+      body.mc-product-page header.header > .mc-header-search-below-nav,
+      body.mc-product-page header.header > .header__section.header__section--middle,
+      body.mc-product-page header.header > .header__section--middle,
+      body.mc-theater-seating-pdp header.header > .mc-header-search-below-nav,
+      body.mc-theater-seating-pdp header.header > .header__section.header__section--middle,
+      body.mc-theater-seating-pdp header.header > .header__section--middle {
+        display: none !important;
+        visibility: hidden !important;
+        height: 0 !important;
+        min-height: 0 !important;
+        margin: 0 !important;
+        padding: 0 !important;
+        overflow: hidden !important;
+        pointer-events: none !important;
+        border: 0 !important;
+        clip-path: inset(50%) !important;
+      }
+    }
+html.mc-allow-home-hero body.is-home #slideshow-container,
+body.is-home.category #slideshow-container,
+html.category body.is-home #slideshow-container {
+  display: block !important;
+  visibility: visible !important;
+  height: auto !important;
+  min-height: 0 !important;
+  max-height: none !important;
+  opacity: 1 !important;
+  overflow: visible !important;
+}
+
+html.mc-allow-home-hero body.is-home #slideshow-container .hero-menu,
+body.is-home.category #slideshow-container .hero-menu,
+html.category body.is-home #slideshow-container .hero-menu {
+  display: flex !important;
+  visibility: visible !important;
+  height: auto !important;
+  opacity: 1 !important;
+  pointer-events: auto !important;
+}
+  </style>
+<link href="//d21ivvgspl06jm.cloudfront.net/theme-assets/icons/theme-icons-base.css" rel="stylesheet">
+<script>
+(function () {
+  function mcCssBust() {
+    return 'v=' + Date.now() + '&m=' + Math.random().toString(36).slice(2, 12);
+  }
+  var bust = mcCssBust();
+  var staticEl = document.getElementById('mc-custom-safe-css-static');
+  if (staticEl) {
+    staticEl.href = '/v/vspfiles/css/custom-safe.css?' + bust;
+    return;
+  }
+  if (document.getElementById('mc-custom-safe-css')) {
+    return;
+  }
+  var el = document.createElement('link');
+  el.rel = 'stylesheet';
+  el.id = 'mc-custom-safe-css';
+  el.href = '/v/vspfiles/css/custom-safe.css?' + bust;
+  el.onerror = function () {
+    this.onerror = function () {
+      this.onerror = null;
+      this.href = '/v/vspfiles/css/custom-safe.css?' + mcCssBust();
+    };
+    this.href = '/v/custom-safe.css?' + mcCssBust();
+  };
+  var ref = document.querySelector('link[href*="d21ivvgspl06jm.cloudfront.net/theme-assets"]');
+  if (ref && ref.parentNode) {
+    ref.parentNode.insertBefore(el, ref.nextSibling);
+  } else {
+    document.head.appendChild(el);
+  }
+})();
+</script>
+
+
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  if (window.v65 && typeof window.v65.init === "function") {
+    window.v65.init();
+  }
+  if (window.V65 && typeof window.V65.init === "function") {
+    window.V65.init();
+  }
+  if (window.Volusion && window.Volusion.ProductDetail && typeof window.Volusion.ProductDetail.init === "function") {
+    window.Volusion.ProductDetail.init();
+  }
+});
+</script>
+  <style>
+  .mc-cart-float__icon,
+  .mc-home-float__icon,
+  .mc-search-float__icon {
+    width: 20px;
+    height: 20px;
+    display: block;
+  }
+  body button.mc-search-float,
+  body .mc-search-float {
+    display: none !important;
+    -webkit-appearance: none;
+    appearance: none;
+  }
+  @media (min-width: 992px) {
+    body button.mc-search-float,
+    body .mc-search-float {
+      position: fixed !important;
+      top: 10px !important;
+      right: 200px !important;
+      z-index: 10070 !important;
+      width: 52px !important;
+      height: 52px !important;
+      max-width: 52px !important;
+      border: 0 !important;
+      border-radius: 50% !important;
+      background: #fff !important;
+      box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08) !important;
+      display: flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+      padding: 0 !important;
+      margin: 0 !important;
+      cursor: pointer !important;
+      color: #111 !important;
+    }
+    .mc-search-float__icon {
+      width: 20px !important;
+      height: 20px !important;
+      display: block !important;
+    }
+  }
+  /* Desktop-only cart inset (mobile uses custom-safe.css end block) */
+  @media (min-width: 992px) {
+    body a.mc-home-float, body .mc-home-float { margin-right: 0 !important; }
+    body a.mc-cart-float, body .mc-cart-float {
+      margin-left: 0 !important;
+      left: calc(100vw - 52px - max(10px, env(safe-area-inset-right))) !important;
+      right: auto !important;
+      width: 52px !important;
+      max-width: 52px !important;
+    }
+  }
+  </style>
+  <!-- Hero headline: IDs + head CSS + sync script — Volusion often strips p/class/style; this must win -->
+  <style id="mc-hero-copy-critical">
+    #mc-hero-copy-tagline {
+      display: block !important;
+      font-size: 36px !important;
+      line-height: 1.2 !important;
+      font-weight: 400 !important;
+      letter-spacing: 0.12em !important;
+      color: #d8d6d3 !important;
+      text-transform: none !important;
+      text-align: center !important;
+      margin: 0.2em auto 0 !important;
+      padding: 0 !important;
+      font-family: inherit !important;
+      white-space: nowrap !important;
+      max-width: min(96vw, 920px) !important;
+      margin-left: auto !important;
+      margin-right: auto !important;
+      box-sizing: border-box !important;
+    }
+    #mc-hero-copy-subline {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      margin: 0 !important;
+      padding: 0 !important;
+      overflow: hidden !important;
+      font-size: 0 !important;
+      line-height: 0 !important;
+    }
+    @media (max-width: 991px) {
+      #mc-hero-copy-tagline {
+        font-size: clamp(11px, 2.85vw, 36px) !important;
+        letter-spacing: clamp(0.05em, 0.09vw, 0.12em) !important;
+      }
+    }
+  </style>
+  <script id="mc-hero-copy-head-force">
+(function () {
+  var TAG = '';
+  function paintTagline(el) {
+    if (!el) return;
+    el.style.cssText = '';
+    el.style.setProperty('display', 'block', 'important');
+    el.style.setProperty('text-align', 'center', 'important');
+    el.style.setProperty('width', '100%', 'important');
+    el.style.setProperty('max-width', 'min(96vw,920px)', 'important');
+    el.style.setProperty('margin-left', 'auto', 'important');
+    el.style.setProperty('margin-right', 'auto', 'important');
+    el.style.setProperty('box-sizing', 'border-box', 'important');
+    el.style.setProperty('font-size', '36px', 'important');
+    el.style.setProperty('line-height', '1.2', 'important');
+    el.style.setProperty('font-weight', '400', 'important');
+    el.style.setProperty('letter-spacing', '0.12em', 'important');
+    el.style.setProperty('color', '#d8d6d3', 'important');
+    el.style.setProperty('text-transform', 'none', 'important');
+    el.style.setProperty('margin-top', '0.2em', 'important');
+    el.style.setProperty('margin-bottom', '0', 'important');
+    el.style.setProperty('white-space', 'nowrap', 'important');
+  }
+  function mcHeroEnsureCopy() {
+    var sc = document.getElementById('slideshow-container');
+    if (!sc) return;
+    var ov = sc.querySelector('.mc-hero-overlay');
+    if (!ov) return;
+    var wrap = ov.querySelector('.hero-logo-wrap');
+    var t = sc.querySelector('#mc-hero-copy-tagline');
+    var s = sc.querySelector('#mc-hero-copy-subline');
+    if (s && s.parentNode) s.parentNode.removeChild(s);
+    if (!t) {
+      t = document.createElement('div');
+      t.id = 'mc-hero-copy-tagline';
+      if (wrap) wrap.insertAdjacentElement('afterend', t);
+      else ov.insertBefore(t, ov.firstChild);
+    }
+    if (t.textContent.replace(/\s+/g, ' ').trim().indexOf('CUSTOM FURNITURE') === -1) t.textContent = TAG;
+    paintTagline(t);
+    ov.style.setProperty('z-index', '5', 'important');
+    t.style.setProperty('-webkit-text-fill-color', '#d8d6d3', 'important');
+    try {
+      if (window.matchMedia && window.matchMedia('(max-width: 991px)').matches) {
+        t.style.setProperty('font-size', 'clamp(11px, 2.85vw, 36px)', 'important');
+        t.style.setProperty('letter-spacing', 'clamp(0.05em, 0.09vw, 0.12em)', 'important');
+      }
+    } catch (eM) {}
+  }
+  function boot() {
+    mcHeroEnsureCopy();
+    var n = 0;
+    var iv = window.setInterval(function () {
+      mcHeroEnsureCopy();
+      if (++n >= 50) window.clearInterval(iv);
+    }, 120);
+  }
+  window.mcHeroEnsureCopy = mcHeroEnsureCopy;
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', boot);
+  else boot();
+  window.addEventListener('load', mcHeroEnsureCopy);
+})();
+  </script>
+  <!-- Category grid: in-template fallback so layout works even if /v/vspfiles/css/custom-safe.css is stale or blocked -->
+  <style id="mc-category-grid-critical">
+  @media (min-width: 992px) {
+    body:not(.productdetails) #content_area .v-product-grid {
+      display: grid !important;
+      grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+      gap: 20px !important;
+      width: 100% !important;
+      max-width: 100% !important;
+      min-width: 0 !important;
+      float: none !important;
+      clear: both !important;
+    }
+  }
+  @media (min-width: 576px) and (max-width: 991px) {
+    body:not(.productdetails) #content_area .v-product-grid {
+      display: grid !important;
+      grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+      gap: 16px !important;
+      width: 100% !important;
+    }
+  }
+  @media (max-width: 575px) {
+    body:not(.productdetails) #content_area .v-product-grid {
+      display: grid !important;
+      grid-template-columns: minmax(0, 1fr) !important;
+      gap: 12px !important;
+    }
+  }
+  body:not(.productdetails) #content_area .v-product-grid > .v-product,
+  body:not(.productdetails) #content_area ul.v-product-grid > li.v-product {
+    display: flex !important;
+    flex-direction: column !important;
+    align-items: stretch !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    min-width: 100% !important;
+    box-sizing: border-box !important;
+    float: none !important;
+  }
+  /* Category PLP: white image tile (path /-s/ sets html.category before body paint) */
+  html.category body:not(.productdetails):not(.is-home) #content_area .v-product-grid,
+  html.category body:not(.productdetails):not(.is-home) #content_area ul.v-product-grid {
+    background-color: #ffffff !important;
+  }
+  html.category body:not(.productdetails) #content_area a.v-product__img,
+  html.category body:not(.productdetails) #content_area .v-product__img,
+  html.category body:not(.productdetails) #content_area .v-product__image,
+  html.category body:not(.productdetails) #content_area .product_image,
+  html.category body:not(.productdetails) #content_area .vcss_img,
+  html.category body:not(.productdetails) #content_area ul.v-product-grid > li .v-product__img {
+    display: flex !important;
+    align-items: flex-end !important;
+    justify-content: center !important;
+    height: 280px !important;
+    min-height: 280px !important;
+    max-height: 280px !important;
+    padding: 14px !important;
+    box-sizing: border-box !important;
+    overflow: hidden !important;
+    background: #ffffff !important;
+  }
+  html.category body:not(.productdetails) #content_area .v-product__img img,
+  html.category body:not(.productdetails) #content_area a.v-product__img > img {
+    width: auto !important;
+    max-width: 100% !important;
+    min-width: 0 !important;
+    object-fit: contain !important;
+    object-position: center bottom !important;
+    margin: 0 auto !important;
+    border: 0 !important;
+    display: block !important;
+  }
+  @media (max-width: 991px) {
+    html.category body:not(.productdetails) #content_area a.v-product__img,
+    html.category body:not(.productdetails) #content_area .v-product__img {
+      height: 220px !important;
+      min-height: 220px !important;
+      max-height: 220px !important;
+      padding: 12px !important;
+    }
+    html.category body:not(.productdetails) #content_area .v-product__img img,
+    html.category body:not(.productdetails) #content_area a.v-product__img > img {
+      height: 172px !important;
+      max-height: 172px !important;
+    }
+  }
+  </style>
+
+<script>
+(function () {
+  function enforceMobileLayout() {
+    if (!window.matchMedia('(max-width: 991px)').matches) return;
+
+    var gutters = document.querySelectorAll(
+      '#content_area, .content_area-wrapper, #v65-product-parent, #options_table, #divDescription, #divQuestions, .TabbedPanelsContent, .TabbedPanelsContentGroup, .resp-tabs-container, .product_description'
+    );
+
+    gutters.forEach(function (el) {
+      el.style.paddingLeft = '16px';
+      el.style.paddingRight = '16px';
+      el.style.marginLeft = '0';
+      el.style.marginRight = '0';
+      el.style.maxWidth = '100%';
+      el.style.boxSizing = 'border-box';
+    });
+
+    /* Cart/home position is controlled by custom-safe.css (safe-area, no run-off) */
+  }
+
+  function runProductHardFixes() {
+  enforceMobileLayout();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', runProductHardFixes);
+  } else {
+    runProductHardFixes();
+  }
+
+  window.addEventListener('load', runProductHardFixes);
+})();
+</script>
+
+
+ 
+  <!-- DESIGN TOOLKIT -->
+  <script src="/v/vspfiles/templates/266/js/min/design-toolkit.min.js?v=20260625plp"></script>
+  <script id="mc-pdp-auth-cta-boot">/* PDP: mc-pdp-auth-cta-fix.js */</script>
+  <script>
+(function (g, d) {
+  var FP = "20260624A";
+  function bootFreshCta() {
+    if (!d.getElementById("v65-product-parent")) return;
+    if (String(g.__MC_DEPLOY_FP__ || "") === FP) return;
+    if (d.documentElement.getAttribute("data-mc-pdp-auth-head-boot")) return;
+    d.documentElement.setAttribute("data-mc-pdp-auth-head-boot", "1");
+    d.querySelectorAll('script[src*="mc-pdp-auth-cta-fix.js"]').forEach(function (old) {
+      try { old.remove(); } catch (eRm) {}
+    });
+    var s = d.createElement("script");
+    s.src = "/v/vspfiles/js/mc-pdp-auth-cta-fix.js?mcrd=" + Date.now();
+    s.async = false;
+    (d.head || d.documentElement).appendChild(s);
+  }
+  bootFreshCta();
+  d.addEventListener("DOMContentLoaded", bootFreshCta);
+})(window, document);
+  </script>
+  <script src="/v/vspfiles/js/mc-pdp-price-stack.js?v=20260607member"></script>
+  <script src="/v/vspfiles/js/mc-bedroom-collection-section.js?v=20260620collection2"></script><!-- MC_BEDROOM_COLLECTION_DEPLOY_VERIFY_20260620collection2 -->
+  <!-- mc-pdp-auth-cta-fix.js is loaded fresh (?mcrd=Date.now()) by the bootFreshCta loader above.
+       A second static ?mcrd=live tag used to live here; it cached an old copy whose stabilizer
+       fought the fresh script and made the ATC bounce. Removed. MC_TEMPLATE_DEPLOY_VERIFY_20260624B -->
+  <style id="mc-ss-hero-critical-20260701">
+@media (min-width:992px){
+  html body.productdetails:has(#v65-product-parent input[name="ProductCode"][value^="SS-"]) #v65-product-parent>tbody>tr:nth-of-type(2)>td:first-child,
+  html body.mc-product-page:has(#v65-product-parent input[name="ProductCode"][value^="SS-"]) #v65-product-parent>tbody>tr:nth-of-type(2)>td:first-child,
+  html body.mc-steve-silver-altview-pdp :is(#content_area,#v65-product-parent) td.mc-pdp-media-td,
+  html body.mc-steve-silver-altview-pdp td.mc-unified-pdp-media{
+    display:flex!important;flex-direction:column!important;grid-template-columns:none!important;
+    align-items:flex-start!important;width:650px!important;max-width:min(650px,100%)!important;min-width:0!important}
+  html body.productdetails:has(#v65-product-parent input[name="ProductCode"][value^="SS-"]) img#product_photo,
+  html body.mc-product-page:has(#v65-product-parent input[name="ProductCode"][value^="SS-"]) img#product_photo,
+  html body.mc-steve-silver-altview-pdp img#product_photo{
+    width:650px!important;max-width:min(650px,100%)!important;height:auto!important;display:block!important;
+    margin-left:0!important;margin-right:auto!important;object-fit:contain!important}
+  html body.productdetails:has(#v65-product-parent input[name="ProductCode"][value^="SS-"]) table:has(img#product_photo),
+  html body.mc-steve-silver-altview-pdp table:has(img#product_photo){
+    width:100%!important;max-width:650px!important;grid-column:auto!important;margin-left:0!important}
+}
+</style>
+  <style id="mc-tmh-pdp-critical-20260702">
+html:has(#v65-product-parent input[name="ProductCode"][value^="TMH-"]):not(.mc-mahjong-pdp-ready) #ProductDetail_ProductDetails_div2,
+html:has(#v65-product-parent input[name="ProductCode"][value^="TMH-"]):not(.mc-mahjong-pdp-ready) #Header_ProductDetail_ProductDetails,
+html:has(#v65-product-parent input[name="ProductCode"][value^="TMH-"]):not(.mc-mahjong-pdp-ready) td#Header_ProductDetail_ProductDetails,
+html:has(#v65-product-parent input[name="ProductCode"][value^="TMH-"]):not(.mc-mahjong-pdp-ready) #v65-product-parent > tbody > tr > td:first-child table.colors_descriptionbox,
+html.mc-mahjong-pdp-init:not(.mc-mahjong-pdp-ready) #ProductDetail_ProductDetails_div2,
+html.mc-mahjong-pdp-init:not(.mc-mahjong-pdp-ready) #Header_ProductDetail_ProductDetails,
+html.mc-mahjong-pdp-init:not(.mc-mahjong-pdp-ready) td#Header_ProductDetail_ProductDetails,
+html.mc-mahjong-pdp-init:not(.mc-mahjong-pdp-ready) #v65-product-parent > tbody > tr > td:first-child table.colors_descriptionbox,
+html.mc-mahjong-pdp-init:not(.mc-mahjong-pdp-ready) #mc-pdp-accordion{
+  display:none!important}
+</style>
+  <script id="mc-tmh-pdp-boot-20260702">
+(function (g, d) {
+  function tagTmhInit() {
+    try {
+      var pc = String(g.global_Current_ProductCode || "").toUpperCase();
+      if (!pc) {
+        var el = d.querySelector('input[name="ProductCode"], input[name="productcode"]');
+        pc = String((el && el.value) || "").toUpperCase();
+      }
+      if (!/^TMH-/.test(pc)) return false;
+      if (d.documentElement) d.documentElement.classList.add("mc-mahjong-pdp-init");
+      if (d.body) d.body.classList.add("mc-mahjong-house-pdp", "mc-mahjong-pdp-init");
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+  if (!tagTmhInit()) {
+    var n = 0;
+    var iv = g.setInterval(function () {
+      if (tagTmhInit() || ++n > 40) g.clearInterval(iv);
+    }, 50);
+  }
+  d.addEventListener("DOMContentLoaded", tagTmhInit);
+})(window, document);
+</script>
+  <script id="mc-ss-piece-hero-boot">
+(function (g, d) {
+  var SS_HERO_VER = "20260701sshero2";
+  function productCode() {
+    var input = d.querySelector('input[name="ProductCode"]');
+    return String(
+      (g.global_Current_ProductCode || "") ||
+      (input && input.value) ||
+      ""
+    ).toUpperCase();
+  }
+  function photo(code, n, thumb) {
+    return "/v/vspfiles/photos/" + code + "-" + n + (thumb ? "T" : "") + ".jpg";
+  }
+  function normalizePhotoUrl(url) {
+    return String(url || "").replace(/\?.*$/, "").split("#")[0];
+  }
+  function isDesktop() {
+    return !!(g.matchMedia && g.matchMedia("(min-width: 992px)").matches);
+  }
+  function applyPieceHeroLayout(img) {
+    if (!img) return;
+    try {
+      d.body.classList.add("mc-steve-silver-altview-pdp");
+    } catch (eBody) {}
+    var desktop = isDesktop();
+    var maxW = desktop ? "650px" : "100%";
+    var mediaCell =
+      img.closest("td.mc-unified-pdp-media, td.mc-pdp-media-td, #product_photo_td") ||
+      img.closest("td");
+    if (mediaCell) {
+      mediaCell.style.setProperty("display", "flex", "important");
+      mediaCell.style.setProperty("flex-direction", "column", "important");
+      mediaCell.style.setProperty("grid-template-columns", "none", "important");
+      mediaCell.style.setProperty("align-items", "flex-start", "important");
+      mediaCell.style.setProperty("width", desktop ? "650px" : "100%", "important");
+      mediaCell.style.setProperty("max-width", desktop ? "650px" : "100%", "important");
+    }
+    img.style.setProperty("width", desktop ? "650px" : "100%", "important");
+    img.style.setProperty("max-width", maxW, "important");
+    img.style.setProperty("height", "auto", "important");
+    img.style.setProperty("display", "block", "important");
+    img.style.setProperty("margin-left", "0", "important");
+    img.style.setProperty("object-fit", "contain", "important");
+    if (mediaCell) {
+      mediaCell.querySelectorAll("table").forEach(function (tbl) {
+        if (!tbl.querySelector("img#product_photo")) return;
+        tbl.style.setProperty("width", "100%", "important");
+        tbl.style.setProperty("max-width", desktop ? "650px" : "100%", "important");
+        tbl.style.setProperty("grid-column", "auto", "important");
+        tbl.style.setProperty("margin-left", "0", "important");
+      });
+    }
+    if (typeof g.ensureSteveSilverHeroImageSize === "function") {
+      try {
+        g.ensureSteveSilverHeroImageSize();
+      } catch (eExt) {}
+    }
+  }
+  function applyPieceHero() {
+    var code = productCode();
+    if (!/^SS-/.test(code)) return;
+    var img = d.getElementById("product_photo");
+    if (!img) return false;
+    var full = photo(code, 1, false);
+    var cur = String(img.getAttribute("src") || img.src || "");
+    if (/-2T\.|-2\.jpg/i.test(cur) || normalizePhotoUrl(cur) !== normalizePhotoUrl(full)) {
+      img.setAttribute("src", full);
+      img.src = full;
+      img.removeAttribute("srcset");
+    }
+    var zoom = d.querySelector("a#product_photo_zoom_url, a#product_photo_zoom_url2");
+    if (zoom && normalizePhotoUrl(zoom.getAttribute("href") || "") !== normalizePhotoUrl(full)) {
+      zoom.setAttribute("href", full);
+    }
+    if (!img.__mcSsHeroLock) {
+      img.__mcSsHeroLock = true;
+      try {
+        new g.MutationObserver(function () {
+          var src = img.getAttribute("src") || "";
+          if (/-2T\.|-2\.jpg/i.test(src)) {
+            img.setAttribute("src", full);
+            img.src = full;
+          }
+          applyPieceHeroLayout(img);
+        }).observe(img, { attributes: true, attributeFilter: ["src"] });
+      } catch (eLock) {}
+    }
+    applyPieceHeroLayout(img);
+    return true;
+  }
+  function boot() {
+    if (!applyPieceHero()) return;
+    g.__MC_SS_TEMPLATE_HERO_VER__ = SS_HERO_VER;
+  }
+  [0, 120, 500, 1200, 2500, 5000].forEach(function (ms) {
+    g.setTimeout(boot, ms);
+  });
+  if (d.readyState === "loading") {
+    d.addEventListener("DOMContentLoaded", boot);
+  } else {
+    boot();
+  }
+  g.addEventListener("load", boot);
+})(window, document);
+  </script>
+  <script id="mc-plp-enforcer-bridge">
+(function(g,d){var W="20260716freeship1",vn=function(v){var n=parseInt(String(v||"").replace(/\D/g,""),10);return isNaN(n)?0:n;};
+
+function cat(){try{var p=String(g.location.pathname||"").toLowerCase();
+var isHome =
+  p === "/" ||
+  /\/default\.asp$/i.test(p) ||
+  /\/default\.html?$/i.test(p) ||
+  /\/index\.html?$/i.test(p);
+
+if (isHome) return false;
+
+if(g.document.body&&g.document.body.classList.contains("productdetails"))return false;if(/shoppingcart|one-page-checkout|checkout|orderconfirm/i.test(p))return false;if((/-s\//.test(p)||/category-s\//.test(p))&&/\.html?/i.test(p))return true;if(/productslist\.asp|searchresults\.asp/.test(p))return true;var r=d.getElementById("content_area");if(r&&r.querySelector(".v-product-grid a.v-product__img, ul.v-product-grid li.v-product"))return true;}catch(e){}return false;}function go(){if(!cat())return;if(vn(g.__MC_PLP_ENFORCER_VER__)>=vn(W)&&typeof g.mcPlpEnforcerRun==="function")return;d.querySelectorAll('script[src*="mc-plp-enforcer"]').forEach(function(s){try{s.remove();}catch(e2){}});delete g.__MC_PLP_ENFORCER__;delete g.__MC_PLP_ENFORCER_VER__;delete g.mcPlpEnforcerRun;var s=d.createElement("script");s.id="mc-plp-enforcer-js";s.src="/v/vspfiles/js/mc-plp-enforcer.js?v="+W+"&mcrd="+Date.now();s.onload=function(){try{g.mcPlpEnforcerRun&&g.mcPlpEnforcerRun();}catch(e3){}};(d.head||d.documentElement).appendChild(s);}if(d.readyState==="loading")d.addEventListener("DOMContentLoaded",go);else go();g.addEventListener("load",go);[0,200,900,2500].forEach(function(t){g.setTimeout(go,t);});})(window,document);
+  </script>
+
+</head>
+
+
+<!-- ========== Vibes - 266 ======================
+    DESIGNER: WA
+    DEVELOPER: CD
+    CODE DATE: 2017-05
+    VERSION: 3.0.21
+========================================= -->
+
+<body>
+ 
+<script>
+(function () {
+  try {
+    if (typeof window.mcSyncHomeBodyClass === "function") window.mcSyncHomeBodyClass();
+    else if (typeof window.mcPathIsHomepage === "function") {
+      if (window.mcPathIsHomepage()) document.body.classList.add("is-home");
+      else document.body.classList.remove("is-home");
+    }
+  } catch (e) {}
+})();
+</script>
+<script>
+(function () {
+  try {
+    window.isSectionalProductPage = function isSectionalProductPage() {
+      var path = String(window.location.pathname || "").toLowerCase();
+      if (path.indexOf("room-planner") !== -1) return false;
+      /* Theater seating PDPs use "Choose configuration" for seats — must NOT be treated as sofa/sectionals. */
+      if (
+        path.indexOf("theater-seating") !== -1 ||
+        path.indexOf("theatre-seating") !== -1 ||
+        path.indexOf("customtheaterseating") !== -1 ||
+        path.indexOf("home-theater") !== -1 ||
+        path.indexOf("home-theatre") !== -1
+      ) {
+        return false;
+      }
+      /* Theater guard must NOT scan all of #v65-product-parent (nav/footer mention "Theater Seating").
+         Only the visible product identity (title / schema name). */
+      try {
+        var prodRootEarly = document.getElementById("v65-product-parent");
+        var titleHay = " " + String(document.title || "").toLowerCase();
+        var h1n = prodRootEarly ? prodRootEarly.querySelector("h1") : document.querySelector("h1");
+        var nm = prodRootEarly ? prodRootEarly.querySelector('[itemprop="name"]') : document.querySelector('#v65-product-parent [itemprop="name"]');
+        if (h1n) titleHay += " " + String(h1n.textContent || "").toLowerCase();
+        if (nm) titleHay += " " + String(nm.textContent || "").toLowerCase();
+        if (
+          /\b(theater|theatre)\s+seating\b/i.test(titleHay) &&
+          !/\bsectional\b/i.test(titleHay)
+        ) {
+          return false;
+        }
+        if (/\bhome\s+(theater|theatre)\b/i.test(titleHay) && !/\bsectional\b/i.test(titleHay)) {
+          return false;
+        }
+      } catch (eBody) {}
+      if (path.includes("-sc-")) return true;
+      try {
+        var pcEl = document.querySelector('input[name="ProductCode"], input[name="productcode"]');
+        var pcVal = pcEl ? String(pcEl.value || "").trim() : "";
+        if (/-sc-/i.test(pcVal)) return true;
+      } catch (ePc) {}
+      var titleHaySec = " " + String(document.title || "").toLowerCase();
+      try {
+        var prodRootSec = document.getElementById("v65-product-parent");
+        var h1Sec = prodRootSec ? prodRootSec.querySelector("h1") : document.querySelector("h1");
+        var nmSec = prodRootSec ? prodRootSec.querySelector('[itemprop="name"]') : document.querySelector('#v65-product-parent [itemprop="name"]');
+        if (h1Sec) titleHaySec += " " + String(h1Sec.textContent || "").toLowerCase();
+        if (nmSec) titleHaySec += " " + String(nmSec.textContent || "").toLowerCase();
+      } catch (eTitleSec) {}
+      if (/sectional\s+configuration/i.test(titleHaySec)) return true;
+
+      try {
+        var pcKeys = document.querySelector('input[name="ProductCode"], input[name="productcode"]');
+        var pcKeysVal = pcKeys ? String(pcKeys.value || "").trim() : "";
+        var cfgMtl = window.MTL_SECTIONAL_CONFIGS;
+        if (cfgMtl && typeof cfgMtl === "object") {
+          var mSc = pcKeysVal.match(/^([A-Za-z][A-Za-z0-9]*)[-_]SC(?:[-_]|$)/i);
+          if (mSc && mSc[1]) {
+            var styleFromPc = String(mSc[1]).toLowerCase();
+            var mtlKeysPc = Object.keys(cfgMtl);
+            for (var mpi = 0; mpi < mtlKeysPc.length; mpi++) {
+              if (String(mtlKeysPc[mpi] || "").toLowerCase() === styleFromPc && cfgMtl[mtlKeysPc[mpi]]) return true;
+            }
+          }
+          var identityHay = (
+            path + " " + titleHaySec + " " + String(pcKeysVal || "").toLowerCase()
+          ).replace(/\s+/g, " ");
+          var sortedKeys = Object.keys(cfgMtl).slice().sort(function (a, b) {
+            return b.length - a.length;
+          });
+          for (var mi = 0; mi < sortedKeys.length; mi++) {
+            var mk = sortedKeys[mi];
+            if (!mk || !cfgMtl[mk]) continue;
+            var esc = String(mk).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+            if (new RegExp("\\b" + esc + "\\b", "i").test(identityHay)) return true;
+          }
+        }
+      } catch (eMtl) {}
+
+      return false;
+    };
+
+    var pathOnly = String(window.location.pathname || "").toLowerCase();
+    if (pathOnly.indexOf("room-planner") === -1 && pathOnly.includes("-sc-")) {
+      try {
+        document.documentElement.classList.add("is-sectional-product");
+      } catch (eHtml) {}
+    }
+
+    var b = document.body;
+    if (!b) return;
+    var p = (location.pathname || "").toLowerCase();
+    var pcEl =
+      document.querySelector('input[name="ProductCode"]') ||
+      document.querySelector('input[name="productcode"]');
+    var pc = String((pcEl && pcEl.value) || "").trim();
+    // Saranoni product pages: tag the body from the real ProductCode (not URL/title)
+    // so layout + the configured-color swatch system can scope to them.
+    var pcUpper = pc.toUpperCase();
+    if (/^SAR/.test(pcUpper)) {
+      b.classList.add("mc-saranoni-pdp");
+      if (pcUpper === "SAR-RUCHED-MINKY-THROW-BLANKET") {
+        b.classList.add("mc-ruched-blanket-pdp");
+      }
+    }
+    if (/^TMH/.test(pcUpper)) {
+      b.classList.add("mc-mahjong-house-pdp", "mc-mahjong-pdp-init");
+      if (document.documentElement) {
+        document.documentElement.classList.add("mc-mahjong-pdp-init");
+      }
+    }
+    var catEarly =
+      document.querySelector('input[name="CategoryID"], input[name="categoryid"], input[name="Category_Id"]');
+    var catEarlyV = catEarly && String(catEarly.value || "").trim();
+    var isBean =
+      /^BB/i.test(pc) ||
+      /\/bean-bag-seating-s\//.test(p) ||
+      /product-p\/bb-/i.test(p) ||
+      catEarlyV === "103";
+    if (isBean) {
+      b.classList.add("mc-bean-bag-pdp");
+      return;
+    }
+    function mcSyncSectionalHtmlClassFromPdp() {
+      if (window.isSectionalProductPage()) {
+        try {
+          document.documentElement.classList.add("is-sectional-product");
+        } catch (eSec) {}
+      } else if (document.getElementById("v65-product-parent")) {
+        try {
+          document.documentElement.classList.remove("is-sectional-product");
+        } catch (eSecR) {}
+      }
+    }
+    mcSyncSectionalHtmlClassFromPdp();
+    document.addEventListener("DOMContentLoaded", mcSyncSectionalHtmlClassFromPdp);
+    var looksPdp =
+      !!pcEl ||
+      !!document.getElementById("v65-product-parent") ||
+      (b.classList && b.classList.contains("productdetails"));
+    if (looksPdp && !window.isSectionalProductPage()) {
+      b.classList.add("mc-hide-native-options-until-mc");
+    }
+  } catch (e2) {}
+})();
+</script>
+<script>
+(function () {
+  function markCategoryOrListingPage() {
+    try {
+      var path = String(window.location.pathname || "").toLowerCase();
+      var b = document.body;
+      var isProductPage =
+        path.indexOf("-p/") !== -1 ||
+        path.indexOf("/product-p/") !== -1 ||
+        !!document.querySelector("#v65-product-parent") ||
+        (!!document.querySelector('input[name="ProductCode"]') &&
+          b &&
+          (b.classList.contains("productdetails") ||
+            b.classList.contains("mc-product-page") ||
+            b.classList.contains("mc-bean-bag-pdp")));
+      if (!isProductPage) document.documentElement.classList.add("is-category-or-listing-page");
+      else document.documentElement.classList.remove("is-category-or-listing-page");
+    } catch (eCat) {}
+  }
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", markCategoryOrListingPage);
+  else markCategoryOrListingPage();
+  window.addEventListener("load", markCategoryOrListingPage);
+})();
+</script>
+<!-- MC_TEMPLATE: header-critical-bar-20260401q -->
+<!-- Do not override window.location.reload: CAPTCHA / bot checks (Cloudflare, etc.) call reload to finish; blocking it causes verify loops. -->
+<a class="mc-account-float" href="/myaccount.asp" aria-label="My account" rel="nofollow">
+  <svg class="mc-account-float__icon" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path>
+  </svg>
+</a>
+<a class="mc-cart-float" href="/shoppingcart.asp" aria-label="Cart" rel="nofollow">
+  <svg class="mc-cart-float__icon" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M7 18c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm10 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zM6.2 6l.4 2h12.2c.5 0 .9.2 1.2.6.3.4.3.9.2 1.4l-1.2 5.2c-.2.7-.8 1.2-1.6 1.2H8.1c-.8 0-1.4-.5-1.6-1.2L4.3 4H2V2h3.1c.7 0 1.3.5 1.4 1.2L6.2 6zm1.3 9h9.8l1.1-5H6.6l.9 5z"></path>
+  </svg>
+</a>
+<a class="mc-home-float" href="/default.asp" aria-label="Home">
+  <svg class="mc-home-float__icon" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M12 3l9 8h-2v10a1 1 0 0 1-1 1h-5v-7H11v7H6a1 1 0 0 1-1-1V11H3l9-8z"></path>
+  </svg>
+</a>
+<button type="button" class="mc-search-float" aria-label="Search">
+  <svg class="mc-search-float__icon" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true">
+    <circle cx="11" cy="11" r="7" fill="none" stroke="currentColor" stroke-width="2"></circle>
+    <line x1="16.5" y1="16.5" x2="21" y2="21" stroke="currentColor" stroke-width="2"></line>
+  </svg>
+</button>
+<script>
+(function () {
+  function isMobile() {
+    return window.matchMedia("(max-width: 991px)").matches;
+  }
+  var FLOAT_NAV = [
+    { sel: "a.mc-home-float", href: "/default.asp" },
+    { sel: "a.mc-cart-float", href: "/shoppingcart.asp" },
+    { sel: "a.mc-account-float", href: "/myaccount.asp" }
+  ];
+  function closePushMenu() {
+    try {
+      document.documentElement.classList.remove("push-menu-open");
+      document.body.classList.remove("push-menu-open");
+    } catch (eClose) {}
+  }
+  function bindMobileFloatNav() {
+    FLOAT_NAV.forEach(function (item) {
+      var el = document.querySelector(item.sel);
+      if (!el) return;
+      var href = el.getAttribute("href") || item.href;
+      if (!href || href === "#") el.setAttribute("href", item.href);
+      el.setAttribute("role", "link");
+      el.style.pointerEvents = "auto";
+      if (el.dataset.mcFloatNavBound === "1") return;
+      el.dataset.mcFloatNavBound = "1";
+      /* Native <a href> navigation — do not preventDefault (was blocking taps on live mobile). */
+      el.addEventListener("click", function () {
+        if (!isMobile()) return;
+        closePushMenu();
+      });
+    });
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", bindMobileFloatNav);
+  } else {
+    bindMobileFloatNav();
+  }
+  window.addEventListener("resize", bindMobileFloatNav);
+})();
+</script>
+
+
+  <span style="display:none;" id="svgIncludes"></span>
+
+
+
+  <article class="vol-container">
+    <section class="vol-inner">
+      <div class="page-wrap">
+
+        <nav class="menu push-menu hidden-sm hidden-md hidden-lg" data-menu-type="slide-top" menu-icon-type="chevron">
+          <div class="push-menu__close-btn close-menu hidden">
+            <svg class="icon"><use xlink:href="#svg-close"></use></svg>
+          </div>
+          <div id="push-nav__menu" class="push-menu__menu-wrapper">
+            <!-- content populated with js -->
+          </div>
+        </nav>
+
+
+        <header class="header" data-ui-block="header-1">
+          <div class="header__section">
+          
+
+  <!-- LOGO -->
+  <div class="col-xs-6 col-sm-8 col-md-9 col-lg-3">
+    <div class="microblock vol-logo" id="display_homepage_title"><span class="vol-logo vol-logo--graphic" itemscope itemtype='http://schema.org/FurnitureStore'><meta itemprop='name' content='McCabe&#039;s Theater &amp; Living'><a class="vol-logo__link" href="https://www.mccabestheaterandliving.com/default.asp" title="McCabe&#039;s Theater &amp; Living">McCabe's Theater & Living</a><meta itemprop='legalName' content='McCabe&#039;s Theater &amp; Living'></span></div>
+  </div>
+
+
+                <div class="col-xs-6 col-sm-4 col-md-3 col-lg-2 col-lg-push-7 microblock-group text-right no-pad-left-xs">
+                  <div class="search__wrapper microblock">
+                    <div id="toggle1" class="toggle search__toggle searchToggle " tabindex="0" role="button">
+                      <span class="sr-only">Toggle search bar</span>
+                      <svg class="icon toggle__icon toggle__icon--closed"><use xlink:href="#svg-search"></use></svg>
+                      <svg class="icon toggle__icon toggle__icon--open"><use xlink:href="#svg-close"></use></svg>
+                    </div>
+                  </div>
+</div>
+           
+
+             
+
+            <div class="header__section--bottom text-center visible-xs">
+              <span class="microblock menu-toggle">
+                <a class="menu-toggle__link" href="javascript:void(0);" id="nav-toggle" data-menu-type="slide-top">
+                  <span class="menu-toggle__text push-menu--closed">SELECT A CATEGORY</span>
+                  <span class="menu-toggle__text push-menu--open">CLOSE MENU</span>
+                  <svg class="menu-toggle__icon"><use xlink:href="#svg-menu"></use></svg>
+                </a>
+              </span>
+            </div>
+
+          </div>
+<div class="col-xs-12 no-pad-lg mc-header-desktop-bar" data-mc-header-bar="20260409a">
+  <div class="microblock main-menu hidden-xs">
+    <nav id="display_menu_1" class="menu" link-alignment="center"><script type="text/javascript">var breadCrumb="|201||194|";</script>
+<link rel='stylesheet' type='text/css' href='/a/c/vnav.css'>
+<script src='/a/j/vnav.js?1'></script>
+<ul class='vnav vnav--horizontal vnav--level1'>
+<li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/194.htm' class='vnav__link' >Game Room</a>
+<ul class='vnav vnav__subnav vnav--level2'>
+<li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/mahjong-s/201.htm' class='vnav__link' >Mahjong</a>
+<ul class='vnav vnav__subnav vnav--level3'>
+<li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/202.htm' class='vnav__link' >Mahjong Tile Sets</a>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/203.htm' class='vnav__link' >Mahjong Mats & Racks</a>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/204.htm' class='vnav__link' >Mahjong Accessories</a>
+</li></ul>
+</li></ul>
+</li>
+<li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/139.htm' class='vnav__link' >Living Room</a>
+<ul class='vnav vnav__subnav vnav--level2'>
+<li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/198.htm' class='vnav__link' >Sectionals</a>
+<ul class='vnav vnav__subnav vnav--level3'>
+<li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/187.htm' class='vnav__link' >Stationary Sectionals</a>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/188.htm' class='vnav__link' >Reclining Sectionals</a>
+</li></ul>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/197.htm' class='vnav__link' >Sofas</a>
+<ul class='vnav vnav__subnav vnav--level3'>
+<li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/177.htm' class='vnav__link' >Stationary Sofas</a>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/179.htm' class='vnav__link' >Reclining Sofas</a>
+</li></ul>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/195.htm' class='vnav__link' >Occasional</a>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/199.htm' class='vnav__link' >Loveseats</a>
+<ul class='vnav vnav__subnav vnav--level3'>
+<li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/157.htm' class='vnav__link' >Stationary Loveseats</a>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/147.htm' class='vnav__link' >Reclining Loveseats</a>
+</li></ul>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/149.htm' class='vnav__link' >Recliners</a>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/178.htm' class='vnav__link' >Chairs</a>
+<ul class='vnav vnav__subnav vnav--level3'>
+<li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/175.htm' class='vnav__link' >Accent Chairs</a>
+</li></ul>
+</li></ul>
+</li>
+<li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/193.htm' class='vnav__link' >Dining</a>
+<ul class='vnav vnav__subnav vnav--level2'>
+<li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/216.htm' class='vnav__link' >Chairs and Stools</a>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/215.htm' class='vnav__link' >Dining Collections</a>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/217.htm' class='vnav__link' >Servers and Storage</a>
+</li></ul>
+</li>
+<li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/142.htm' class='vnav__link' >Bedroom</a>
+<ul class='vnav vnav__subnav vnav--level2'>
+<li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/214.htm' class='vnav__link' >Beds</a>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/210.htm' class='vnav__link' >Nightstands</a>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/211.htm' class='vnav__link' >Chests</a>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/212.htm' class='vnav__link' >Dressers</a>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/213.htm' class='vnav__link' >Mirrors</a>
+</li></ul>
+</li>
+<li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/bean-bag-seating-s/103.htm' class='vnav__link' >Bean Bags</a>
+</li>
+<li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/196.htm' class='vnav__link' >Luxe Comforts</a>
+<ul class='vnav vnav__subnav vnav--level2'>
+<li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/205.htm' class='vnav__link' >Adult Blankets</a>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/207.htm' class='vnav__link' >Baby Blankets</a>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/206.htm' class='vnav__link' >Kids Blankets</a>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/208.htm' class='vnav__link' >Snugglewear</a>
+</li><li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/209.htm' class='vnav__link' >Bedding</a>
+</li></ul>
+</li>
+<li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/181.htm' class='vnav__link' >Closeout Sale</a>
+</li>
+<li class='vnav__item'><a href='https://www.mccabestheaterandliving.com/category-s/136.htm' class='vnav__link' >About Us</a>
+</li>
+</ul>
+</nav>
+  </div>
+  <div class="mc-header-search-cart-wrap">
+    <div class="header__section header__section--middle mc-header-search-below-nav">
+      <div class="collapsing-search" id="collapsingSearch">
+        <form class="collapsing-search__form" action="/searchresults.asp" method="get" name="SearchBoxForm">
+          <div class="container">
+            <div class="row">
+              <input class="collapsing-search__input" id="search" placeholder="Search" type="text" name="Search" value="">
+              <label class="collapsing-search__label searchToggle sr-only" for="search">
+                <span class="collapsing-search__label__text">Search</span>
+              </label>
+              <button type="submit" name="Submit" class="collapsing-search__submit">
+                <p class="sr-only">Search Submit</p>
+                <svg class="collapsing-search__icon collapsing-search__icon--submit"><use xlink:href="#svg-search"></use></svg>
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+    <div class="microblock mc-header-cart hidden-xs">
+      <a class="mc-header-cart__link" href="/shoppingcart.asp"></a>
+    </div>
+  </div>
+</div>
+        </header>
+<script>
+(function () {
+  document.addEventListener('click', function (e) {
+    var x = e.target.closest('.push-menu__close-btn');
+    if (!x) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    document.documentElement.classList.remove('push-menu-open');
+    document.body.classList.remove('push-menu-open');
+  }, true);
+})();
+</script>
+<script>
+(function () {
+  function mcFindMainMenuRow() {
+    var h = document.querySelector('header.header');
+    if (!h) return null;
+    var bar = h.querySelector('.mc-header-desktop-bar');
+    if (bar) return bar;
+    var anchor = h.querySelector('.microblock.main-menu') || h.querySelector('#display_menu_1');
+    if (anchor) {
+      var row = anchor.closest('.col-xs-12');
+      if (row) return row;
+      row = anchor.closest('[class*="col-xs"]');
+      if (row) return row;
+      return anchor.parentElement;
+    }
+    return (
+      h.querySelector('.hidden-xs.col-xs-12.no-pad-lg') ||
+      h.querySelector('.hidden-xs.col-xs-12') ||
+      null
+    );
+  }
+
+  /**
+   * Search block may live in .mc-header-desktop-bar (source HTML) or in #mcHeroSearchOverlay after
+   * a homepage mount. If we only query the bar, interior pages return null while the node is still
+   * inside hidden #if_homepage — mcMountSearchLayout would exit early and never pull it back.
+   */
+  function mcFindHeaderSearchMid() {
+    var h = document.querySelector('header.header');
+    if (!h) return null;
+    var bar = h.querySelector('.mc-header-desktop-bar');
+    if (bar) {
+      var inBar =
+        bar.querySelector('.mc-header-search-below-nav.header__section--middle') ||
+        bar.querySelector('.mc-header-search-below-nav .header__section--middle') ||
+        bar.querySelector('.mc-header-search-below-nav');
+      if (inBar) return inBar;
+    }
+    var ov = document.getElementById('mcHeroSearchOverlay');
+    if (ov) {
+      var inHero =
+        ov.querySelector('.mc-header-search-below-nav') ||
+        ov.querySelector('.header__section--middle') ||
+        ov.querySelector('.mc-hero-search-inner .header__section--middle');
+      if (inHero) return inHero;
+    }
+    var fromSearch = h.querySelector('#search');
+    if (fromSearch) {
+      var wrap =
+        fromSearch.closest('.mc-header-search-below-nav') ||
+        fromSearch.closest('.header__section--middle');
+      if (wrap && h.contains(wrap)) return wrap;
+    }
+    return (
+      h.querySelector('.mc-header-search-below-nav') ||
+      h.querySelector('.header__section--middle')
+    );
+  }
+
+  function mcMountSearchLayout() {
+    var hHdr = document.querySelector('header.header');
+    var mid = mcFindHeaderSearchMid();
+    if (!mid && hHdr) {
+      var gSearch = document.getElementById('search');
+      if (gSearch && gSearch.closest && hHdr.contains(gSearch)) {
+        var w =
+          gSearch.closest('.mc-header-search-below-nav') ||
+          gSearch.closest('.header__section--middle') ||
+          gSearch.closest('.collapsing-search') ||
+          gSearch.parentElement;
+        if (w && hHdr.contains(w)) mid = w;
+      }
+    }
+    if (!mid) return;
+
+    var isHome = typeof window.mcPathIsHomepage === 'function' && window.mcPathIsHomepage();
+    var overlay = isHome ? document.getElementById('mcHeroSearchOverlay') : null;
+
+    if (isHome && overlay) {
+      if (mid.getAttribute('data-mc-search-mount') !== 'hero') {
+        var inner = document.createElement('div');
+        inner.className = 'mc-hero-search-inner';
+        inner.appendChild(mid);
+        overlay.appendChild(inner);
+        mid.setAttribute('data-mc-search-mount', 'hero');
+        overlay.classList.add('mc-hero-search-overlay--mounted');
+      }
+      return;
+    }
+  }
+
+  function mcPlaceInteriorSearchInBar(menuRow, mid) {
+    var hRoot = document.querySelector('header.header');
+    var bar = hRoot && hRoot.querySelector('.mc-header-desktop-bar');
+    if (!menuRow) menuRow = bar;
+    if (!menuRow || !mid) return;
+    var wrap = hRoot && hRoot.querySelector('.mc-header-search-cart-wrap');
+    var cart = hRoot && hRoot.querySelector('.mc-header-cart');
+    var mm = menuRow.querySelector('.microblock.main-menu');
+    if (!mm && bar) mm = bar.querySelector('.microblock.main-menu');
+    var anchorForWrap = bar || menuRow || hRoot;
+    if (!wrap && anchorForWrap) {
+      wrap = document.createElement('div');
+      wrap.className = 'mc-header-search-cart-wrap';
+      if (mm && mm.parentNode === anchorForWrap) {
+        anchorForWrap.insertBefore(wrap, mm.nextSibling);
+      } else if (mm && anchorForWrap.contains && anchorForWrap.contains(mm)) {
+        try {
+          mm.parentNode.insertBefore(wrap, mm.nextSibling);
+        } catch (eW1) {
+          anchorForWrap.appendChild(wrap);
+        }
+      } else {
+        anchorForWrap.appendChild(wrap);
+      }
+    }
+    if (!wrap) return;
+    if (mid.parentNode !== wrap) {
+      wrap.insertBefore(mid, wrap.firstChild);
+    }
+    if (cart && cart.parentNode !== wrap) {
+      wrap.appendChild(cart);
+    }
+    if (wrap.parentNode !== menuRow) {
+      if (mm) {
+        menuRow.insertBefore(wrap, mm.nextSibling);
+      } else {
+        menuRow.appendChild(wrap);
+      }
+    }
+  }
+
+  function bindSearchToggle() {
+    return;
+  }
+
+  function boot() {
+    try {
+      if (typeof window.mcSyncHomeBodyClass === "function") window.mcSyncHomeBodyClass();
+      else if (typeof window.mcPathIsHomepage === "function") {
+        if (window.mcPathIsHomepage()) document.body.classList.add("is-home");
+        else document.body.classList.remove("is-home");
+      }
+    } catch (eSync) {}
+    mcMountSearchLayout();
+    bindSearchToggle();
+  }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', boot);
+  else boot();
+})();
+</script>
+
+    
+        <div class="container container--content">
+          <aside class="vol-list-grid text-right vol-hide hidden-xs">
+            <section class="vol-list-grid-toggle vol-grid" data-grid-type="grid">
+              <svg class="icon grid-toggle__icon"><use xlink:href="#svg-cat-toggle-grid"></use></svg>
+            </section>
+            <section class="vol-list-grid-toggle vol-list" data-grid-type="list">
+              <svg class="icon grid-toggle__icon"><use xlink:href="#svg-cat-toggle-list"></use></svg>
+            </section>
+          </aside>
+
+          <div class="row">
+            <div class="sidebar-wrapper col-md-3 hidden-xs hidden-sm" role="complementary">
+              <div class="sidebar left-nav" menu-type="smart-expand toggle-expand">
+                
+
+                <div id="Menu2_Title" class="menu-title hidden">Nav Menu 2</div>
+                <nav id="display_menu_2" class="menu"><ul class='vnav vnav--vertical vnav--level1'>
+</ul>
+</nav>
+
+                <div id="Menu3_Title" class="menu-title hidden">Nav Menu 3</div>
+                <nav id="display_menu_3" class="menu"><ul class='vnav vnav--vertical vnav--level1'>
+</ul>
+</nav>
+
+                <div id="Menu4_Title" class="menu-title hidden">Nav Menu 4</div>
+                <nav id="display_menu_4" class="menu"><ul class='vnav vnav--vertical vnav--level1'>
+</ul>
+</nav>
+
+                <div id="Menu5_Title" class="menu-title hidden">Nav Menu 5</div>
+                <nav id="display_menu_5" class="menu"><ul class='vnav vnav--vertical vnav--level1'>
+</ul>
+</nav>
+
+                <div id="Menu6_Title" class="menu-title hidden">Nav Menu 6</div>
+                <nav id="display_menu_6" class="menu"><ul class='vnav vnav--vertical vnav--level1'>
+</ul>
+</nav>
+
+                <div id="Menu7_Title" class="menu-title hidden">Nav Menu 7</div>
+                <nav id="display_menu_7" class="menu"><ul class='vnav vnav--vertical vnav--level1'>
+</ul>
+</nav>
+
+                <div id="Menu8_Title" class="menu-title hidden">Nav Menu 8</div>
+                <nav id="display_menu_8" class="menu"><ul class='vnav vnav--vertical vnav--level1'>
+</ul>
+</nav>
+              </div>
+            </div>
+
+            <section class="content_area-wrapper col-xs-12 col-md-9" role="main">
+
+  <!-- REQUIRED: Volusion injects all page content here -->
+  <div id="content_area">
+<script type="text/javascript">
+var SearchParams = 'searching=Y&sort=13&cat=201&show=30&page=1';
+</script>
+
+
+<script type="text/javascript" src="/a/j/productlist.js"></script>
+    <div id='divWaitModal' class="a65chromeModal ui-dialog noniframe" style="width: 75px; height: 75px; display: none;">
+        <div style="height: 50px">
+            <img src="/a/i/ajax-loader.gif" alt="Waiting..." height="25px" width="25px;" style="padding: 12px" />
+        </div>
+    </div>
+	
+      <table width="100%" border="0" cellspacing="0" cellpadding="0">
+        <tr> 
+          <td> 
+            <table width="100%" border="0" cellspacing="0" cellpadding="5">
+              <tr> 
+                <td>
+				
+				
+				
+					<b><!--You are here://--><a href="https://www.mccabestheaterandliving.com/">Home</a> &gt; <a href="https://www.mccabestheaterandliving.com/category-s/194.htm" title="">Game Room</a> &gt; <a href="https://www.mccabestheaterandliving.com/mahjong-s/201.htm" title="mahjong">Mahjong</a></b>
+					
+				  </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+		
+		
+        
+		<tr>
+          <td class="colors_lines_light"><img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="1" height="1" alt=""></td>
+        </tr>
+			
+
+
+        <tr>
+			<td valign="top" align="center">
+				<span id="listOfErrorsSpan">
+				
+				</span>
+			</td>
+        </tr>
+      </table>
+
+
+<table width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr> 
+          <td> 
+<table width="100%" border=0 cellpadding=0 cellspacing=0>
+<tr>
+<td>
+<table width="100%" border="0" cellspacing="10" cellpadding="10">
+<tr>
+<td>
+<style>
+#mc-mahjong-page {
+  --mc-black: #111;
+  --mc-text: #383838;
+  --mc-muted: #777;
+  --mc-soft: #f7f7f5;
+  --mc-line: #e5e5e2;
+  --mc-white: #fff;
+  width: 100%;
+  max-width: 1440px;
+  margin: 0 auto;
+  background: var(--mc-white);
+  color: var(--mc-text);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.65;
+  letter-spacing: .01em;
+  overflow: hidden;
+}
+
+#mc-mahjong-page,
+#mc-mahjong-page * { box-sizing: border-box; }
+
+#mc-mahjong-page img {
+  display: block;
+  max-width: 100%;
+}
+
+#mc-mahjong-page a { color: inherit; }
+
+#mc-mahjong-page button,
+#mc-mahjong-page select { font: inherit; }
+
+#mc-mahjong-page .mc-wrap {
+  width: min(1180px, calc(100% - 44px));
+  margin: 0 auto;
+}
+
+#mc-mahjong-page .mc-eyebrow {
+  margin: 0 0 11px;
+  color: var(--mc-muted);
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 1.2;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+}
+
+#mc-mahjong-page h1,
+#mc-mahjong-page h2,
+#mc-mahjong-page h3,
+#mc-mahjong-page p { margin-top: 0; }
+
+#mc-mahjong-page h1,
+#mc-mahjong-page h2,
+#mc-mahjong-page h3 {
+  font-family: inherit;
+  font-weight: 400;
+  color: var(--mc-black);
+}
+
+#mc-mahjong-page h1 {
+  margin-bottom: 17px;
+  font-size: clamp(27px, 3vw, 32px);
+  line-height: 1.24;
+  letter-spacing: .09em;
+  text-transform: uppercase;
+}
+
+#mc-mahjong-page h2 {
+  margin-bottom: 14px;
+  font-size: clamp(21px, 2.4vw, 27px);
+  line-height: 1.3;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+}
+
+#mc-mahjong-page h3 {
+  margin-bottom: 8px;
+  font-size: 14px;
+  line-height: 1.42;
+  letter-spacing: .11em;
+  text-transform: uppercase;
+}
+
+#mc-mahjong-page p { margin-bottom: 17px; }
+
+#mc-mahjong-page .mc-lead {
+  max-width: 680px;
+  color: #555;
+  font-size: 15px;
+  line-height: 1.75;
+}
+
+#mc-mahjong-page .mc-btn {
+  display: inline-flex;
+  min-height: 45px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 23px;
+  border: 1px solid var(--mc-black);
+  border-radius: 0;
+  background: var(--mc-black);
+  color: #fff;
+  text-decoration: none;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background .2s ease, color .2s ease;
+}
+
+#mc-mahjong-page .mc-btn:hover {
+  background: #333;
+  border-color: #333;
+}
+
+#mc-mahjong-page .mc-btn--outline {
+  background: transparent;
+  color: var(--mc-black);
+}
+
+#mc-mahjong-page .mc-btn--outline:hover {
+  background: var(--mc-black);
+  color: #fff;
+}
+
+#mc-mahjong-page .mc-text-link {
+  display: inline-block;
+  padding-bottom: 2px;
+  border-bottom: 1px solid currentColor;
+  text-decoration: none;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: .11em;
+  text-transform: uppercase;
+}
+
+#mc-mahjong-page .mc-section { padding: 70px 0; }
+#mc-mahjong-page .mc-section--soft { background: var(--mc-soft); }
+
+#mc-mahjong-page .mc-section-head {
+  max-width: 760px;
+  margin: 0 auto 34px;
+  text-align: center;
+}
+
+/* Smaller category-page hero */
+#mc-mahjong-page .mc-hero-shell {
+  padding: 28px 0 34px;
+  border-bottom: 1px solid var(--mc-line);
+}
+
+#mc-mahjong-page .mc-hero {
+  display: grid;
+  grid-template-columns: minmax(340px, .85fr) minmax(0, 1.15fr);
+  min-height: 365px;
+  background: #fff;
+}
+
+#mc-mahjong-page .mc-hero-copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 38px 48px 38px 0;
+}
+
+#mc-mahjong-page .mc-hero-copy .mc-lead {
+  margin-bottom: 24px;
+}
+
+#mc-mahjong-page .mc-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+}
+
+#mc-mahjong-page .mc-hero-media {
+  height: 365px;
+  overflow: hidden;
+  background: #eee;
+}
+
+#mc-mahjong-page .mc-hero-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+}
+
+/* Sales-first category cards */
+#mc-mahjong-page .mc-shop-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 22px;
+}
+
+#mc-mahjong-page .mc-shop-card {
+  display: block;
+  text-decoration: none;
+}
+
+#mc-mahjong-page .mc-shop-card__image {
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  margin-bottom: 15px;
+  background: #fafafa;
+  border: 1px solid var(--mc-line);
+}
+
+#mc-mahjong-page .mc-shop-card__image--split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  background: var(--mc-line);
+}
+
+#mc-mahjong-page .mc-shop-card__image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform .25s ease;
+}
+
+#mc-mahjong-page .mc-shop-card:hover .mc-shop-card__image img {
+  transform: scale(1.025);
+}
+
+#mc-mahjong-page .mc-shop-card p {
+  min-height: 60px;
+  color: var(--mc-muted);
+  font-size: 12px;
+}
+
+/* Buying guide */
+#mc-mahjong-page .mc-buy-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: 1px solid var(--mc-line);
+  border-bottom: 1px solid var(--mc-line);
+}
+
+#mc-mahjong-page .mc-buy-card {
+  min-height: 195px;
+  padding: 28px 26px;
+  border-right: 1px solid var(--mc-line);
+}
+
+#mc-mahjong-page .mc-buy-card:last-child { border-right: 0; }
+
+#mc-mahjong-page .mc-buy-card__number {
+  display: block;
+  margin-bottom: 22px;
+  color: #aaa;
+  font-size: 11px;
+  letter-spacing: .16em;
+}
+
+#mc-mahjong-page .mc-buy-card p {
+  color: #666;
+  font-size: 12px;
+}
+
+/* Trainer */
+#mc-mahjong-page .mc-trainer {
+  display: grid;
+  grid-template-columns: 300px minmax(0, 1fr);
+  gap: 32px;
+  padding: 32px;
+  border: 1px solid var(--mc-line);
+  background: #fff;
+}
+
+#mc-mahjong-page .mc-trainer-controls {
+  padding-right: 30px;
+  border-right: 1px solid var(--mc-line);
+}
+
+#mc-mahjong-page .mc-field { margin-bottom: 17px; }
+
+#mc-mahjong-page .mc-field label {
+  display: block;
+  margin-bottom: 7px;
+  color: #555;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: .13em;
+  text-transform: uppercase;
+}
+
+#mc-mahjong-page .mc-field select {
+  width: 100%;
+  min-height: 43px;
+  padding: 9px 12px;
+  border: 1px solid #ccc;
+  border-radius: 0;
+  background: #fff;
+  color: #333;
+}
+
+#mc-mahjong-page .mc-trainer-stat {
+  margin-top: 18px;
+  color: var(--mc-muted);
+  font-size: 11px;
+}
+
+#mc-mahjong-page .mc-results-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 17px;
+}
+
+#mc-mahjong-page .mc-disclaimer {
+  max-width: 390px;
+  color: var(--mc-muted);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+#mc-mahjong-page .mc-pattern-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+#mc-mahjong-page .mc-pattern {
+  min-width: 0;
+  min-height: 208px;
+  padding: 17px;
+  border: 1px solid var(--mc-line);
+  background: #fff;
+}
+
+#mc-mahjong-page .mc-pattern__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+#mc-mahjong-page .mc-pattern__tag,
+#mc-mahjong-page .mc-pattern__level {
+  color: var(--mc-muted);
+  font-size: 10px;
+  letter-spacing: .11em;
+  text-transform: uppercase;
+}
+
+#mc-mahjong-page .mc-tile-strip {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 2px;
+  width: 100%;
+  margin-bottom: 13px;
+  overflow: hidden;
+}
+
+#mc-mahjong-page .mc-tile-strip img {
+  width: calc((100% - 26px) / 14);
+  min-width: 18px;
+  height: auto;
+  aspect-ratio: 86 / 112;
+  object-fit: contain;
+}
+
+#mc-mahjong-page .mc-pattern p {
+  margin-bottom: 0;
+  color: #666;
+  font-size: 12px;
+}
+
+#mc-mahjong-page .mc-empty {
+  grid-column: 1 / -1;
+  padding: 35px;
+  border: 1px dashed #ccc;
+  color: var(--mc-muted);
+  text-align: center;
+}
+
+#mc-mahjong-page .mc-more-wrap {
+  margin-top: 22px;
+  text-align: center;
+}
+
+#mc-mahjong-page .mc-more-wrap[hidden] { display: none; }
+
+/* Supplementary lifestyle content */
+#mc-mahjong-page .mc-lifestyle-grid {
+  display: grid;
+  grid-template-columns: 1.1fr .95fr .95fr;
+  gap: 18px;
+}
+
+#mc-mahjong-page .mc-lifestyle-card {
+  position: relative;
+  min-height: 350px;
+  overflow: hidden;
+  background: #eee;
+}
+
+#mc-mahjong-page .mc-lifestyle-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+#mc-mahjong-page .mc-lifestyle-copy {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  padding: 21px;
+  color: #fff;
+  background: linear-gradient(transparent, rgba(0,0,0,.72));
+}
+
+#mc-mahjong-page .mc-lifestyle-copy h3 {
+  margin-bottom: 5px;
+  color: #fff;
+}
+
+#mc-mahjong-page .mc-lifestyle-copy p {
+  margin-bottom: 0;
+  font-size: 12px;
+}
+
+/* FAQ */
+#mc-mahjong-page .mc-faq {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+#mc-mahjong-page details {
+  padding: 19px 0;
+  border-top: 1px solid var(--mc-line);
+}
+
+#mc-mahjong-page details:last-child {
+  border-bottom: 1px solid var(--mc-line);
+}
+
+#mc-mahjong-page summary {
+  list-style: none;
+  cursor: pointer;
+  color: var(--mc-black);
+  font-size: 13px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+
+#mc-mahjong-page summary::-webkit-details-marker { display: none; }
+
+#mc-mahjong-page summary::after {
+  content: "+";
+  float: right;
+  font-size: 18px;
+  font-weight: 300;
+}
+
+#mc-mahjong-page details[open] summary::after { content: "−"; }
+
+#mc-mahjong-page details p {
+  max-width: 720px;
+  margin: 14px 0 0;
+  color: var(--mc-muted);
+}
+
+@media (max-width: 1000px) {
+  #mc-mahjong-page .mc-shop-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  #mc-mahjong-page .mc-lifestyle-grid { grid-template-columns: 1fr 1fr; }
+  #mc-mahjong-page .mc-lifestyle-card:first-child { grid-column: 1 / -1; }
+}
+
+@media (max-width: 780px) {
+  #mc-mahjong-page .mc-wrap { width: min(100% - 28px, 1180px); }
+  #mc-mahjong-page .mc-section { padding: 56px 0; }
+
+  #mc-mahjong-page .mc-hero {
+    grid-template-columns: 1fr;
+    min-height: 0;
+  }
+
+  #mc-mahjong-page .mc-hero-media {
+    height: 310px;
+    order: -1;
+  }
+
+  #mc-mahjong-page .mc-hero-copy {
+    padding: 34px 0 12px;
+  }
+
+  #mc-mahjong-page .mc-buy-grid { grid-template-columns: 1fr; }
+  #mc-mahjong-page .mc-buy-card {
+    min-height: 0;
+    border-right: 0;
+    border-bottom: 1px solid var(--mc-line);
+  }
+  #mc-mahjong-page .mc-buy-card:last-child { border-bottom: 0; }
+
+  #mc-mahjong-page .mc-trainer {
+    grid-template-columns: 1fr;
+    padding: 21px;
+  }
+
+  #mc-mahjong-page .mc-trainer-controls {
+    padding: 0 0 23px;
+    border-right: 0;
+    border-bottom: 1px solid var(--mc-line);
+  }
+
+  #mc-mahjong-page .mc-results-head { display: block; }
+  #mc-mahjong-page .mc-pattern-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 560px) {
+  #mc-mahjong-page .mc-shop-grid,
+  #mc-mahjong-page .mc-lifestyle-grid {
+    grid-template-columns: 1fr;
+  }
+
+  #mc-mahjong-page .mc-lifestyle-card:first-child { grid-column: auto; }
+  #mc-mahjong-page .mc-lifestyle-card { min-height: 315px; }
+  #mc-mahjong-page .mc-shop-card p { min-height: 0; }
+  #mc-mahjong-page .mc-tile-strip { gap: 1px; }
+}
+</style>
+<style id="mc-mahjong-v5-overrides">
+/* Match the live McCabe's typography and palette */
+#mc-mahjong-page {
+  background: #fff !important;
+  color: #454545 !important;
+  font-family: Inter, system-ui, -apple-system, "Helvetica Neue", Helvetica, Arial, sans-serif !important;
+  font-size: 13px !important;
+  font-weight: 400 !important;
+  letter-spacing: .02em !important;
+}
+
+#mc-mahjong-page,
+#mc-mahjong-page * {
+  font-family: inherit !important;
+}
+
+#mc-mahjong-page .mc-section,
+#mc-mahjong-page .mc-section--soft,
+#mc-mahjong-page .mc-hero-shell,
+#mc-mahjong-page .mc-shop-card__image,
+#mc-mahjong-page .mc-trainer,
+#mc-mahjong-page .mc-pattern {
+  background: #fff !important;
+}
+
+#mc-mahjong-page .mc-wrap {
+  width: min(1080px, calc(100% - 40px)) !important;
+}
+
+#mc-mahjong-page h1 {
+  font-size: 29.6px !important;
+  font-weight: 400 !important;
+  line-height: 1.28 !important;
+  letter-spacing: .10em !important;
+  color: #1a1a1a !important;
+}
+
+#mc-mahjong-page h2 {
+  font-size: 22px !important;
+  font-weight: 400 !important;
+  line-height: 1.35 !important;
+  letter-spacing: .10em !important;
+  color: #1a1a1a !important;
+}
+
+#mc-mahjong-page h3,
+#mc-mahjong-page .mc-eyebrow {
+  font-size: 11px !important;
+  font-weight: 400 !important;
+  letter-spacing: .16em !important;
+  color: #777 !important;
+}
+
+#mc-mahjong-page .mc-lead,
+#mc-mahjong-page p {
+  color: #454545 !important;
+  font-size: 13px !important;
+  line-height: 1.7 !important;
+}
+
+#mc-mahjong-page .mc-btn {
+  min-height: 44px !important;
+  border-radius: 0 !important;
+  background: #1a1a1a !important;
+  border-color: #1a1a1a !important;
+  color: #fff !important;
+  font-size: 11px !important;
+  font-weight: 500 !important;
+  letter-spacing: .14em !important;
+}
+
+#mc-mahjong-page .mc-btn--outline {
+  background: #fff !important;
+  color: #1a1a1a !important;
+}
+
+/* Categories closer together horizontally */
+#mc-mahjong-page .mc-shop-grid {
+  max-width: 960px !important;
+  margin: 0 auto !important;
+  gap: 10px !important;
+}
+
+#mc-mahjong-page .mc-shop-card {
+  padding: 0 3px !important;
+}
+
+#mc-mahjong-page .mc-shop-card__image {
+  margin-bottom: 12px !important;
+}
+
+/* Bigger trainer tiles: two rows of seven */
+#mc-mahjong-page .mc-pattern-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  gap: 14px !important;
+}
+
+#mc-mahjong-page .mc-pattern {
+  min-height: 320px !important;
+  padding: 18px !important;
+}
+
+#mc-mahjong-page .mc-tile-strip {
+  display: grid !important;
+  grid-template-columns: repeat(7, 50px) !important;
+  justify-content: center !important;
+  gap: 7px 5px !important;
+  width: 100% !important;
+  margin: 0 auto 15px !important;
+  overflow: visible !important;
+}
+
+#mc-mahjong-page .mc-tile-strip img {
+  width: 50px !important;
+  min-width: 50px !important;
+  height: auto !important;
+  aspect-ratio: 86 / 112 !important;
+  object-fit: contain !important;
+}
+
+/* Teacher locator */
+#mc-mahjong-page .mc-teacher-locator {
+  display: grid !important;
+  grid-template-columns: .92fr 1.08fr !important;
+  align-items: stretch !important;
+  border: 1px solid #e5e5e5 !important;
+  background: #fff !important;
+}
+
+#mc-mahjong-page .mc-teacher-copy {
+  display: flex !important;
+  flex-direction: column !important;
+  justify-content: center !important;
+  padding: 38px !important;
+}
+
+#mc-mahjong-page .mc-teacher-form {
+  display: grid !important;
+  grid-template-columns: minmax(0, 1fr) auto !important;
+  gap: 8px !important;
+  margin: 4px 0 14px !important;
+}
+
+#mc-mahjong-page .mc-teacher-form input {
+  width: 100% !important;
+  min-height: 44px !important;
+  padding: 9px 11px !important;
+  border: 1px solid #c8c8c8 !important;
+  border-radius: 0 !important;
+  background: #fff !important;
+  color: #1a1a1a !important;
+  font-size: 12px !important;
+  font-weight: 400 !important;
+  letter-spacing: .04em !important;
+}
+
+#mc-mahjong-page .mc-teacher-form input:focus {
+  outline: none !important;
+  border-color: #1a1a1a !important;
+  box-shadow: 0 0 0 1px #1a1a1a !important;
+}
+
+#mc-mahjong-page .mc-teacher-links {
+  display: flex !important;
+  flex-wrap: wrap !important;
+  gap: 16px !important;
+  margin-top: 4px !important;
+}
+
+#mc-mahjong-page .mc-teacher-image {
+  min-height: 345px !important;
+  overflow: hidden !important;
+}
+
+#mc-mahjong-page .mc-teacher-image img {
+  width: 100% !important;
+  height: 100% !important;
+  object-fit: cover !important;
+}
+
+#mc-mahjong-page #mc-teacher-error {
+  color: #9c2f2f !important;
+  font-size: 11px !important;
+  margin: 0 0 12px !important;
+}
+
+@media (max-width: 1040px) {
+  #mc-mahjong-page .mc-tile-strip {
+    grid-template-columns: repeat(7, 44px) !important;
+  }
+
+  #mc-mahjong-page .mc-tile-strip img {
+    width: 44px !important;
+    min-width: 44px !important;
+  }
+}
+
+@media (max-width: 900px) {
+  #mc-mahjong-page .mc-pattern-grid {
+    grid-template-columns: 1fr !important;
+  }
+
+  #mc-mahjong-page .mc-pattern {
+    min-height: 0 !important;
+  }
+
+  #mc-mahjong-page .mc-tile-strip {
+    grid-template-columns: repeat(7, 54px) !important;
+  }
+
+  #mc-mahjong-page .mc-tile-strip img {
+    width: 54px !important;
+    min-width: 54px !important;
+  }
+}
+
+@media (max-width: 760px) {
+  #mc-mahjong-page .mc-teacher-locator {
+    grid-template-columns: 1fr !important;
+  }
+
+  #mc-mahjong-page .mc-teacher-image {
+    min-height: 285px !important;
+    order: -1 !important;
+  }
+
+  #mc-mahjong-page .mc-teacher-copy {
+    padding: 28px 22px !important;
+  }
+}
+
+@media (max-width: 560px) {
+  #mc-mahjong-page .mc-shop-grid {
+    gap: 24px !important;
+  }
+
+  #mc-mahjong-page .mc-tile-strip {
+    grid-template-columns: repeat(7, minmax(0, 40px)) !important;
+    gap: 5px 3px !important;
+  }
+
+  #mc-mahjong-page .mc-tile-strip img {
+    width: 100% !important;
+    min-width: 0 !important;
+  }
+
+  #mc-mahjong-page .mc-teacher-form {
+    grid-template-columns: 1fr !important;
+  }
+}
+</style>
+<style id="mc-mahjong-v6-styles">
+/* Learning-path tabs */
+#mc-mahjong-page .mc-learning-tabs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  max-width: 760px;
+  margin: 0 auto 34px;
+  border: 1px solid #d9d9d9;
+  background: #fff;
+}
+
+#mc-mahjong-page .mc-learning-tab {
+  min-height: 52px;
+  padding: 12px 18px;
+  border: 0;
+  border-right: 1px solid #d9d9d9;
+  border-radius: 0;
+  background: #fff;
+  color: #555;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+#mc-mahjong-page .mc-learning-tab:last-child {
+  border-right: 0;
+}
+
+#mc-mahjong-page .mc-learning-tab.is-active {
+  background: #1a1a1a;
+  color: #fff;
+}
+
+#mc-mahjong-page .mc-learning-panel[hidden] {
+  display: none !important;
+}
+
+#mc-mahjong-page .mc-learning-panel {
+  background: #fff;
+}
+
+#mc-mahjong-page .mc-section-head--left {
+  max-width: 760px;
+  margin-right: auto;
+  margin-left: 0;
+  text-align: left;
+}
+
+#mc-mahjong-page .mc-subsection {
+  margin-top: 58px;
+}
+
+/* Beginner tile key */
+#mc-mahjong-page .mc-key-card {
+  margin-bottom: 18px;
+  padding: 26px;
+  border: 1px solid #e3e3e3;
+  background: #fff;
+}
+
+#mc-mahjong-page .mc-key-card > h3 {
+  margin-bottom: 22px;
+}
+
+#mc-mahjong-page .mc-key-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 24px;
+}
+
+#mc-mahjong-page .mc-key-group {
+  min-width: 0;
+}
+
+#mc-mahjong-page .mc-key-tiles {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  min-height: 126px;
+  margin-bottom: 12px;
+}
+
+#mc-mahjong-page .mc-key-tile {
+  width: 64px;
+  margin: 0;
+  text-align: center;
+}
+
+#mc-mahjong-page .mc-key-tile img {
+  width: 64px;
+  height: auto;
+  margin: 0 auto 6px;
+}
+
+#mc-mahjong-page .mc-key-tile figcaption {
+  color: #777;
+  font-size: 10px;
+  line-height: 1.3;
+}
+
+#mc-mahjong-page .mc-key-group p {
+  margin-bottom: 0;
+  color: #555;
+  font-size: 12px;
+}
+
+/* Pair/pung/kong/quint examples */
+#mc-mahjong-page .mc-group-examples {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+#mc-mahjong-page .mc-group-example {
+  min-width: 0;
+  padding: 20px;
+  border: 1px solid #e3e3e3;
+  background: #fff;
+}
+
+#mc-mahjong-page .mc-step-label {
+  display: block;
+  margin-bottom: 14px;
+  color: #777;
+  font-size: 11px;
+  letter-spacing: .15em;
+  text-transform: uppercase;
+}
+
+#mc-mahjong-page .mc-example-tiles {
+  display: flex;
+  align-items: flex-start;
+  gap: 5px;
+  min-height: 90px;
+  margin-bottom: 12px;
+}
+
+#mc-mahjong-page .mc-example-tiles img {
+  width: 46px;
+  min-width: 0;
+  height: auto;
+}
+
+#mc-mahjong-page .mc-group-example p {
+  margin-bottom: 0;
+  color: #666;
+  font-size: 12px;
+}
+
+/* Beginner steps */
+#mc-mahjong-page .mc-beginner-steps {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  border-top: 1px solid #e3e3e3;
+  border-left: 1px solid #e3e3e3;
+}
+
+#mc-mahjong-page .mc-beginner-step {
+  display: grid;
+  grid-template-columns: 42px 1fr;
+  gap: 14px;
+  min-height: 160px;
+  padding: 24px;
+  border-right: 1px solid #e3e3e3;
+  border-bottom: 1px solid #e3e3e3;
+  background: #fff;
+}
+
+#mc-mahjong-page .mc-beginner-step > span {
+  color: #999;
+  font-size: 11px;
+  letter-spacing: .15em;
+}
+
+#mc-mahjong-page .mc-beginner-step p {
+  margin-bottom: 0;
+  color: #666;
+  font-size: 12px;
+}
+
+/* Glossary */
+#mc-mahjong-page .mc-glossary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border-top: 1px solid #e3e3e3;
+  border-left: 1px solid #e3e3e3;
+}
+
+#mc-mahjong-page .mc-glossary-grid article {
+  min-height: 142px;
+  padding: 20px;
+  border-right: 1px solid #e3e3e3;
+  border-bottom: 1px solid #e3e3e3;
+  background: #fff;
+}
+
+#mc-mahjong-page .mc-glossary-grid p {
+  margin-bottom: 0;
+  color: #666;
+  font-size: 12px;
+}
+
+/* Beginner shopping bridge */
+#mc-mahjong-page .mc-beginner-shop {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 24px;
+  margin-top: 58px;
+  padding: 28px;
+  border: 1px solid #dcdcdc;
+  background: #fff;
+}
+
+#mc-mahjong-page .mc-beginner-shop h2 {
+  margin-bottom: 8px;
+}
+
+#mc-mahjong-page .mc-beginner-shop p {
+  margin-bottom: 0;
+}
+
+#mc-mahjong-page .mc-beginner-shop__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/* Regular-player cues */
+#mc-mahjong-page .mc-regular-cues {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-bottom: 28px;
+  border-top: 1px solid #e3e3e3;
+  border-left: 1px solid #e3e3e3;
+}
+
+#mc-mahjong-page .mc-regular-cues article {
+  min-height: 150px;
+  padding: 20px;
+  border-right: 1px solid #e3e3e3;
+  border-bottom: 1px solid #e3e3e3;
+}
+
+#mc-mahjong-page .mc-regular-cues p {
+  margin-bottom: 0;
+  color: #666;
+  font-size: 12px;
+}
+
+#mc-mahjong-page .mc-regular-key-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 22px;
+  padding: 14px 17px;
+  border: 1px solid #e3e3e3;
+}
+
+#mc-mahjong-page .mc-regular-key-link p {
+  margin-bottom: 0;
+}
+
+#mc-mahjong-page .mc-text-button {
+  padding: 0 0 2px;
+  border: 0;
+  border-bottom: 1px solid #1a1a1a;
+  background: transparent;
+  color: #1a1a1a;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+/* Trainer: one pattern per row so tiles cannot overlap */
+#mc-mahjong-page .mc-pattern-grid {
+  grid-template-columns: 1fr !important;
+}
+
+#mc-mahjong-page .mc-pattern {
+  min-height: 0 !important;
+  padding: 20px !important;
+}
+
+#mc-mahjong-page .mc-tile-strip {
+  display: grid !important;
+  grid-template-columns: repeat(7, minmax(0, 68px)) !important;
+  justify-content: start !important;
+  gap: 8px 7px !important;
+  width: 100% !important;
+  max-width: 560px !important;
+  margin: 0 0 15px !important;
+  overflow: visible !important;
+}
+
+#mc-mahjong-page .mc-tile-strip img {
+  width: 100% !important;
+  max-width: 68px !important;
+  min-width: 0 !important;
+  height: auto !important;
+  aspect-ratio: 86 / 112 !important;
+  object-fit: contain !important;
+}
+
+/* Remove nested section spacing from trainer inside regular tab */
+#mc-mahjong-page #mc-regular-panel > .mc-trainer-section,
+#mc-mahjong-page #mc-regular-panel > section {
+  padding: 0 !important;
+  border-top: 0 !important;
+}
+
+#mc-mahjong-page #mc-regular-panel .mc-section-head:first-child {
+  display: none;
+}
+
+@media (max-width: 980px) {
+  #mc-mahjong-page .mc-key-row,
+  #mc-mahjong-page .mc-group-examples,
+  #mc-mahjong-page .mc-glossary-grid,
+  #mc-mahjong-page .mc-regular-cues {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  #mc-mahjong-page .mc-beginner-shop {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  #mc-mahjong-page .mc-learning-tabs {
+    grid-template-columns: 1fr;
+  }
+
+  #mc-mahjong-page .mc-learning-tab {
+    border-right: 0;
+    border-bottom: 1px solid #d9d9d9;
+  }
+
+  #mc-mahjong-page .mc-learning-tab:last-child {
+    border-bottom: 0;
+  }
+
+  #mc-mahjong-page .mc-beginner-steps {
+    grid-template-columns: 1fr;
+  }
+
+  #mc-mahjong-page .mc-tile-strip {
+    grid-template-columns: repeat(7, minmax(0, 1fr)) !important;
+    max-width: 100% !important;
+    gap: 6px 4px !important;
+  }
+}
+
+@media (max-width: 560px) {
+  #mc-mahjong-page .mc-key-row,
+  #mc-mahjong-page .mc-group-examples,
+  #mc-mahjong-page .mc-glossary-grid,
+  #mc-mahjong-page .mc-regular-cues {
+    grid-template-columns: 1fr;
+  }
+
+  #mc-mahjong-page .mc-key-card {
+    padding: 20px;
+  }
+
+  #mc-mahjong-page .mc-key-tiles {
+    flex-wrap: wrap;
+    min-height: 0;
+  }
+
+  #mc-mahjong-page .mc-key-tile {
+    width: 58px;
+  }
+
+  #mc-mahjong-page .mc-key-tile img {
+    width: 58px;
+  }
+
+  #mc-mahjong-page .mc-beginner-step {
+    grid-template-columns: 34px 1fr;
+    padding: 20px;
+  }
+
+  #mc-mahjong-page .mc-regular-key-link {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  #mc-mahjong-page .mc-beginner-shop__actions {
+    flex-direction: column;
+  }
+
+  #mc-mahjong-page .mc-beginner-shop__actions .mc-btn {
+    width: 100%;
+  }
+}
+</style>
+<style id="mc-mahjong-v7-fixes">
+/* V7: restore always-visible trainer and tighten vertical spacing */
+#mc-mahjong-page .mc-section {
+  padding-top: 46px !important;
+  padding-bottom: 46px !important;
+}
+
+#mc-mahjong-page .mc-hero-shell {
+  padding-top: 14px !important;
+  padding-bottom: 20px !important;
+}
+
+#mc-mahjong-page .mc-section-head {
+  margin-bottom: 24px !important;
+}
+
+#mc-mahjong-page .mc-subsection {
+  margin-top: 34px !important;
+}
+
+#mc-mahjong-page .mc-learning-tabs {
+  margin-bottom: 24px !important;
+}
+
+#mc-mahjong-page .mc-key-card {
+  margin-bottom: 13px !important;
+  padding: 22px !important;
+}
+
+#mc-mahjong-page .mc-key-card > h3 {
+  margin-bottom: 17px !important;
+}
+
+#mc-mahjong-page .mc-beginner-shop {
+  margin-top: 36px !important;
+}
+
+#mc-mahjong-page .mc-teacher-copy {
+  padding-top: 30px !important;
+  padding-bottom: 30px !important;
+}
+
+/* Keep regular-player heading visible now that trainer is outside the tab */
+#mc-mahjong-page #mc-regular-panel > .mc-section-head:first-child {
+  display: block !important;
+}
+
+/* Always-visible trainer section */
+#mc-mahjong-page #mc-mahjong-trainer {
+  display: block !important;
+  background: #fff !important;
+}
+
+#mc-mahjong-page #mc-mahjong-trainer > .mc-wrap {
+  width: min(1080px, calc(100% - 40px)) !important;
+  margin-right: auto !important;
+  margin-left: auto !important;
+}
+
+#mc-mahjong-page .mc-regular-trainer-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  margin-top: 22px;
+  padding: 18px 20px;
+  border: 1px solid #e3e3e3;
+  background: #fff;
+}
+
+#mc-mahjong-page .mc-regular-trainer-link p {
+  margin-bottom: 0 !important;
+}
+
+#mc-mahjong-page .mc-trainer {
+  margin-top: 0 !important;
+}
+
+/* Tile images remain readable and cannot overlap */
+#mc-mahjong-page .mc-pattern-grid {
+  grid-template-columns: 1fr !important;
+}
+
+#mc-mahjong-page .mc-pattern {
+  min-height: 0 !important;
+  overflow: hidden !important;
+}
+
+#mc-mahjong-page .mc-tile-strip {
+  display: grid !important;
+  grid-template-columns: repeat(7, minmax(46px, 68px)) !important;
+  justify-content: start !important;
+  gap: 8px 7px !important;
+  width: 100% !important;
+  max-width: 560px !important;
+  overflow: visible !important;
+}
+
+#mc-mahjong-page .mc-tile-strip img {
+  display: block !important;
+  width: 100% !important;
+  min-width: 0 !important;
+  max-width: 68px !important;
+  height: auto !important;
+  margin: 0 !important;
+  object-fit: contain !important;
+}
+
+@media (max-width: 760px) {
+  #mc-mahjong-page .mc-section {
+    padding-top: 38px !important;
+    padding-bottom: 38px !important;
+  }
+
+  #mc-mahjong-page #mc-mahjong-trainer > .mc-wrap {
+    width: min(100% - 26px, 1080px) !important;
+  }
+
+  #mc-mahjong-page .mc-regular-trainer-link {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  #mc-mahjong-page .mc-tile-strip {
+    grid-template-columns: repeat(7, minmax(0, 1fr)) !important;
+    max-width: 100% !important;
+    gap: 6px 4px !important;
+  }
+}
+</style>
+<style id="mc-mahjong-live-trainer-v8">
+#mc-mahjong-page .mc-live-trainer{margin:0 0 34px;padding:28px;border:1px solid #ded8d0;background:#fff}
+#mc-mahjong-page .mc-live-trainer__head{display:flex;align-items:flex-start;justify-content:space-between;gap:24px;margin-bottom:20px}
+#mc-mahjong-page .mc-live-trainer__head h3,#mc-mahjong-page .mc-live-advisor__heading h3{margin:0!important;font-family:inherit!important;font-weight:400!important;letter-spacing:.055em!important;text-transform:uppercase!important;color:#2d2722!important}
+#mc-mahjong-page .mc-live-trainer__head h3{font-size:21px!important;line-height:1.25!important}
+#mc-mahjong-page .mc-live-trainer__head p{max-width:760px;margin:10px 0 0!important;font-size:13px!important;line-height:1.65!important;color:#62574e!important}
+#mc-mahjong-page .mc-live-trainer__count{flex:0 0 auto;padding:9px 12px;border:1px solid #d8d1c8;background:#f7f4ef;color:#62574e;font-size:10px;font-weight:700;line-height:1;letter-spacing:.13em}
+#mc-mahjong-page .mc-live-trainer__controls{display:flex;flex-wrap:wrap;gap:9px;margin-bottom:12px}
+#mc-mahjong-page .mc-live-trainer__controls button{min-height:42px;padding:0 18px;border:1px solid #111;border-radius:0;background:#111;color:#fff;font:600 11px/1 inherit;letter-spacing:.1em;text-transform:uppercase;cursor:pointer}
+#mc-mahjong-page .mc-live-trainer__controls button:nth-child(2),#mc-mahjong-page .mc-live-trainer__controls button:nth-child(3){background:#fff;color:#111}
+#mc-mahjong-page .mc-live-trainer__controls button:disabled{border-color:#d7d2cb;background:#eeeae5;color:#9b938b;cursor:not-allowed}
+#mc-mahjong-page .mc-live-trainer__status{min-height:21px;margin:0 0 14px!important;color:#554b43!important;font-size:12px!important;font-weight:600!important;line-height:1.55!important}
+#mc-mahjong-page .mc-live-rack{display:flex;align-items:flex-end;gap:5px;width:100%;min-height:104px;padding:15px 12px 11px;overflow-x:auto;border:1px solid #ddd7cf;background:#f7f4ef;scrollbar-width:thin}
+#mc-mahjong-page .mc-live-tile{position:relative;flex:0 0 58px;width:58px;padding:0;border:0;background:transparent;cursor:default;transition:transform .14s ease}
+#mc-mahjong-page .mc-live-rack.is-discarding .mc-live-tile{cursor:pointer}
+#mc-mahjong-page .mc-live-tile.is-selected{transform:translateY(-11px)}
+#mc-mahjong-page .mc-live-tile img{display:block!important;width:58px!important;height:auto!important;aspect-ratio:86/112;object-fit:contain!important;border:0!important;background:#fff;box-shadow:0 2px 8px rgba(46,38,31,.09)}
+#mc-mahjong-page .mc-live-tile.is-drawn::after{content:"DRAWN";position:absolute;right:2px;bottom:2px;padding:3px 4px;background:#111;color:#fff;font-size:7px;font-weight:700;line-height:1;letter-spacing:.08em}
+#mc-mahjong-page .mc-live-advisor{margin-top:24px;padding-top:22px;border-top:1px solid #ded8d0}
+#mc-mahjong-page .mc-live-advisor__heading{display:flex;justify-content:space-between;align-items:flex-end;gap:24px;margin-bottom:14px}
+#mc-mahjong-page .mc-live-advisor__heading h3{font-size:18px!important;line-height:1.25!important}
+#mc-mahjong-page .mc-live-advisor__heading>p{max-width:420px;margin:0!important;text-align:right;color:#5c5148!important;font-size:12px!important;font-weight:600!important;line-height:1.5!important}
+#mc-mahjong-page .mc-live-suggestions{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}
+#mc-mahjong-page .mc-live-suggestion{padding:16px;border:1px solid #ded8d0;background:#fff}
+#mc-mahjong-page .mc-live-suggestion__top{display:flex;justify-content:space-between;gap:12px;margin-bottom:8px}
+#mc-mahjong-page .mc-live-suggestion__top strong{color:#2d2722;font-size:12px;line-height:1.35;letter-spacing:.07em;text-transform:uppercase}
+#mc-mahjong-page .mc-live-suggestion__score{flex:0 0 auto;color:#766a5f;font-size:10px;font-weight:700;line-height:1.35;letter-spacing:.08em}
+#mc-mahjong-page .mc-live-suggestion p{margin:0 0 9px!important;color:#62574e!important;font-size:12px!important;line-height:1.55!important}
+#mc-mahjong-page .mc-live-missing-label{margin-bottom:6px;color:#7b7168;font-size:9px;font-weight:700;line-height:1.2;letter-spacing:.11em;text-transform:uppercase}
+#mc-mahjong-page .mc-live-missing{display:flex;flex-wrap:wrap;gap:4px}
+#mc-mahjong-page .mc-live-missing img{display:block!important;width:28px!important;height:auto!important;aspect-ratio:86/112;object-fit:contain!important;border:0!important}
+#mc-mahjong-page .mc-live-complete{color:#2d2722;font-size:11px;font-weight:700;line-height:1.5}
+#mc-mahjong-page .mc-live-trainer__disclaimer{margin:16px 0 0!important;color:#7b7168!important;font-size:10px!important;line-height:1.55!important}
+#mc-mahjong-page .mc-section-head--pattern-library{margin-top:38px!important}
+@media(max-width:900px){#mc-mahjong-page .mc-live-suggestions{grid-template-columns:1fr}#mc-mahjong-page .mc-live-advisor__heading{display:block}#mc-mahjong-page .mc-live-advisor__heading>p{margin-top:8px!important;text-align:left}}
+@media(max-width:560px){#mc-mahjong-page .mc-live-trainer{padding:18px 12px}#mc-mahjong-page .mc-live-trainer__head{display:block}#mc-mahjong-page .mc-live-trainer__count{display:inline-block;margin-top:12px}#mc-mahjong-page .mc-live-trainer__controls{display:grid;grid-template-columns:1fr}#mc-mahjong-page .mc-live-trainer__controls button{width:100%}#mc-mahjong-page .mc-live-rack{padding-left:8px;padding-right:8px}#mc-mahjong-page .mc-live-tile,#mc-mahjong-page .mc-live-tile img{width:49px!important;flex-basis:49px}}
+</style>
+
+
+<style id="mc-mahjong-no-random-photo-fix-v12">
+/* V12: remove random lifestyle photos and use clean Mahjong tile/product visuals only. */
+#mc-mahjong-page .mc-teacher-tile-panel,
+#mc-mahjong-page .mc-practical-card {
+  background: #f7f7f5 !important;
+  border: 1px solid #e5e5e2 !important;
+  box-shadow: none !important;
+}
+#mc-mahjong-page .mc-teacher-tile-panel {
+  min-height: 100% !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  padding: 34px 24px !important;
+}
+#mc-mahjong-page .mc-teacher-tile-inner {
+  width: 100% !important;
+  max-width: 360px !important;
+  text-align: center !important;
+}
+#mc-mahjong-page .mc-practical-grid {
+  display: grid !important;
+  grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+  gap: 18px !important;
+}
+#mc-mahjong-page .mc-practical-card {
+  padding: 28px !important;
+  min-height: 230px !important;
+}
+#mc-mahjong-page .mc-mini-tile-strip,
+#mc-mahjong-page .mc-teacher-tile-strip {
+  display: flex !important;
+  flex-wrap: wrap !important;
+  gap: 6px !important;
+  margin-bottom: 18px !important;
+  align-items: center !important;
+}
+#mc-mahjong-page .mc-teacher-tile-strip {
+  justify-content: center !important;
+  margin-bottom: 22px !important;
+}
+#mc-mahjong-page .mc-mini-tile-strip img,
+#mc-mahjong-page .mc-teacher-tile-strip img {
+  width: 42px !important;
+  height: auto !important;
+  display: block !important;
+  border: 0 !important;
+  outline: 0 !important;
+  box-shadow: none !important;
+  clip-path: inset(8% 8% 8% 8% round 7%) !important;
+}
+#mc-mahjong-page .mc-teacher-tile-strip img {
+  width: 54px !important;
+}
+#mc-mahjong-page .mc-practical-card h3,
+#mc-mahjong-page .mc-teacher-tile-inner h3 {
+  margin: 0 0 8px !important;
+  color: #111 !important;
+  font-size: 15px !important;
+  letter-spacing: .08em !important;
+  text-transform: uppercase !important;
+}
+#mc-mahjong-page .mc-practical-card p,
+#mc-mahjong-page .mc-teacher-tile-inner p {
+  margin: 0 !important;
+  color: #555 !important;
+  font-size: 13px !important;
+  line-height: 1.65 !important;
+}
+@media (max-width: 900px) {
+  #mc-mahjong-page .mc-practical-grid { grid-template-columns: 1fr !important; }
+  #mc-mahjong-page .mc-teacher-tile-panel { min-height: 260px !important; }
+}
+</style>
+<style id="mc-mahjong-final-layout-fixes">
+#mc-mahjong-page .mc-top-category-tabs{display:flex;align-items:stretch;justify-content:center;width:min(1080px,calc(100% - 40px));margin:14px auto 0;border:1px solid #dedede;background:#fff;overflow-x:auto;scrollbar-width:none}
+#mc-mahjong-page .mc-top-category-tabs::-webkit-scrollbar{display:none}
+#mc-mahjong-page .mc-top-category-tabs a{flex:1 0 auto;min-width:150px;padding:14px 18px;border-right:1px solid #dedede;color:#383838!important;font-size:11px!important;font-weight:500!important;line-height:1.25!important;letter-spacing:.12em!important;text-align:center;text-decoration:none!important;text-transform:uppercase;white-space:nowrap}
+#mc-mahjong-page .mc-top-category-tabs a:last-child{border-right:0}
+#mc-mahjong-page .mc-top-category-tabs a[aria-current="page"]{background:#1a1a1a;color:#fff!important}
+#mc-mahjong-page .mc-hero-shell{padding-top:18px!important;padding-bottom:22px!important}
+#mc-mahjong-page #mc-shop-categories{padding-top:34px!important;padding-bottom:36px!important}
+#mc-mahjong-page #mc-mahjong-trainer{padding-top:30px!important;padding-bottom:38px!important}
+#mc-mahjong-page #mc-mahjong-trainer .mc-section-head{margin-bottom:18px!important}
+#mc-mahjong-page #mc-mahjong-trainer .mc-live-trainer{margin-top:0!important}
+@media(max-width:760px){
+  #mc-mahjong-page{font-size:12px!important;line-height:1.55!important}
+  #mc-mahjong-page .mc-wrap{width:calc(100% - 26px)!important}
+  #mc-mahjong-page .mc-top-category-tabs{justify-content:flex-start;width:calc(100% - 26px);margin-top:10px}
+  #mc-mahjong-page .mc-top-category-tabs a{min-width:124px;padding:12px 13px;font-size:9px!important;letter-spacing:.09em!important}
+  #mc-mahjong-page h1{font-size:clamp(21px,7vw,25px)!important;line-height:1.2!important;letter-spacing:.055em!important;overflow-wrap:normal!important;word-break:normal!important}
+  #mc-mahjong-page h2{font-size:clamp(18px,5.7vw,21px)!important;line-height:1.25!important;letter-spacing:.055em!important;overflow-wrap:normal!important;word-break:normal!important}
+  #mc-mahjong-page h3{font-size:10px!important;line-height:1.35!important;letter-spacing:.11em!important}
+  #mc-mahjong-page .mc-lead,#mc-mahjong-page p{font-size:12px!important;line-height:1.58!important}
+  #mc-mahjong-page .mc-hero{grid-template-columns:1fr!important;min-height:0!important}
+  #mc-mahjong-page .mc-hero-media{height:260px!important;min-height:0!important;order:-1!important}
+  #mc-mahjong-page .mc-hero-copy{padding:24px 3px 8px!important}
+  #mc-mahjong-page .mc-hero-actions{gap:8px!important}
+  #mc-mahjong-page .mc-btn{min-height:41px!important;padding:0 15px!important;font-size:9px!important;letter-spacing:.1em!important}
+  #mc-mahjong-page .mc-section{padding-top:36px!important;padding-bottom:36px!important}
+  #mc-mahjong-page #mc-shop-categories{padding-top:28px!important;padding-bottom:30px!important}
+  #mc-mahjong-page #mc-mahjong-trainer{padding-top:22px!important;padding-bottom:30px!important}
+  #mc-mahjong-page .mc-section-head{margin-bottom:20px!important}
+}
+@media(max-width:420px){
+  #mc-mahjong-page h1{font-size:21px!important;letter-spacing:.04em!important}
+  #mc-mahjong-page h2{font-size:18px!important;letter-spacing:.04em!important}
+  #mc-mahjong-page .mc-hero-media{height:225px!important}
+}
+</style>
+<style id="mc-mahjong-trainer-top-placement">
+/* Final placement: trainer directly below the Mahjong hero */
+#mc-mahjong-page #mc-mahjong-trainer {
+  margin-top: 0 !important;
+  padding-top: 24px !important;
+  padding-bottom: 42px !important;
+}
+#mc-mahjong-page .mc-hero-shell {
+  margin-bottom: 0 !important;
+  padding-bottom: 0 !important;
+}
+@media (max-width: 760px) {
+  #mc-mahjong-page #mc-mahjong-trainer {
+    padding-top: 18px !important;
+    padding-bottom: 32px !important;
+  }
+}
+</style><div data-mc-mahjong-version="v12-no-random-photos" id="mc-mahjong-page">
+<nav aria-label="Mahjong categories" class="mc-top-category-tabs">
+<a aria-current="page" href="https://www.mccabestheaterandliving.com/category-s/201.htm">Mahjong</a>
+<a href="https://www.mccabestheaterandliving.com/category-s/202.htm">Tile Sets</a>
+<a href="https://www.mccabestheaterandliving.com/category-s/203.htm">Mats &amp; Racks</a>
+<a href="https://www.mccabestheaterandliving.com/category-s/204.htm">Accessories</a>
+</nav>
+<section class="mc-hero-shell">
+<div class="mc-wrap">
+<div class="mc-hero">
+<div class="mc-hero-copy">
+<p class="mc-eyebrow">Mahjong</p>
+<h1>Tile Sets, Mats, Racks &amp; More</h1>
+<p class="mc-lead">Shop a complete Mahjong setup for home or travel, then use the guides and interactive tools below to compare what you need and get more from every game.</p>
+<div class="mc-hero-actions">
+<a class="mc-btn" href="https://www.mccabestheaterandliving.com/category-s/202.htm">Shop tile sets</a>
+<a class="mc-btn mc-btn--outline" href="#mc-shop-categories">Browse categories</a>
+</div>
+</div>
+<div class="mc-hero-media">
+<img alt="Four women playing Mahjong together in a bright room" class="mc-mahjong-landing-image" data-mc-landing-src="/v/vspfiles/mahjong/hero-community.jpg" decoding="async" loading="eager" src="/v/vspfiles/mahjong/hero-community.jpg" style="background-image:url('/v/vspfiles/mahjong/hero-community.jpg');background-size:cover;background-position:center;background-repeat:no-repeat"/>
+</div>
+</div>
+</div>
+</section><section class="mc-section" id="mc-mahjong-trainer"><div class="mc-wrap">
+<div class="mc-section-head">
+<p class="mc-eyebrow">Interactive practice</p>
+<h2>Draw, Analyze &amp; Discard</h2>
+<p class="mc-lead">Deal a 13-tile rack, draw a 14th tile, select a discard, and compare the closest original practice directions. Use the visual combination library below for more focused study.</p>
+</div>
+<div class="mc-live-trainer" id="mc-live-trainer">
+<div class="mc-live-trainer__head">
+<div>
+<p class="mc-eyebrow">Live hand practice</p>
+<h3>Practice A Real 13-Tile Rack</h3>
+<p>The trainer deals 13 tiles, updates its suggested practice directions after every draw, and lets you select and discard one tile to return to 13.</p>
+</div>
+<div aria-live="polite" class="mc-live-trainer__count" id="mc-live-count">13 TILES</div>
+</div>
+<div class="mc-live-trainer__controls">
+<button id="mc-live-auto-deal" type="button">Auto deal 13 tiles</button>
+<button id="mc-live-draw" type="button">Draw tile</button>
+<button disabled="" id="mc-live-discard" type="button">Discard selected</button>
+</div>
+<p aria-live="polite" class="mc-live-trainer__status" id="mc-live-status"></p>
+<div aria-label="Your Mahjong rack" class="mc-live-rack" id="mc-live-rack"></div>
+<div class="mc-live-advisor">
+<div class="mc-live-advisor__heading">
+<div>
+<p class="mc-eyebrow">Live hand advisor</p>
+<h3>Suggested Pattern Directions</h3>
+</div>
+<p id="mc-live-discard-advice">Draw one tile to receive a discard recommendation.</p>
+</div>
+<div class="mc-live-suggestions" id="mc-live-suggestions"></div>
+</div>
+<p class="mc-live-trainer__disclaimer">The suggestions are original pattern-recognition exercises. They do not reproduce an official National Mah Jongg League card or replace the current card used at your table.</p>
+</div>
+<div class="mc-section-head mc-section-head--pattern-library">
+<p class="mc-eyebrow">Visual combination library</p>
+<h2>Filter Practice Patterns</h2>
+<p class="mc-lead">Choose a focus, number of suits, and skill level. Every combination is shown with actual tile images.</p>
+</div>
+<div class="mc-trainer">
+<div class="mc-trainer-controls">
+<div class="mc-field">
+<label for="mc-strength">Pattern focus</label>
+<select id="mc-strength">
+<option value="any">Show all focuses</option>
+<option value="pairs">Pairs</option>
+<option value="runs">Runs &amp; sequences</option>
+<option value="repeats">Repeated numbers</option>
+<option value="honors">Winds &amp; dragons</option>
+<option value="flowers">Flowers</option>
+</select>
+</div>
+<div class="mc-field">
+<label for="mc-suits">Number of suits</label>
+<select id="mc-suits">
+<option value="any">Any number of suits</option>
+<option value="1">One suit</option>
+<option value="2">Two suits</option>
+<option value="3">Three suits</option>
+</select>
+</div>
+<div class="mc-field">
+<label for="mc-level">Practice level</label>
+<select id="mc-level">
+<option value="any">Any level</option>
+<option value="beginner">Beginner</option>
+<option value="intermediate">Intermediate</option>
+<option value="advanced">Advanced</option>
+</select>
+</div>
+<button class="mc-btn" id="mc-find-patterns" type="button">Find combinations</button>
+<p class="mc-trainer-stat"><strong id="mc-pattern-total">24</strong> original practice combinations included.</p>
+</div>
+<div class="mc-trainer-results">
+<div class="mc-results-head">
+<div>
+<p class="mc-eyebrow">Visual examples</p>
+<h3 id="mc-results-title">Showing Recommended Combinations</h3>
+</div>
+<p class="mc-disclaimer">These are original teaching examples, not official card hands. Use the current card selected by your group during actual play.</p>
+</div>
+<div class="mc-pattern-grid" id="mc-pattern-grid"></div>
+<div class="mc-more-wrap" id="mc-more-wrap">
+<button class="mc-btn mc-btn--outline" id="mc-show-more" type="button">Show more combinations</button>
+</div>
+</div>
+</div>
+</div></section>
+<section class="mc-section" id="mc-shop-categories">
+<div class="mc-wrap">
+<div class="mc-section-head">
+<p class="mc-eyebrow">Shop by category</p>
+<h2>Find The Right Mahjong Setup</h2>
+<p class="mc-lead">Choose the pieces you need now, then add coordinating mats, racks, storage, and travel options when you are ready.</p>
+</div>
+<div class="mc-shop-grid">
+<a class="mc-shop-card" href="https://www.mccabestheaterandliving.com/category-s/202.htm">
+<div class="mc-shop-card__image">
+<img alt="Classic American Mahjong tile set" class="mc-mahjong-landing-image" data-mc-landing-src="/v/vspfiles/mahjong/category-tiles.jpg" decoding="async" loading="eager" src="/v/vspfiles/mahjong/category-tiles.jpg" style="background-image:url('/v/vspfiles/mahjong/category-tiles.jpg');background-size:cover;background-position:center;background-repeat:no-repeat"/>
+</div>
+<h3>Full-Size Tile Sets</h3>
+<p>Substantial everyday sets for regular home games and weekly groups.</p>
+<span class="mc-text-link">Shop tile sets</span>
+</a>
+<a class="mc-shop-card" href="https://www.mccabestheaterandliving.com/SearchResults.asp?Search=travel+mahjong+tiles">
+<div class="mc-shop-card__image">
+<img alt="Pink travel Mahjong tiles" class="mc-mahjong-landing-image" data-mc-landing-src="/v/vspfiles/mahjong/category-travel.jpg" decoding="async" loading="eager" src="/v/vspfiles/mahjong/category-travel.jpg" style="background-image:url('/v/vspfiles/mahjong/category-travel.jpg');background-size:cover;background-position:center;background-repeat:no-repeat"/>
+</div>
+<h3>Travel Tile Sets</h3>
+<p>Thinner, lighter sets made for trips, smaller spaces, and portable game nights.</p>
+<span class="mc-text-link">Shop travel sets</span>
+</a>
+<a class="mc-shop-card" href="https://www.mccabestheaterandliving.com/category-s/203.htm">
+<div class="mc-shop-card__image mc-shop-card__image--split">
+<img alt="Colorful reversible Mahjong mat" class="mc-mahjong-landing-image" data-mc-landing-src="/v/vspfiles/mahjong/category-mat.jpg" decoding="async" loading="eager" src="/v/vspfiles/mahjong/category-mat.jpg" style="background-image:url('/v/vspfiles/mahjong/category-mat.jpg');background-size:cover;background-position:center;background-repeat:no-repeat"/>
+<img alt="Clear acrylic Mahjong racks" class="mc-mahjong-landing-image" data-mc-landing-src="/v/vspfiles/mahjong/category-racks.jpg" decoding="async" loading="eager" src="/v/vspfiles/mahjong/category-racks.jpg" style="background-image:url('/v/vspfiles/mahjong/category-racks.jpg');background-size:cover;background-position:center;background-repeat:no-repeat"/>
+</div>
+<h3>Mats &amp; Racks</h3>
+<p>Protect the table, soften tile noise, and give every player a clean place to organize.</p>
+<span class="mc-text-link">Shop mats &amp; racks</span>
+</a>
+<a class="mc-shop-card" href="https://www.mccabestheaterandliving.com/category-s/204.htm">
+<div class="mc-shop-card__image">
+<img alt="Mahjong tile storage box" class="mc-mahjong-landing-image" data-mc-landing-src="/v/vspfiles/mahjong/category-accessories.jpg" decoding="async" loading="eager" src="/v/vspfiles/mahjong/category-accessories.jpg" style="background-image:url('/v/vspfiles/mahjong/category-accessories.jpg');background-size:cover;background-position:center;background-repeat:no-repeat"/>
+</div>
+<h3>Storage &amp; Accessories</h3>
+<p>Carrying pieces, storage, scorekeeping tools, and useful table extras.</p>
+<span class="mc-text-link">Shop accessories</span>
+</a>
+</div>
+</div>
+</section>
+<section class="mc-section">
+<div class="mc-wrap">
+<div class="mc-section-head">
+<p class="mc-eyebrow">A simple buying guide</p>
+<h2>Build A Complete Table</h2>
+</div>
+<div class="mc-buy-grid">
+<article class="mc-buy-card">
+<span class="mc-buy-card__number">01</span>
+<h3>Start With The Tiles</h3>
+<p>Choose full-size tiles for regular home play or travel tiles when portability matters most.</p>
+<a class="mc-text-link" href="https://www.mccabestheaterandliving.com/category-s/202.htm">Compare tile sets</a>
+</article>
+<article class="mc-buy-card">
+<span class="mc-buy-card__number">02</span>
+<h3>Add A Mat &amp; Racks</h3>
+<p>A mat reduces noise and protects the surface. Racks make every hand easier to read and manage.</p>
+<a class="mc-text-link" href="https://www.mccabestheaterandliving.com/category-s/203.htm">Shop table pieces</a>
+</article>
+<article class="mc-buy-card">
+<span class="mc-buy-card__number">03</span>
+<h3>Finish With Storage</h3>
+<p>Keep tiles and accessories together so setting up the next game takes minutes instead of a scavenger hunt.</p>
+<a class="mc-text-link" href="https://www.mccabestheaterandliving.com/category-s/204.htm">Shop storage</a>
+</article>
+</div>
+</div>
+</section>
+<section class="mc-section mc-learning-section" id="mc-learning-paths">
+<div class="mc-wrap">
+<div class="mc-section-head">
+<p class="mc-eyebrow">Choose your experience level</p>
+<h2>Learn At The Level That Fits You</h2>
+<p class="mc-lead">New players get the true ABCs and 123s. Regular players can skip straight to visual combinations and strategy filters.</p>
+</div>
+<div aria-label="Mahjong experience level" class="mc-learning-tabs" role="tablist">
+<button aria-controls="mc-beginner-panel" aria-selected="true" class="mc-learning-tab is-active" data-learning-tab="beginner" id="mc-beginner-tab" role="tab" type="button">
+          I’m New To Mahjong
+        </button>
+<button aria-controls="mc-regular-panel" aria-selected="false" class="mc-learning-tab" data-learning-tab="regular" id="mc-regular-tab" role="tab" type="button">
+          I’m A Regular Player
+        </button>
+</div>
+<div aria-labelledby="mc-beginner-tab" class="mc-learning-panel is-active" data-learning-panel="beginner" id="mc-beginner-panel" role="tabpanel">
+<div class="mc-section-head mc-section-head--left">
+<p class="mc-eyebrow">Start here</p>
+<h2>Mahjong ABCs &amp; 123s</h2>
+<p class="mc-lead">This is the no-assumed-knowledge version: what the tiles are, what the words mean, and what actually happens during a game.</p>
+</div>
+<div class="mc-key-card">
+<h3>The Three Numbered Suits</h3>
+<div class="mc-key-row">
+<div class="mc-key-group">
+<div class="mc-key-tiles">
+<figure class="mc-key-tile"><img alt="1 Dot" src="/v/vspfiles/mahjong/tiles/tile-d1.png"/><figcaption>1 Dot</figcaption></figure>
+<figure class="mc-key-tile"><img alt="5 Dot" src="/v/vspfiles/mahjong/tiles/tile-d5.png"/><figcaption>5 Dot</figcaption></figure>
+<figure class="mc-key-tile"><img alt="9 Dot" src="/v/vspfiles/mahjong/tiles/tile-d9.png"/><figcaption>9 Dot</figcaption></figure>
+</div>
+<p><strong>Dots</strong>, also called circles, are numbered 1 through 9.</p>
+</div>
+<div class="mc-key-group">
+<div class="mc-key-tiles">
+<figure class="mc-key-tile"><img alt="1 Bam" src="/v/vspfiles/mahjong/tiles/tile-b1.png"/><figcaption>1 Bam</figcaption></figure>
+<figure class="mc-key-tile"><img alt="5 Bam" src="/v/vspfiles/mahjong/tiles/tile-b5.png"/><figcaption>5 Bam</figcaption></figure>
+<figure class="mc-key-tile"><img alt="9 Bam" src="/v/vspfiles/mahjong/tiles/tile-b9.png"/><figcaption>9 Bam</figcaption></figure>
+</div>
+<p><strong>Bam</strong> tiles, short for bamboo, are numbered 1 through 9.</p>
+</div>
+<div class="mc-key-group">
+<div class="mc-key-tiles">
+<figure class="mc-key-tile"><img alt="1 Crak" src="/v/vspfiles/mahjong/tiles/tile-c1.png"/><figcaption>1 Crak</figcaption></figure>
+<figure class="mc-key-tile"><img alt="5 Crak" src="/v/vspfiles/mahjong/tiles/tile-c5.png"/><figcaption>5 Crak</figcaption></figure>
+<figure class="mc-key-tile"><img alt="9 Crak" src="/v/vspfiles/mahjong/tiles/tile-c9.png"/><figcaption>9 Crak</figcaption></figure>
+</div>
+<p><strong>Crak</strong> tiles, short for characters, are numbered 1 through 9.</p>
+</div>
+</div>
+</div>
+<div class="mc-key-card">
+<h3>Winds, Dragons, Flowers &amp; Jokers</h3>
+<div class="mc-key-row mc-key-row--special">
+<div class="mc-key-group">
+<div class="mc-key-tiles">
+<figure class="mc-key-tile"><img alt="East Wind" src="/v/vspfiles/mahjong/tiles/tile-east.png"/><figcaption>East Wind</figcaption></figure>
+<figure class="mc-key-tile"><img alt="South Wind" src="/v/vspfiles/mahjong/tiles/tile-south.png"/><figcaption>South Wind</figcaption></figure>
+<figure class="mc-key-tile"><img alt="West Wind" src="/v/vspfiles/mahjong/tiles/tile-west.png"/><figcaption>West Wind</figcaption></figure>
+<figure class="mc-key-tile"><img alt="North Wind" src="/v/vspfiles/mahjong/tiles/tile-north.png"/><figcaption>North Wind</figcaption></figure>
+</div>
+<p><strong>Winds</strong> are East, South, West, and North. They are not numbered suits.</p>
+</div>
+<div class="mc-key-group">
+<div class="mc-key-tiles">
+<figure class="mc-key-tile"><img alt="Red Dragon" src="/v/vspfiles/mahjong/tiles/tile-red.png"/><figcaption>Red Dragon</figcaption></figure>
+<figure class="mc-key-tile"><img alt="Green Dragon" src="/v/vspfiles/mahjong/tiles/tile-green.png"/><figcaption>Green Dragon</figcaption></figure>
+<figure class="mc-key-tile"><img alt="White Dragon" src="/v/vspfiles/mahjong/tiles/tile-white.png"/><figcaption>White Dragon</figcaption></figure>
+</div>
+<p><strong>Dragons</strong> are red, green, and white. The white dragon is often called “soap.”</p>
+</div>
+<div class="mc-key-group">
+<div class="mc-key-tiles">
+<figure class="mc-key-tile"><img alt="Flower" src="/v/vspfiles/mahjong/tiles/tile-flower-1.png?v=20260717flowers8"/><figcaption>Flower</figcaption></figure>
+<figure class="mc-key-tile"><img alt="Joker" src="/v/vspfiles/mahjong/tiles/tile-joker.png"/><figcaption>Joker</figcaption></figure>
+</div>
+<p><strong>Flowers</strong> are special tiles. <strong>Jokers</strong> may substitute in certain groups, but not singles or pairs.</p>
+</div>
+</div>
+</div>
+<div class="mc-subsection">
+<div class="mc-section-head mc-section-head--left">
+<p class="mc-eyebrow">How groups are named</p>
+<h2>Pair, Pung, Kong &amp; Quint</h2>
+</div>
+<div class="mc-group-examples">
+<article class="mc-group-example">
+<span class="mc-step-label">Pair</span>
+<div aria-label="Pair of 5 Dot" class="mc-example-tiles"><img alt="Pair of 5 Dot" src="/v/vspfiles/mahjong/tiles/tile-d5.png"/><img alt="Pair of 5 Dot" src="/v/vspfiles/mahjong/tiles/tile-d5.png"/></div>
+<p>Two identical tiles.</p>
+</article>
+<article class="mc-group-example">
+<span class="mc-step-label">Pung</span>
+<div aria-label="Pung of 3 Bam" class="mc-example-tiles"><img alt="Pung of 3 Bam" src="/v/vspfiles/mahjong/tiles/tile-b3.png"/><img alt="Pung of 3 Bam" src="/v/vspfiles/mahjong/tiles/tile-b3.png"/><img alt="Pung of 3 Bam" src="/v/vspfiles/mahjong/tiles/tile-b3.png"/></div>
+<p>Three identical tiles.</p>
+</article>
+<article class="mc-group-example">
+<span class="mc-step-label">Kong</span>
+<div aria-label="Kong of 7 Crak" class="mc-example-tiles"><img alt="Kong of 7 Crak" src="/v/vspfiles/mahjong/tiles/tile-c7.png"/><img alt="Kong of 7 Crak" src="/v/vspfiles/mahjong/tiles/tile-c7.png"/><img alt="Kong of 7 Crak" src="/v/vspfiles/mahjong/tiles/tile-c7.png"/><img alt="Kong of 7 Crak" src="/v/vspfiles/mahjong/tiles/tile-c7.png"/></div>
+<p>Four identical tiles.</p>
+</article>
+<article class="mc-group-example">
+<span class="mc-step-label">Quint</span>
+<div aria-label="Quint of 8 Dot with a Joker" class="mc-example-tiles"><img alt="Quint of 8 Dot with a Joker" src="/v/vspfiles/mahjong/tiles/tile-d8.png"/><img alt="Quint of 8 Dot with a Joker" src="/v/vspfiles/mahjong/tiles/tile-d8.png"/><img alt="Quint of 8 Dot with a Joker" src="/v/vspfiles/mahjong/tiles/tile-d8.png"/><img alt="Quint of 8 Dot with a Joker" src="/v/vspfiles/mahjong/tiles/tile-d8.png"/><img alt="Quint of 8 Dot with a Joker" src="/v/vspfiles/mahjong/tiles/tile-joker.png"/></div>
+<p>Five identical tiles. A joker is normally needed because only four natural copies exist.</p>
+</article>
+</div>
+</div>
+<div class="mc-subsection">
+<div class="mc-section-head mc-section-head--left">
+<p class="mc-eyebrow">A game from start to finish</p>
+<h2>Six Simple Steps</h2>
+</div>
+<div class="mc-beginner-steps">
+<article class="mc-beginner-step">
+<span>01</span>
+<div>
+<h3>Learn The Tile Families</h3>
+<p>First separate Dot, Bam, and Crak tiles from winds, dragons, flowers, and jokers. You do not need to memorize winning hands yet.</p>
+</div>
+</article>
+<article class="mc-beginner-step">
+<span>02</span>
+<div>
+<h3>Sort Your Rack</h3>
+<p>Place each suit in number order. Keep pairs and repeated numbers together so possible directions are easier to see.</p>
+</div>
+</article>
+<article class="mc-beginner-step">
+<span>03</span>
+<div>
+<h3>Use The Card Like A Recipe</h3>
+<p>The current American Mahjong card lists the exact combinations that can win. Pick a line your rack is naturally moving toward instead of forcing one immediately.</p>
+</div>
+</article>
+<article class="mc-beginner-step">
+<span>04</span>
+<div>
+<h3>Pass During The Charleston</h3>
+<p>Before normal play, players pass groups of three unwanted tiles according to the table’s Charleston sequence. Protect useful pairs and connected groups.</p>
+</div>
+</article>
+<article class="mc-beginner-step">
+<span>05</span>
+<div>
+<h3>Draw One, Discard One</h3>
+<p>On a normal turn, draw a tile, decide whether it helps, and discard one tile. Watch what other players discard and expose.</p>
+</div>
+</article>
+<article class="mc-beginner-step">
+<span>06</span>
+<div>
+<h3>Match One Line Exactly</h3>
+<p>A winning hand contains 14 tiles arranged exactly like one line on the card being used. When complete, call “Mahjong.”</p>
+</div>
+</article>
+</div>
+</div>
+<div class="mc-subsection">
+<div class="mc-section-head mc-section-head--left">
+<p class="mc-eyebrow">Common words at the table</p>
+<h2>Mahjong Terms In Plain English</h2>
+</div>
+<div class="mc-glossary-grid">
+<article><h3>Rack</h3><p>The holder that keeps your tiles standing and organized.</p></article>
+<article><h3>Wall</h3><p>The stacked rows of face-down tiles players draw from.</p></article>
+<article><h3>Charleston</h3><p>The opening exchange in which players pass groups of three tiles before normal turns begin.</p></article>
+<article><h3>Exposure</h3><p>A completed group placed face-up after calling another player’s discard.</p></article>
+<article><h3>Concealed</h3><p>A hand played without calling discards for exposures, except when allowed to claim the winning tile.</p></article>
+<article><h3>Joker Swap</h3><p>Replacing a joker in an exposed group with the exact natural tile it represents.</p></article>
+<article><h3>Call</h3><p>Taking another player’s discard because it completes a legal exposed group or wins the hand.</p></article>
+<article><h3>Mahjong</h3><p>The declaration made when your tiles exactly complete a winning hand on the card being used.</p></article>
+</div>
+</div>
+<div class="mc-beginner-shop">
+<div>
+<p class="mc-eyebrow">Ready to build a starter setup?</p>
+<h2>Begin With Tiles, Racks And A Mat</h2>
+<p>A beginner does not need every accessory on day one. Start with the pieces that make the game playable and comfortable.</p>
+</div>
+<div class="mc-beginner-shop__actions">
+<a class="mc-btn" href="https://www.mccabestheaterandliving.com/category-s/202.htm">Shop tile sets</a>
+<a class="mc-btn mc-btn--outline" href="https://www.mccabestheaterandliving.com/category-s/203.htm">Shop mats &amp; racks</a>
+<a class="mc-btn mc-btn--outline" href="#mc-mahjong-trainer">Practice with tile trainer</a></div>
+</div>
+</div>
+<div aria-labelledby="mc-regular-tab" class="mc-learning-panel" data-learning-panel="regular" hidden="" id="mc-regular-panel" role="tabpanel">
+<div class="mc-section-head mc-section-head--left">
+<p class="mc-eyebrow">For experienced players</p>
+<h2>Pattern Recognition &amp; Strategy</h2>
+<p class="mc-lead">Skip the basic vocabulary and work directly with suit structure, repeated numbers, honors, flowers, difficulty, and defensive judgment.</p>
+</div>
+<div class="mc-regular-cues">
+<article><h3>Stay Flexible Longer</h3><p>Compare at least two plausible card lines until the Charleston and early discards clarify the stronger route.</p></article>
+<article><h3>Read Availability</h3><p>Track discards and exposures before committing to a tile that may already be dead or dangerous.</p></article>
+<article><h3>Protect Joker Value</h3><p>Use jokers where they preserve the most structure, and watch exposed groups for possible swaps.</p></article>
+<article><h3>Shift To Defense</h3><p>When your hand stalls, stop feeding likely hands and prioritize safe discards over wishful drawing.</p></article>
+</div>
+<div class="mc-regular-key-link">
+<p>Need a quick tile or terminology refresher?</p>
+<button class="mc-text-button" data-switch-to-beginner="" type="button">Open the beginner key</button>
+</div>
+<div class="mc-regular-trainer-link"><p>Use the filters below to work through all 24 visual combinations.</p><a class="mc-btn" href="#mc-mahjong-trainer">Open interactive trainer</a></div></div>
+</div>
+</section>
+<section class="mc-section" id="mc-teacher-locator">
+<div class="mc-wrap">
+<div class="mc-teacher-locator">
+<div class="mc-teacher-copy">
+<p class="mc-eyebrow">Find local instruction</p>
+<h2>Mahjong Teacher Locator</h2>
+<p class="mc-lead">Enter a city, state, or ZIP code to search for American Mahjong teachers and lessons nearby.</p>
+<form class="mc-teacher-form" id="mc-teacher-form">
+<input aria-label="City, state, or ZIP code" autocomplete="postal-code" id="mc-teacher-location" inputmode="search" placeholder="City, state, or ZIP code" required="" type="text"/>
+<button class="mc-btn" type="submit">Find teachers</button>
+</form>
+<p hidden="" id="mc-teacher-error" role="alert">Please enter a city, state, or ZIP code.</p>
+<div class="mc-teacher-links">
+<a class="mc-text-link" href="https://mahjongcompare.com/teachers" rel="noopener" target="_blank">Browse teacher directory</a>
+<a class="mc-text-link" href="https://meetformahjong.com/" rel="noopener" target="_blank">Find players &amp; instructors</a>
+</div>
+</div>
+<div class="mc-teacher-image mc-teacher-tile-panel">
+<div class="mc-teacher-tile-inner">
+<div aria-label="Mahjong tile examples" class="mc-teacher-tile-strip">
+<img alt="1 Dot" decoding="async" loading="eager" src="/v/vspfiles/mahjong/tiles/tile-d1.png"/>
+<img alt="5 Bam" decoding="async" loading="eager" src="/v/vspfiles/mahjong/tiles/tile-b5.png"/>
+<img alt="East Wind" decoding="async" loading="eager" src="/v/vspfiles/mahjong/tiles/tile-east.png"/>
+<img alt="Red Dragon" decoding="async" loading="eager" src="/v/vspfiles/mahjong/tiles/tile-red.png"/>
+<img alt="Joker" decoding="async" loading="eager" src="/v/vspfiles/mahjong/tiles/tile-joker.png"/>
+</div>
+<h3>Learn With The Tiles</h3>
+<p>Keep the page focused on Mahjong pieces, patterns, and practical play instead of random stock photos.</p>
+</div>
+</div>
+</div>
+</div>
+</section>
+<section class="mc-section">
+<div class="mc-wrap">
+<div class="mc-section-head">
+<p class="mc-eyebrow">Better game nights</p>
+<h2>Practical Mahjong Details</h2>
+<p class="mc-lead">No candy photos, no random stock people. Just tile-focused tips that support the shopping and learning sections.</p>
+</div>
+<div class="mc-practical-grid">
+<article class="mc-practical-card">
+<div aria-label="Rack and tile spacing examples" class="mc-mini-tile-strip">
+<img alt="2 Dot" decoding="async" loading="eager" src="/v/vspfiles/mahjong/tiles/tile-d2.png"/>
+<img alt="3 Dot" decoding="async" loading="eager" src="/v/vspfiles/mahjong/tiles/tile-d3.png"/>
+<img alt="4 Dot" decoding="async" loading="eager" src="/v/vspfiles/mahjong/tiles/tile-d4.png"/>
+</div>
+<h3>Allow Enough Table Space</h3>
+<p>Every player needs room for a rack, card, drink, and comfortable tile movement.</p>
+</article>
+<article class="mc-practical-card">
+<div aria-label="Dragon tile examples" class="mc-mini-tile-strip">
+<img alt="Red Dragon" decoding="async" loading="eager" src="/v/vspfiles/mahjong/tiles/tile-red.png"/>
+<img alt="Green Dragon" decoding="async" loading="eager" src="/v/vspfiles/mahjong/tiles/tile-green.png"/>
+<img alt="Soap Dragon" decoding="async" loading="eager" src="/v/vspfiles/mahjong/tiles/tile-white.png"/>
+</div>
+<h3>Protect The Tiles</h3>
+<p>Keep food and drinks away from the rack area so the set stays clean and easier to handle.</p>
+</article>
+<article class="mc-practical-card">
+<div aria-label="Winds and joker examples" class="mc-mini-tile-strip">
+<img alt="East Wind" decoding="async" loading="eager" src="/v/vspfiles/mahjong/tiles/tile-east.png"/>
+<img alt="North Wind" decoding="async" loading="eager" src="/v/vspfiles/mahjong/tiles/tile-north.png"/>
+<img alt="Joker" decoding="async" loading="eager" src="/v/vspfiles/mahjong/tiles/tile-joker.png"/>
+</div>
+<h3>Learn At A Patient Table</h3>
+<p>Real players teach timing, etiquette, and practical strategy better than memorizing rules alone.</p>
+</article>
+</div>
+</div>
+</section>
+<section class="mc-section">
+<div class="mc-wrap mc-faq">
+<div class="mc-section-head">
+<p class="mc-eyebrow">Before you buy</p>
+<h2>Mahjong Shopping FAQ</h2>
+</div>
+<details>
+<summary>What does a beginner need to start playing?</summary>
+<p>A practical starter setup includes an American Mahjong tile set, four racks with pushers, a current card for each player, and a mat or protected playing surface.</p>
+</details>
+<details>
+<summary>Should I buy full-size or travel tiles?</summary>
+<p>Choose full-size tiles for regular home play and a more substantial feel. Travel tiles are thinner and lighter when portability and storage matter more.</p>
+</details>
+<details>
+<summary>Do I really need a Mahjong mat?</summary>
+<p>A mat is not mandatory, but it protects the table, softens the sound of the tiles, and makes shuffling and dealing more comfortable.</p>
+</details>
+<details>
+<summary>Are the pattern-trainer examples official hands?</summary>
+<p>No. They are original visual exercises designed to demonstrate tile relationships without reproducing official card content.</p>
+</details>
+</div>
+</section>
+</div>
+<script id="mc-mahjong-live-draw-discard-v9">
+(function () {
+  "use strict";
+  var root = document.getElementById("mc-mahjong-page");
+  if (!root) return;
+
+  (function initLiveDrawDiscardTrainer() {
+    var liveRoot = root.querySelector("#mc-live-trainer");
+    if (!liveRoot || liveRoot.dataset.mcLiveTrainerBound === "1") return;
+    liveRoot.dataset.mcLiveTrainerBound = "1";
+
+    var asset = "/v/vspfiles/mahjong/tiles";
+    var rackEl = liveRoot.querySelector("#mc-live-rack");
+    var statusEl = liveRoot.querySelector("#mc-live-status");
+    var countEl = liveRoot.querySelector("#mc-live-count");
+    var suggestionsEl = liveRoot.querySelector("#mc-live-suggestions");
+    var discardAdviceEl = liveRoot.querySelector("#mc-live-discard-advice");
+    var autoBtn = liveRoot.querySelector("#mc-live-auto-deal");
+    var drawBtn = liveRoot.querySelector("#mc-live-draw");
+    var discardBtn = liveRoot.querySelector("#mc-live-discard");
+    if (!rackEl || !statusEl || !countEl || !suggestionsEl || !discardAdviceEl || !autoBtn || !drawBtn || !discardBtn) return;
+
+    var rack = [], wall = [], selectedIndex = -1, drawnIndex = -1;
+    var names = {east:"East Wind",south:"South Wind",west:"West Wind",north:"North Wind",red:"Red Dragon",green:"Green Dragon",white:"White Dragon",flower:"Flower",joker:"Joker"};
+    var order = {c:0,d:1,b:2,east:30,south:31,west:32,north:33,red:34,green:35,white:36,flower:37,joker:38};
+    var suitPermutations = [
+      {a:"c",b:"d",c:"b"},{a:"c",b:"b",c:"d"},
+      {a:"d",b:"c",c:"b"},{a:"d",b:"b",c:"c"},
+      {a:"b",b:"c",c:"d"},{a:"b",b:"d",c:"c"}
+    ];
+
+    function repeat(code,n){var out=[];while(n-->0)out.push(code);return out;}
+    function join(){return Array.prototype.concat.apply([],arguments);}
+
+    var livePatterns = [
+      {name:"Even Pung Ladder",tiles:join(["flower","flower"],repeat("a2",3),repeat("a4",3),repeat("a6",3),repeat("a8",3)),note:"Four repeated even-number groups in one suit."},
+      {name:"Odd Pung Ladder",tiles:join(["flower","flower"],repeat("a1",3),repeat("a3",3),repeat("a5",3),repeat("a7",3)),note:"Four repeated odd-number groups in one suit."},
+      {name:"One-Suit Sequence",tiles:join(["a1","a2","a3","a4","a5","a6","a7","a8","a9"],repeat("a9",3),repeat("red",2)),note:"A long same-suit run with a strong end group."},
+      {name:"Two-Suit Ladder",tiles:join(["a1","a2","a3","a4","a5","a6","b7","b8","b9"],repeat("b9",3),["flower","flower"]),note:"Connected low numbers move into a second-suit high block."},
+      {name:"Three-Suit Steps",tiles:join(["a1","a2","a3","b4","b5","b6","c7","c8","c9"],repeat("red",4),["flower"]),note:"Three short runs supported by a dragon group."},
+      {name:"Same Number Across Suits",tiles:join(repeat("a5",4),repeat("b5",4),repeat("c5",4),["flower","flower"]),note:"The same number repeated in all three suits."},
+      {name:"Wind Frame",tiles:join(repeat("east",3),repeat("south",3),repeat("west",3),repeat("north",3),repeat("red",2)),note:"A wind-heavy direction with a dragon pair."},
+      {name:"Dragon Frame",tiles:join(repeat("red",4),repeat("green",4),repeat("white",4),["flower","flower"]),note:"Three strong dragon groups framed by flowers."},
+      {name:"Seven-Pair Study",tiles:join(repeat("a1",2),repeat("a3",2),repeat("a5",2),repeat("b2",2),repeat("b4",2),repeat("c6",2),repeat("red",2)),note:"A pair-heavy direction that rewards patience."},
+      {name:"Consecutive Pairs",tiles:join(repeat("a1",2),repeat("a2",2),repeat("a3",2),repeat("a4",2),repeat("a5",2),repeat("a6",2),["flower","flower"]),note:"Six consecutive pairs in one suit."},
+      {name:"Mirror Numbers",tiles:join(repeat("a1",3),repeat("a9",3),repeat("b1",3),repeat("b9",3),["flower","flower"]),note:"Matching low and high groups across two suits."},
+      {name:"Twin Runs",tiles:join(["a1","a2","a3","a1","a2","a3","b7","b8","b9","b7","b8","b9","flower","flower"]),note:"Two repeated runs in opposite ends of two suits."}
+    ];
+
+    function tileName(code){
+      if(names[code])return names[code];
+      var suit={c:"Crak",d:"Dot",b:"Bam"}[code.charAt(0)]||"Tile";
+      return code.slice(1)+" "+suit;
+    }
+    function tileSortValue(code){
+      if(order[code]!=null)return order[code];
+      return (order[code.charAt(0)]||0)*10+Number(code.slice(1));
+    }
+    function sortRack(list){return list.slice().sort(function(a,b){return tileSortValue(a)-tileSortValue(b);});}
+    function shuffle(list){
+      var out=list.slice();
+      for(var i=out.length-1;i>0;i--){
+        var j=Math.floor(Math.random()*(i+1));
+        var temp=out[i];out[i]=out[j];out[j]=temp;
+      }
+      return out;
+    }
+    function buildWall(){
+      var out=[];
+      ["c","d","b"].forEach(function(s){for(var n=1;n<=9;n++)out=out.concat(repeat(s+n,4));});
+      ["east","south","west","north","red","green","white"].forEach(function(code){out=out.concat(repeat(code,4));});
+      return shuffle(out.concat(repeat("flower",8),repeat("joker",8)));
+    }
+    function countTiles(list){
+      var out={};
+      list.forEach(function(code){out[code]=(out[code]||0)+1;});
+      return out;
+    }
+    function expandPattern(spec,perm){
+      return spec.tiles.map(function(code){
+        var first=code.charAt(0);
+        if((first==="a"||first==="b"||first==="c")&&/\d/.test(code.slice(1)))return perm[first]+code.slice(1);
+        return code;
+      });
+    }
+    function analyzeTarget(target,hand){
+      var targetCounts=countTiles(target),handCounts=countTiles(hand),matched=0,missing=[];
+      Object.keys(targetCounts).forEach(function(code){
+        var exact=Math.min(targetCounts[code],handCounts[code]||0);
+        matched+=exact;
+        for(var i=exact;i<targetCounts[code];i++)missing.push(code);
+      });
+      var jokers=handCounts.joker||0,jokerUsed=0;
+      for(var m=missing.length-1;m>=0&&jokerUsed<jokers;m--){
+        var code=missing[m],groupSize=targetCounts[code]||0;
+        if(code!=="flower"&&code!=="joker"&&groupSize>=3){missing.splice(m,1);jokerUsed++;}
+      }
+      return {matched:matched+jokerUsed,missing:missing,jokerUsed:jokerUsed,target:target};
+    }
+    function rankPatterns(hand){
+      var ranked=livePatterns.map(function(spec){
+        var best=null;
+        suitPermutations.forEach(function(perm){
+          var result=analyzeTarget(expandPattern(spec,perm),hand);
+          result.name=spec.name;result.note=spec.note;
+          if(!best||result.matched>best.matched||(result.matched===best.matched&&result.missing.length<best.missing.length))best=result;
+        });
+        return best;
+      });
+      ranked.sort(function(a,b){
+        if(b.matched!==a.matched)return b.matched-a.matched;
+        if(a.missing.length!==b.missing.length)return a.missing.length-b.missing.length;
+        return a.name.localeCompare(b.name);
+      });
+      return ranked;
+    }
+    function bestDiscardCandidates(hand){
+      if(hand.length!==14)return [];
+      var candidates=hand.map(function(code,index){
+        var test=hand.slice();test.splice(index,1);
+        var ranked=rankPatterns(test);
+        var quality=(ranked[0].matched*100)+(ranked[1].matched*10)+ranked[2].matched;
+        if(code==="joker")quality-=1000;
+        if(code==="flower")quality-=80;
+        return {code:code,index:index,quality:quality};
+      }).sort(function(a,b){return b.quality-a.quality;});
+      var unique=[];
+      candidates.forEach(function(item){if(!unique.some(function(x){return x.code===item.code;}))unique.push(item);});
+      return unique.slice(0,3);
+    }
+    function tileImageSrc(code,flowerNumber){
+      if(code==="flower"){
+        var flowerIndex=((flowerNumber||1)-1)%8+1;
+        return asset+"/tile-flower-"+flowerIndex+".png?v=20260717flowers8";
+      }
+      return asset+"/tile-"+code+".png?v=20260717tiles";
+    }
+    function tileImg(code,loading,flowerNumber){
+      return '<img src="'+tileImageSrc(code,flowerNumber)+'" alt="'+tileName(code)+'" loading="'+(loading||"eager")+'" decoding="async">';
+    }
+    function renderRack(){
+      rackEl.innerHTML="";
+      rackEl.classList.toggle("is-discarding",rack.length===14);
+      var flowerSeen=0;
+      rack.forEach(function(code,index){
+        var tileButton=document.createElement("button");
+        tileButton.type="button";tileButton.className="mc-live-tile";
+        if(index===selectedIndex)tileButton.classList.add("is-selected");
+        if(index===drawnIndex)tileButton.classList.add("is-drawn");
+        tileButton.setAttribute("aria-label",tileName(code)+(rack.length===14?". Select to discard.":""));
+        tileButton.setAttribute("aria-pressed",index===selectedIndex?"true":"false");
+        if(code==="flower")flowerSeen++;
+        tileButton.innerHTML=tileImg(code,"eager",flowerSeen);
+        tileButton.addEventListener("click",function(){
+          if(rack.length!==14)return;
+          selectedIndex=(selectedIndex===index?-1:index);
+          renderLiveTrainer();
+        });
+        rackEl.appendChild(tileButton);
+      });
+    }
+    function compactMissing(missing){
+      var counts=countTiles(missing),ordered=Object.keys(counts).sort(function(a,b){return tileSortValue(a)-tileSortValue(b);}),html=[];
+      var missingFlowerSeen=0;
+      ordered.forEach(function(code){
+        for(var i=0;i<counts[code];i++){
+          if(code==="flower")missingFlowerSeen++;
+          html.push(tileImg(code,"lazy",missingFlowerSeen));
+        }
+      });
+      return html.join("");
+    }
+    function renderSuggestions(ranked){
+      suggestionsEl.innerHTML="";
+      ranked.slice(0,3).forEach(function(item){
+        var card=document.createElement("article");
+        card.className="mc-live-suggestion";
+        var missingHtml=item.missing.length
+          ?'<div class="mc-live-missing-label">Still needed</div><div class="mc-live-missing">'+compactMissing(item.missing)+'</div>'
+          :'<div class="mc-live-complete">This rack already contains the full original practice structure.</div>';
+        card.innerHTML='<div class="mc-live-suggestion__top"><strong>'+item.name+'</strong><span class="mc-live-suggestion__score">'+item.matched+'/14 aligned</span></div><p>'+item.note+'</p>'+missingHtml;
+        suggestionsEl.appendChild(card);
+      });
+    }
+    function renderLiveTrainer(){
+      countEl.textContent=rack.length+" TILE"+(rack.length===1?"":"S");
+      drawBtn.disabled=rack.length!==13;
+      discardBtn.disabled=rack.length!==14||selectedIndex<0;
+      if(rack.length===13)statusEl.textContent="Your 13-tile rack is ready. Draw one tile, then choose a discard.";
+      else if(selectedIndex>=0)statusEl.textContent="Selected "+tileName(rack[selectedIndex])+". Click DISCARD SELECTED to return to 13 tiles.";
+      else statusEl.textContent="You drew "+tileName(rack[drawnIndex])+". Click any tile to choose your discard.";
+
+      var ranked=rankPatterns(rack);
+      renderRack();
+      renderSuggestions(ranked);
+
+      if(rack.length===14){
+        var best=bestDiscardCandidates(rack);
+        discardAdviceEl.textContent=best.length?"Best discard candidates: "+best.map(function(item){return tileName(item.code);}).join(", ")+".":"Choose the tile that helps the fewest suggested directions.";
+      }else{
+        discardAdviceEl.textContent="Draw one tile to receive a discard recommendation.";
+      }
+    }
+    function deal(){
+      wall=buildWall();rack=[];
+      for(var i=0;i<13;i++)rack.push(wall.pop());
+      rack=sortRack(rack);selectedIndex=-1;drawnIndex=-1;renderLiveTrainer();
+    }
+    function drawTile(){
+      if(rack.length!==13)return;
+      if(!wall.length)wall=buildWall();
+      rack.push(wall.pop());drawnIndex=rack.length-1;selectedIndex=-1;renderLiveTrainer();
+    }
+    function discardSelected(){
+      if(rack.length!==14||selectedIndex<0)return;
+      rack.splice(selectedIndex,1);rack=sortRack(rack);selectedIndex=-1;drawnIndex=-1;renderLiveTrainer();
+    }
+
+    autoBtn.addEventListener("click",deal);
+    drawBtn.addEventListener("click",drawTile);
+    discardBtn.addEventListener("click",discardSelected);
+    deal();
+  })();
+})();
+</script>
+<script>
+(function () {
+  "use strict";
+
+  var patterns = [{"type": "pairs", "suits": "2", "level": "beginner", "label": "Pair Ladder", "tiles": ["flower", "flower", "c2", "c2", "d4", "d4", "b6", "b6", "b8", "b8", "b8", "b8", "joker", "joker"], "note": "Protect early pairs, then build one strong four-tile anchor."}, {"type": "runs", "suits": "3", "level": "beginner", "label": "Three-Suit Run", "tiles": ["c1", "c2", "c3", "d4", "d5", "d6", "b7", "b8", "b9", "red", "red", "red", "red", "joker"], "note": "Practice spotting connected groups while keeping one identical group."}, {"type": "repeats", "suits": "2", "level": "intermediate", "label": "Echo Numbers", "tiles": ["c3", "c3", "c3", "d3", "d3", "d3", "b6", "b6", "b6", "b6", "c6", "c6", "joker", "joker"], "note": "Train your eye to repeated numbers appearing across more than one suit."}, {"type": "honors", "suits": "1", "level": "intermediate", "label": "Honor Frame", "tiles": ["north", "north", "north", "east", "east", "east", "c5", "c5", "c5", "red", "red", "red", "red", "joker"], "note": "Use honor-heavy directions only when the winds and dragons are truly strong."}, {"type": "flowers", "suits": "2", "level": "beginner", "label": "Flower Bridge", "tiles": ["flower", "flower", "flower", "flower", "c1", "c2", "c3", "d4", "d5", "d6", "b7", "b7", "b7", "b7"], "note": "Flowers create the frame while short runs shape the middle."}, {"type": "pairs", "suits": "3", "level": "advanced", "label": "Seven-Pair Study", "tiles": ["c1", "c1", "d3", "d3", "b5", "b5", "c7", "c7", "d9", "d9", "red", "red", "flower", "flower"], "note": "A no-joker pair exercise that rewards patience and careful discarding."}, {"type": "runs", "suits": "2", "level": "intermediate", "label": "Split Sequence", "tiles": ["c1", "c2", "c3", "c4", "d5", "d6", "d7", "d8", "b9", "b9", "b9", "red", "red", "red"], "note": "Build two connected blocks, then finish with one repeated number and dragon group."}, {"type": "repeats", "suits": "1", "level": "intermediate", "label": "Single-Suit Rhythm", "tiles": ["flower", "flower", "c2", "c2", "c2", "c4", "c4", "c4", "c6", "c6", "c6", "c8", "c8", "joker"], "note": "A one-suit drill built around repeated even numbers."}, {"type": "runs", "suits": "1", "level": "beginner", "label": "Low Number Sweep", "tiles": ["b1", "b1", "b2", "b2", "b3", "b3", "b4", "b4", "b5", "b5", "b6", "b6", "flower", "flower"], "note": "Practice identifying a low-number direction without forcing exact group sizes."}, {"type": "runs", "suits": "1", "level": "beginner", "label": "High Number Sweep", "tiles": ["d4", "d4", "d5", "d5", "d6", "d6", "d7", "d7", "d8", "d8", "d9", "d9", "flower", "flower"], "note": "The high-number companion to the low-number sweep."}, {"type": "repeats", "suits": "3", "level": "intermediate", "label": "Odd Number Echo", "tiles": ["c1", "c1", "c1", "d3", "d3", "d3", "b5", "b5", "b5", "c7", "c7", "d9", "d9", "joker"], "note": "Spot the odd-number relationship even when the suits change."}, {"type": "repeats", "suits": "3", "level": "intermediate", "label": "Even Number Echo", "tiles": ["c2", "c2", "c2", "d4", "d4", "d4", "b6", "b6", "b6", "c8", "c8", "d8", "d8", "joker"], "note": "A flexible even-number study across three suits."}, {"type": "honors", "suits": "2", "level": "advanced", "label": "Wind Window", "tiles": ["east", "east", "south", "south", "west", "west", "north", "north", "c4", "c4", "d6", "d6", "flower", "flower"], "note": "Use winds as visual anchors while preserving two numbered backup pairs."}, {"type": "honors", "suits": "3", "level": "advanced", "label": "Dragon Trio", "tiles": ["red", "red", "red", "green", "green", "green", "white", "white", "white", "c2", "c2", "d6", "d6", "flower"], "note": "A dragon-recognition drill with two numbered pairs as alternate structure."}, {"type": "flowers", "suits": "1", "level": "intermediate", "label": "Flowered Even Build", "tiles": ["flower", "flower", "flower", "flower", "b2", "b2", "b2", "b4", "b4", "b4", "b6", "b6", "b8", "b8"], "note": "Use flowers to support a single-suit even-number structure."}, {"type": "flowers", "suits": "3", "level": "advanced", "label": "Flowered Mix", "tiles": ["flower", "flower", "c1", "c2", "c3", "d4", "d5", "d6", "b7", "b8", "b9", "red", "red", "joker"], "note": "A broad visual exercise for racks that stay flexible across three suits."}, {"type": "pairs", "suits": "1", "level": "intermediate", "label": "One-Suit Pair Bank", "tiles": ["c1", "c1", "c2", "c2", "c4", "c4", "c5", "c5", "c7", "c7", "c9", "c9", "flower", "flower"], "note": "Keep the pair bank intact until a clearer one-suit direction appears."}, {"type": "repeats", "suits": "2", "level": "advanced", "label": "Double Pung Study", "tiles": ["b3", "b3", "b3", "b3", "d6", "d6", "d6", "d6", "c9", "c9", "c9", "red", "red", "joker"], "note": "Practice seeing two strong identical groups before choosing the finishing block."}, {"type": "runs", "suits": "2", "level": "advanced", "label": "Mirrored Run", "tiles": ["c1", "c2", "c3", "c7", "c8", "c9", "d1", "d2", "d3", "d7", "d8", "d9", "flower", "flower"], "note": "Look for matching low and high runs across two suits."}, {"type": "honors", "suits": "1", "level": "beginner", "label": "Dragon Anchor", "tiles": ["red", "red", "red", "red", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "b8", "flower", "joker"], "note": "Use one dragon group as an anchor while evaluating a connected numbered suit."}, {"type": "pairs", "suits": "2", "level": "advanced", "label": "Alternating Pairs", "tiles": ["c2", "c2", "d2", "d2", "c4", "c4", "d4", "d4", "c6", "c6", "d6", "d6", "flower", "flower"], "note": "A two-suit pair drill built around matching even numbers."}, {"type": "runs", "suits": "3", "level": "advanced", "label": "Broken Run Recovery", "tiles": ["c1", "c2", "c4", "d3", "d4", "d6", "b5", "b6", "b8", "flower", "flower", "red", "joker", "joker"], "note": "Practice deciding which gaps are worth repairing and which tiles should be passed."}, {"type": "repeats", "suits": "1", "level": "beginner", "label": "Triple Repeat", "tiles": ["d2", "d2", "d2", "d5", "d5", "d5", "d8", "d8", "d8", "flower", "flower", "red", "red", "joker"], "note": "Three repeated-number groups make the rack easy to scan and compare."}, {"type": "honors", "suits": "2", "level": "intermediate", "label": "Honor And Run", "tiles": ["north", "north", "north", "green", "green", "green", "c1", "c2", "c3", "d7", "d8", "d9", "flower", "joker"], "note": "Balance honor groups against two short numbered runs."}];
+  var root = document.getElementById("mc-mahjong-page");
+  if (!root) return;
+
+  var assetBase = "/v/vspfiles/mahjong";
+  var grid = root.querySelector("#mc-pattern-grid");
+  var title = root.querySelector("#mc-results-title");
+  var strength = root.querySelector("#mc-strength");
+  var suits = root.querySelector("#mc-suits");
+  var level = root.querySelector("#mc-level");
+  var button = root.querySelector("#mc-find-patterns");
+  var moreButton = root.querySelector("#mc-show-more");
+  var moreWrap = root.querySelector("#mc-more-wrap");
+  var total = root.querySelector("#mc-pattern-total");
+
+  var currentResults = patterns.slice();
+  var visibleCount = 4;
+
+  function tileAlt(code) {
+    var labels = {
+      east:"East Wind", south:"South Wind", west:"West Wind", north:"North Wind",
+      red:"Red Dragon", green:"Green Dragon", white:"White Dragon",
+      flower:"Flower", joker:"Joker"
+    };
+    if (labels[code]) return labels[code];
+
+    var suitsMap = {c:"Crak", b:"Bam", d:"Dot"};
+    var first = code.charAt(0);
+    return code.slice(1) + " " + (suitsMap[first] || "Mahjong tile");
+  }
+
+  function tileStrip(tiles) {
+    var flowerSeen = 0;
+    return '<div class="mc-tile-strip">' + tiles.map(function (code) {
+      var src;
+      if (code === "flower") {
+        flowerSeen++;
+        src = assetBase + '/tiles/tile-flower-' + (((flowerSeen - 1) % 8) + 1) + '.png?v=20260717flowers8';
+      } else {
+        src = assetBase + '/tiles/tile-' + code + '.png?v=20260717tiles';
+      }
+      return '<img src="' + src + '" alt="' + tileAlt(code) + '" loading="lazy" decoding="async">';
+    }).join("") + '</div>';
+  }
+
+  function render() {
+    grid.innerHTML = "";
+
+    if (!currentResults.length) {
+      grid.innerHTML = '<div class="mc-empty">No exact match appeared. Widen one filter and try again.</div>';
+      moreWrap.hidden = true;
+      return;
+    }
+
+    currentResults.slice(0, visibleCount).forEach(function (item) {
+      var card = document.createElement("article");
+      card.className = "mc-pattern";
+      card.innerHTML =
+        '<div class="mc-pattern__meta">' +
+          '<span class="mc-pattern__tag">' + item.label + '</span>' +
+          '<span class="mc-pattern__level">' + item.level + '</span>' +
+        '</div>' +
+        tileStrip(item.tiles) +
+        '<p>' + item.note + '</p>';
+      grid.appendChild(card);
+    });
+
+    moreWrap.hidden = visibleCount >= currentResults.length;
+    moreButton.textContent = "Show " + Math.min(4, currentResults.length - visibleCount) + " more combinations";
+  }
+
+  function filterPatterns() {
+    var selectedStrength = strength.value;
+    var selectedSuits = suits.value;
+    var selectedLevel = level.value;
+
+    currentResults = patterns.filter(function (item) {
+      return (selectedStrength === "any" || item.type === selectedStrength) &&
+             (selectedSuits === "any" || item.suits === selectedSuits) &&
+             (selectedLevel === "any" || item.level === selectedLevel);
+    });
+
+    visibleCount = 4;
+    title.textContent = currentResults.length
+      ? currentResults.length + (currentResults.length === 1 ? " Matching Combination" : " Matching Combinations")
+      : "Try A Broader Combination";
+    render();
+  }
+
+  button.addEventListener("click", filterPatterns);
+
+  moreButton.addEventListener("click", function () {
+    visibleCount += 4;
+    render();
+  });
+
+  total.textContent = patterns.length;
+  title.textContent = patterns.length + " Practice Combinations";
+  render();
+
+  var teacherForm = root.querySelector("#mc-teacher-form");
+  var teacherLocation = root.querySelector("#mc-teacher-location");
+  var teacherError = root.querySelector("#mc-teacher-error");
+
+  if (teacherForm && teacherLocation) {
+    teacherForm.addEventListener("submit", function (event) {
+      event.preventDefault();
+
+      var location = teacherLocation.value.trim();
+
+      if (!location) {
+        teacherError.hidden = false;
+        teacherLocation.focus();
+        return;
+      }
+
+      teacherError.hidden = true;
+
+      var query = encodeURIComponent(
+        "American Mahjong teacher or lessons near " + location
+      );
+
+      window.open(
+        "https://www.google.com/maps/search/?api=1&query=" + query,
+        "_blank",
+        "noopener"
+      );
+    });
+
+    teacherLocation.addEventListener("input", function () {
+      teacherError.hidden = true;
+    });
+  }
+
+})();
+</script>
+
+<script id="mc-mahjong-landing-image-repair-v11">
+(function () {
+  "use strict";
+
+  function repairMahjongLandingImages() {
+    var root = document.getElementById("mc-mahjong-page");
+    if (!root) return;
+
+    root.querySelectorAll("img[data-mc-landing-src]").forEach(function (img) {
+      var source = img.getAttribute("data-mc-landing-src");
+      if (!source) return;
+      if (/\.webp(\?|$)/i.test(source)) {
+        source = source.replace(/\.webp(\?|$)/i, ".jpg$1");
+        img.setAttribute("data-mc-landing-src", source);
+      }
+
+      img.classList.remove("lazy", "lazyload", "lazyloaded", "v-lazy-image");
+      img.removeAttribute("data-src");
+      img.removeAttribute("data-lazy-src");
+      img.removeAttribute("data-original");
+      img.removeAttribute("srcset");
+      img.setAttribute("loading", "eager");
+      img.setAttribute("decoding", "async");
+
+      if (img.getAttribute("src") !== source) img.setAttribute("src", source);
+
+      img.style.setProperty("display", "block", "important");
+      img.style.setProperty("visibility", "visible", "important");
+      img.style.setProperty("opacity", "1", "important");
+      img.style.setProperty("background-image", "url('" + source.replace(/'/g, "\\'") + "')", "important");
+      img.style.setProperty("background-size", "cover", "important");
+      img.style.setProperty("background-position", "center", "important");
+    });
+  }
+
+  repairMahjongLandingImages();
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", repairMahjongLandingImages, { once: true });
+  }
+
+  window.addEventListener("load", repairMahjongLandingImages, { once: true });
+  window.setTimeout(repairMahjongLandingImages, 350);
+})();
+</script>
+
+<style id="mc-mahjong-mobile-layout-final">
+/* Mobile-only Mahjong trainer improvements */
+@media (max-width: 760px) {
+  /* Use nearly the full phone width instead of a narrow centered column. */
+  #mc-mahjong-page,
+  #mc-mahjong-page .mc-wrap,
+  #mc-mahjong-page #mc-mahjong-trainer,
+  #mc-mahjong-page #mc-mahjong-trainer > .mc-wrap,
+  #mc-mahjong-page .mc-live-trainer {
+    width: 100% !important;
+    max-width: none !important;
+    box-sizing: border-box !important;
+  }
+
+  #mc-mahjong-page #mc-mahjong-trainer {
+    margin: 0 !important;
+    padding: 12px 6px 24px !important;
+  }
+
+  #mc-mahjong-page #mc-mahjong-trainer > .mc-wrap {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  #mc-mahjong-page .mc-live-trainer {
+    margin: 0 !important;
+    padding: 12px 6px !important;
+  }
+
+  /* Smaller headings and tighter line spacing. */
+  #mc-mahjong-page #mc-mahjong-trainer .mc-section-head {
+    width: 100% !important;
+    max-width: none !important;
+    margin: 0 0 10px !important;
+    padding: 0 6px !important;
+  }
+
+  #mc-mahjong-page #mc-mahjong-trainer .mc-section-head h2 {
+    margin: 0 0 5px !important;
+    font-size: 19px !important;
+    line-height: 1.05 !important;
+    letter-spacing: .01em !important;
+  }
+
+  #mc-mahjong-page #mc-mahjong-trainer .mc-section-head .mc-lead {
+    margin: 0 !important;
+    font-size: 11px !important;
+    line-height: 1.28 !important;
+  }
+
+  #mc-mahjong-page .mc-live-trainer__head {
+    display: block !important;
+    margin-bottom: 9px !important;
+    padding: 0 3px !important;
+  }
+
+  #mc-mahjong-page .mc-live-trainer__head h3 {
+    margin: 0 0 4px !important;
+    font-size: 15px !important;
+    line-height: 1.05 !important;
+  }
+
+  #mc-mahjong-page .mc-live-trainer__head p {
+    margin: 0 !important;
+    font-size: 10.5px !important;
+    line-height: 1.25 !important;
+  }
+
+  #mc-mahjong-page .mc-live-trainer__count {
+    display: inline-block !important;
+    margin-top: 6px !important;
+    font-size: 10px !important;
+    line-height: 1.15 !important;
+  }
+
+  #mc-mahjong-page .mc-live-trainer__controls {
+    display: grid !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    gap: 5px !important;
+    margin: 0 0 8px !important;
+  }
+
+  #mc-mahjong-page .mc-live-trainer__controls button {
+    min-height: 34px !important;
+    padding: 5px 6px !important;
+    font-size: 9px !important;
+    line-height: 1.05 !important;
+  }
+
+  #mc-mahjong-page .mc-live-trainer__controls button:first-child {
+    grid-column: 1 / -1 !important;
+  }
+
+  #mc-mahjong-page .mc-live-trainer__status {
+    min-height: 0 !important;
+    margin: 0 3px 7px !important;
+    font-size: 10.5px !important;
+    line-height: 1.25 !important;
+  }
+
+  /*
+    Five columns makes each tile substantially larger.
+    Fourteen tiles display as 5 + 5 + 4, all visible with no horizontal scroll.
+  */
+  #mc-mahjong-page .mc-live-rack {
+    display: grid !important;
+    grid-template-columns: repeat(5, minmax(0, 1fr)) !important;
+    justify-content: center !important;
+    gap: 5px !important;
+    width: 100% !important;
+    max-width: none !important;
+    margin: 0 !important;
+    padding: 7px 3px !important;
+    overflow: visible !important;
+    overflow-x: visible !important;
+    white-space: normal !important;
+  }
+
+  #mc-mahjong-page .mc-live-rack::-webkit-scrollbar {
+    display: none !important;
+  }
+
+  #mc-mahjong-page .mc-live-tile {
+    display: block !important;
+    width: 100% !important;
+    min-width: 0 !important;
+    max-width: none !important;
+    margin: 0 !important;
+    flex: none !important;
+  }
+
+  #mc-mahjong-page .mc-live-tile img {
+    display: block !important;
+    width: 100% !important;
+    min-width: 0 !important;
+    max-width: 100% !important;
+    height: auto !important;
+    object-fit: contain !important;
+  }
+
+  #mc-mahjong-page .mc-live-advisor,
+  #mc-mahjong-page .mc-live-advisor__heading {
+    width: 100% !important;
+    max-width: none !important;
+  }
+
+  #mc-mahjong-page .mc-live-advisor__heading h3 {
+    font-size: 15px !important;
+    line-height: 1.05 !important;
+  }
+
+  #mc-mahjong-page .mc-live-advisor__heading p,
+  #mc-mahjong-page .mc-live-trainer__disclaimer {
+    font-size: 10px !important;
+    line-height: 1.28 !important;
+  }
+}
+
+@media (max-width: 390px) {
+  #mc-mahjong-page .mc-live-rack {
+    gap: 4px !important;
+    padding-left: 2px !important;
+    padding-right: 2px !important;
+  }
+
+  #mc-mahjong-page #mc-mahjong-trainer .mc-section-head h2 {
+    font-size: 18px !important;
+  }
+}
+</style>
+
+<style id="mc-mahjong-tile-repair-css-v13">
+#mc-mahjong-page .mc-live-tile,
+#mc-mahjong-page .mc-live-tile:hover,
+#mc-mahjong-page .mc-live-tile:focus,
+#mc-mahjong-page .mc-live-tile:focus-visible,
+#mc-mahjong-page .mc-live-tile:active {
+  border: 0 !important;
+  outline: 0 !important;
+  box-shadow: none !important;
+  background: transparent !important;
+  -webkit-appearance: none !important;
+  appearance: none !important;
+}
+
+#mc-mahjong-page .mc-live-tile.is-selected {
+  transform: translateY(-11px) !important;
+}
+
+#mc-mahjong-page .mc-live-tile img,
+#mc-mahjong-page .mc-tile-strip img,
+#mc-mahjong-page .mc-key-tile img,
+#mc-mahjong-page .mc-example-tiles img,
+#mc-mahjong-page .mc-mini-tile-strip img,
+#mc-mahjong-page .mc-teacher-tile-strip img,
+#mc-mahjong-page .mc-live-missing img {
+  display: block !important;
+  height: auto !important;
+  max-height: none !important;
+  border: 0 !important;
+  outline: 0 !important;
+  box-shadow: none !important;
+  background: transparent !important;
+  background-color: transparent !important;
+  clip-path: none !important;
+  -webkit-clip-path: none !important;
+  object-fit: contain !important;
+  object-position: center bottom !important;
+}
+
+#mc-mahjong-page .mc-pattern,
+#mc-mahjong-page .mc-pattern-grid,
+#mc-mahjong-page .mc-group-example,
+#mc-mahjong-page .mc-key-card,
+#mc-mahjong-page .mc-key-group,
+#mc-mahjong-page .mc-live-trainer {
+  overflow: visible !important;
+}
+</style>
+
+<script id="mc-mahjong-tile-repair-v13">
+(function () {
+  "use strict";
+
+  var root = document.getElementById("mc-mahjong-page");
+  if (!root || root.dataset.mcTileRepairV13 === "1") return;
+  root.dataset.mcTileRepairV13 = "1";
+
+  var OUT_W = 750;
+  var OUT_H = 1000;
+
+  var ALIASES = {
+    "tile-we.png": "tile-east.png",
+    "tile-ws.png": "tile-south.png",
+    "tile-ww.png": "tile-west.png",
+    "tile-wn.png": "tile-north.png",
+    "tile-dr.png": "tile-red.png",
+    "tile-dg.png": "tile-green.png",
+    "tile-ds.png": "tile-white.png"
+  };
+
+  function canonicalSrc(src) {
+    var out = src || "";
+    Object.keys(ALIASES).forEach(function (from) {
+      out = out.replace(from, ALIASES[from]);
+    });
+    return out;
+  }
+
+  function isTileImage(img) {
+    return !!img &&
+      img.tagName === "IMG" &&
+      /\/v\/vspfiles\/mahjong\/tiles\/tile-/.test(img.getAttribute("src") || "");
+  }
+
+  function findVisibleBounds(image) {
+    var canvas = document.createElement("canvas");
+    canvas.width = image.naturalWidth;
+    canvas.height = image.naturalHeight;
+
+    var ctx = canvas.getContext("2d", { willReadFrequently: true });
+    ctx.drawImage(image, 0, 0);
+
+    var imageData;
+    try {
+      imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    } catch (e) {
+      return null;
+    }
+
+    var d = imageData.data;
+    var w = canvas.width;
+    var h = canvas.height;
+    var seen = new Uint8Array(w * h);
+    var queueX = new Int32Array(w * h);
+    var queueY = new Int32Array(w * h);
+    var head = 0;
+    var tail = 0;
+
+    function nearBackground(x, y) {
+      var p = (y * w + x) * 4;
+      var r = d[p];
+      var g = d[p + 1];
+      var b = d[p + 2];
+      var a = d[p + 3];
+
+      if (a < 20) return true;
+
+      var max = Math.max(r, g, b);
+      var min = Math.min(r, g, b);
+
+      return r >= 238 && g >= 238 && b >= 238 && (max - min) <= 14;
+    }
+
+    function add(x, y) {
+      var i = y * w + x;
+      if (seen[i] || !nearBackground(x, y)) return;
+      seen[i] = 1;
+      queueX[tail] = x;
+      queueY[tail] = y;
+      tail++;
+    }
+
+    for (var x = 0; x < w; x++) {
+      add(x, 0);
+      add(x, h - 1);
+    }
+
+    for (var y = 0; y < h; y++) {
+      add(0, y);
+      add(w - 1, y);
+    }
+
+    while (head < tail) {
+      var qx = queueX[head];
+      var qy = queueY[head];
+      head++;
+
+      if (qx > 0) add(qx - 1, qy);
+      if (qx < w - 1) add(qx + 1, qy);
+      if (qy > 0) add(qx, qy - 1);
+      if (qy < h - 1) add(qx, qy + 1);
+    }
+
+    var left = w;
+    var top = h;
+    var right = -1;
+    var bottom = -1;
+
+    for (var yy = 0; yy < h; yy++) {
+      for (var xx = 0; xx < w; xx++) {
+        var idx = yy * w + xx;
+        var p = idx * 4;
+
+        if (!seen[idx] && d[p + 3] > 20) {
+          if (xx < left) left = xx;
+          if (xx > right) right = xx;
+          if (yy < top) top = yy;
+          if (yy > bottom) bottom = yy;
+        }
+      }
+    }
+
+    if (right < left || bottom < top) return null;
+
+    return {
+      x: left,
+      y: top,
+      w: right - left + 1,
+      h: bottom - top + 1
+    };
+  }
+
+  function normalizeToDataUri(img, src) {
+    var loader = new Image();
+    loader.decoding = "async";
+
+    loader.onload = function () {
+      var bounds = findVisibleBounds(loader);
+      if (!bounds) {
+        img.dataset.mcTileRepairState = "done";
+        return;
+      }
+
+      var output = document.createElement("canvas");
+      output.width = OUT_W;
+      output.height = OUT_H;
+
+      var outCtx = output.getContext("2d");
+      outCtx.clearRect(0, 0, OUT_W, OUT_H);
+      outCtx.imageSmoothingEnabled = true;
+      outCtx.imageSmoothingQuality = "high";
+      outCtx.drawImage(
+        loader,
+        bounds.x, bounds.y, bounds.w, bounds.h,
+        0, 0, OUT_W, OUT_H
+      );
+
+      img.dataset.mcTileRepairState = "done";
+      img.src = output.toDataURL("image/png");
+    };
+
+    loader.onerror = function () {
+      img.dataset.mcTileRepairState = "error";
+    };
+
+    loader.src = src;
+  }
+
+  function processImage(img) {
+    if (!isTileImage(img)) return;
+    if (img.dataset.mcTileRepairState === "loading" || img.dataset.mcTileRepairState === "done") return;
+
+    var current = img.getAttribute("src") || "";
+    var fixed = canonicalSrc(current);
+
+    if (fixed !== current) {
+      img.dataset.mcTileRepairState = "";
+      img.setAttribute("src", fixed);
+      return;
+    }
+
+    if (current.indexOf("data:image/") === 0) {
+      img.dataset.mcTileRepairState = "done";
+      return;
+    }
+
+    img.dataset.mcTileRepairState = "loading";
+    normalizeToDataUri(img, fixed);
+  }
+
+  function scan(scope) {
+    if (!scope) return;
+
+    if (scope.nodeType === 1 && scope.tagName === "IMG") {
+      processImage(scope);
+    }
+
+    if (!scope.querySelectorAll) return;
+
+    Array.prototype.forEach.call(
+      scope.querySelectorAll('img[src*="/v/vspfiles/mahjong/tiles/tile-"]'),
+      processImage
+    );
+  }
+
+  scan(root);
+
+  new MutationObserver(function (mutations) {
+    mutations.forEach(function (mutation) {
+      if (mutation.type === "attributes" && mutation.target.tagName === "IMG") {
+        processImage(mutation.target);
+      }
+
+      Array.prototype.forEach.call(mutation.addedNodes, function (node) {
+        if (node.nodeType === 1) scan(node);
+      });
+    });
+  }).observe(root, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ["src"]
+  });
+
+  window.addEventListener("load", function () {
+    scan(root);
+  }, { once: true });
+})();
+</script>
+<style id="mc-mahjong-desktop-tweaks-v14">
+/* Auto Deal: keep light text on the filled black button. */
+#mc-mahjong-page #mc-live-auto-deal,
+#mc-mahjong-page #mc-live-auto-deal:hover,
+#mc-mahjong-page #mc-live-auto-deal:focus,
+#mc-mahjong-page #mc-live-auto-deal:focus-visible,
+#mc-mahjong-page #mc-live-auto-deal:active {
+  background: #111 !important;
+  border-color: #111 !important;
+  color: #fff !important;
+  -webkit-text-fill-color: #fff !important;
+  text-shadow: none !important;
+  opacity: 1 !important;
+}
+
+@media (min-width: 761px) {
+  #mc-mahjong-page .mc-live-tile {
+    flex: 0 0 70px !important;
+    width: 70px !important;
+    min-width: 70px !important;
+    max-width: none !important;
+  }
+
+  #mc-mahjong-page .mc-live-tile img {
+    width: 70px !important;
+    min-width: 70px !important;
+    max-width: none !important;
+  }
+
+  #mc-mahjong-page .mc-tile-strip img {
+    width: 70px !important;
+    min-width: 70px !important;
+    max-width: none !important;
+  }
+}
+</style>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+
+            <form class="search_results_section" method="post" name="MainForm" id="MainForm" action="/searchresults.asp" onsubmit="return OnSubmitSearchForm(event, this);">
+			<input type="hidden" name="Search" value="">
+			<input type="hidden" name="Cat" value="201">
+			
+<table width="100%" border="0" cellspacing="0" cellpadding="4">
+  <tr> 
+	<td>
+	
+              <table cellpadding="3" cellspacing="0" width="100%">
+                <tr> 
+                  <td valign="bottom" rowspan="2">
+				   <table width="250" border="0" cellspacing="0" cellpadding="0">
+                    <tr>
+                      <td width="2" valign="middle"><img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="2" height="1" align="absmiddle" alt=""></td>
+                      <td width="180" valign="middle"><nobr>
+                        <div id="jmenuhide">
+                        <b>Sort By:</b>
+                        <select class="sortby_select" title="Sort By:" id="SortBy" >
+							
+                            <option value="1"   >Price: Low to High</option>
+							<option value="2"   >Price: High to Low</option>
+							<option value="5"   >Most Popular</option>
+							<option value="7"   >Title</option>
+							<option value="9"   >Manufacturer</option>
+							<option value="3"   >Newest</option>
+							<option value="4"   >Oldest</option>
+							<option value="11" >Availability</option>
+						</select>
+                       		</div>
+                        
+                      </nobr> </td>
+                      <td width="3" valign="middle"><img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="3" height="1" align="absmiddle" alt=""></td>
+                      
+					  <td width="65" valign="middle">
+                        
+							<img onclick="if (v$('SortBy').value != '') {Add_Search_Param('sort', v$('SortBy').value);} Refine();" border="0" style="cursor:pointer;" src="/v/vspfiles/templates/266/images/Buttons/btn_go_gray.gif">
+                        
+                      </td>
+					  
+					</tr>
+                  </table></td>
+                  <td align="right">
+					
+					<select class="results_per_page_select" onchange="if (this.value != '') {Add_Search_Param('show', this.value);} Refine();" title="{0} per page">
+					
+					<option selected="selected" value="30">30 per page</option>
+					
+					
+					<option  value="60">60 per page</option>
+					
+					<option  value="120">120 per page</option>
+					
+					<option  value="180">180 per page</option>
+					
+					<option  value="300">300 per page</option>
+					
+					
+					</select>
+					
+					<nobr>
+	              	<font face='Arial' size='2'><b> 
+                    <font face='Arial' size='3'><b>Page <input type="text" value="1" size="3" onkeydown="return OnKeyDownPageInputBox(event, this);" maxlength="4" title="Go to page" /> of 1  </b></font>
+                    </b></font>
+					</nobr>
+					
+					</td>
+                </tr>
+                <tr> 
+                  <td align="right"> 
+				  	
+					
+					
+						
+					</td>
+                </tr>
+              </table>
+	
+              <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                <tr> 
+                  <td background="/v/vspfiles/templates/266/images/Divider_Horizontal.gif"><img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="5" height="5" alt=""></td>
+                </tr>
+              </table>
+	</td>
+  </tr>
+</table>
+
+                          
+
+						<table width="100%" border="0" cellspacing="0" cellpadding="8">
+							<tr> 
+								<td> 
+						
+								<table width="100%" border="0" cellspacing="0" cellpadding="0" class="v65-productDisplay"> 
+<tr class="v65-productDisplay-row"> 
+<td valign="top" class="v65-productDisplay-cell v65-productName" width="33%"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-amethyst-gem-mat.htm" class="productnamecolor colors_productname" title="Amethyst Gem Double-Sided Travel Mahjong Mat, TMH-TRV-AMETHYST-GEM-MAT"> 
+Amethyst Gem Double-Sided Travel Mahjong Mat
+</a>
+</td> 
+<td class="v65-productDisplay-cell v65-productColumn-divider v65-product-rowspan" rowspan="3" background="/v/vspfiles/templates/266/images/Grid_Divider_Vertical.gif"> 
+<img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="9" height="3" alt=""> 
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productName" width="33%"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-amethyst-table-mat.htm" class="productnamecolor colors_productname" title="Amethyst Table Double-Sided Travel Mahjong Mat, TMH-TRV-AMETHYST-TABLE-MAT"> 
+Amethyst Table Double-Sided Travel Mahjong Mat
+</a>
+</td> 
+<td class="v65-productDisplay-cell v65-productColumn-divider v65-product-rowspan" rowspan="3" background="/v/vspfiles/templates/266/images/Grid_Divider_Vertical.gif"> 
+<img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="9" height="3" alt=""> 
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productName" width="33%"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-blue-mat.htm" class="productnamecolor colors_productname" title="Blue Double-Sided Travel Mahjong Mat, TMH-TRV-BLUE-MAT"> 
+Blue Double-Sided Travel Mahjong Mat
+</a>
+</td> 
+</tr> 
+<tr class="v65-productDisplay-row"> 
+<td valign="top" width="33%" class="v65-productDisplay-cell v65-productDetailInfo"> 
+<div>
+
+<table width="100%"cellpadding="0" cellspacing="0"><tr>
+<td width="64%" valign="top" class="v65-productDisplay-cell v65-productAvailability v65-infoButton">
+<div>
+<font class="pricecolor colors_productprice">    <div class="product_productprice">        <b><font class="text colors_text">:</font> $65.00 </b>    </div></font>
+</div>
+</td>
+<td width="36%" align="right"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-amethyst-gem-mat.htm" class="smalltext colors_text"> 
+<img src="/v/vspfiles/templates/266/images/Bullet_MoreInfo.gif" border="0" alt="more info"></a>
+<a href="/shoppingcart.asp?ProductCode=TMH%2DTRV%2DAMETHYST%2DGEM%2DMAT"> 
+<IMG SRC="/v/vspfiles/templates/266/images/Buttons/btn_addtocart_small.gif" ALIGN=absmiddle BORDER=0></A> 
+</td> 
+</tr></table> 
+</div>
+</td> 
+<td valign="top" width="33%" class="v65-productDisplay-cell v65-productDetailInfo"> 
+<div>
+
+<table width="100%"cellpadding="0" cellspacing="0"><tr>
+<td width="64%" valign="top" class="v65-productDisplay-cell v65-productAvailability v65-infoButton">
+<div>
+<font class="pricecolor colors_productprice">    <div class="product_productprice">        <b><font class="text colors_text">:</font> $65.00 </b>    </div></font>
+</div>
+</td>
+<td width="36%" align="right"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-amethyst-table-mat.htm" class="smalltext colors_text"> 
+<img src="/v/vspfiles/templates/266/images/Bullet_MoreInfo.gif" border="0" alt="more info"></a>
+<a href="/shoppingcart.asp?ProductCode=TMH%2DTRV%2DAMETHYST%2DTABLE%2DMAT"> 
+<IMG SRC="/v/vspfiles/templates/266/images/Buttons/btn_addtocart_small.gif" ALIGN=absmiddle BORDER=0></A> 
+</td> 
+</tr></table> 
+</div>
+</td> 
+<td valign="top" width="33%" class="v65-productDisplay-cell v65-productDetailInfo"> 
+<div>
+
+<table width="100%"cellpadding="0" cellspacing="0"><tr>
+<td width="64%" valign="top" class="v65-productDisplay-cell v65-productAvailability v65-infoButton">
+<div>
+<font class="pricecolor colors_productprice">    <div class="product_productprice">        <b><font class="text colors_text">:</font> $65.00 </b>    </div></font>
+</div>
+</td>
+<td width="36%" align="right"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-blue-mat.htm" class="smalltext colors_text"> 
+<img src="/v/vspfiles/templates/266/images/Bullet_MoreInfo.gif" border="0" alt="more info"></a>
+<a href="/shoppingcart.asp?ProductCode=TMH%2DTRV%2DBLUE%2DMAT"> 
+<IMG SRC="/v/vspfiles/templates/266/images/Buttons/btn_addtocart_small.gif" ALIGN=absmiddle BORDER=0></A> 
+</td> 
+</tr></table> 
+</div>
+</td> 
+</tr> 
+<tr class="v65-productDisplay-row"> 
+<td valign="top" class="v65-productDisplay-cell v65-productPhoto" width="33%" align="center"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-amethyst-gem-mat.htm" title="Amethyst Gem Double-Sided Travel Mahjong Mat" alt="Amethyst Gem Double-Sided Travel Mahjong Mat">
+<img src="//cdn4.volusion.store/srulk-fqudj/v/vspfiles/photos/TMH-TRV-AMETHYST-GEM-MAT-1.jpg?v-cache=1784423852" border=0 alt="Amethyst Gem Double-Sided Travel Mahjong Mat" title="Amethyst Gem Double-Sided Travel Mahjong Mat"></a>
+<script type="text/javascript">if(window.VCompare){VCompare('TMH-TRV-AMETHYST-GEM-MAT', 2);}</script>
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productPhoto" width="33%" align="center"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-amethyst-table-mat.htm" title="Amethyst Table Double-Sided Travel Mahjong Mat" alt="Amethyst Table Double-Sided Travel Mahjong Mat">
+<img src="//cdn4.volusion.store/srulk-fqudj/v/vspfiles/photos/TMH-TRV-AMETHYST-TABLE-MAT-1.jpg?v-cache=1784423852" border=0 alt="Amethyst Table Double-Sided Travel Mahjong Mat" title="Amethyst Table Double-Sided Travel Mahjong Mat"></a>
+<script type="text/javascript">if(window.VCompare){VCompare('TMH-TRV-AMETHYST-TABLE-MAT', 2);}</script>
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productPhoto" width="33%" align="center"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-blue-mat.htm" title="Blue Double-Sided Travel Mahjong Mat" alt="Blue Double-Sided Travel Mahjong Mat">
+<img src="//cdn4.volusion.store/srulk-fqudj/v/vspfiles/photos/TMH-TRV-BLUE-MAT-1.jpg?v-cache=1784423852" border=0 alt="Blue Double-Sided Travel Mahjong Mat" title="Blue Double-Sided Travel Mahjong Mat"></a>
+<script type="text/javascript">if(window.VCompare){VCompare('TMH-TRV-BLUE-MAT', 2);}</script>
+</td> 
+</tr> 
+<tr> 
+<td class="v65-productDisplay-cell v65-productRow-divider v65-product-colspan" background="/v/vspfiles/templates/266/images/Grid_Divider_Horizontal.gif" colspan="5"> 
+<img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="3" height="9" alt=""> 
+</td> 
+</tr> 
+<tr class="v65-productDisplay-row"> 
+<td valign="top" class="v65-productDisplay-cell v65-productName" width="33%"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-elec-blu-garden.htm" class="productnamecolor colors_productname" title="Electric Blue Garden Double-Sided Travel Mahjong Mat, TMH-TRV-ELEC-BLU-GARDEN"> 
+Electric Blue Garden Double-Sided Travel Mahjong Mat
+</a>
+</td> 
+<td class="v65-productDisplay-cell v65-productColumn-divider v65-product-rowspan" rowspan="3" background="/v/vspfiles/templates/266/images/Grid_Divider_Vertical.gif"> 
+<img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="9" height="3" alt=""> 
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productName" width="33%"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-elec-blu-trellis.htm" class="productnamecolor colors_productname" title="Electric Blue Trellis Double-Sided Travel Mahjong Mat, TMH-TRV-ELEC-BLU-TRELLIS"> 
+Electric Blue Trellis Double-Sided Travel Mahjong Mat
+</a>
+</td> 
+<td class="v65-productDisplay-cell v65-productColumn-divider v65-product-rowspan" rowspan="3" background="/v/vspfiles/templates/266/images/Grid_Divider_Vertical.gif"> 
+<img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="9" height="3" alt=""> 
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productName" width="33%"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-emerald-gem-mat.htm" class="productnamecolor colors_productname" title="Emerald Gem Double-Sided Travel Mahjong Mat, TMH-TRV-EMERALD-GEM-MAT"> 
+Emerald Gem Double-Sided Travel Mahjong Mat
+</a>
+</td> 
+</tr> 
+<tr class="v65-productDisplay-row"> 
+<td valign="top" width="33%" class="v65-productDisplay-cell v65-productDetailInfo"> 
+<div>
+
+<table width="100%"cellpadding="0" cellspacing="0"><tr>
+<td width="64%" valign="top" class="v65-productDisplay-cell v65-productAvailability v65-infoButton">
+<div>
+<font class="pricecolor colors_productprice">    <div class="product_productprice">        <b><font class="text colors_text">:</font> $65.00 </b>    </div></font>
+</div>
+</td>
+<td width="36%" align="right"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-elec-blu-garden.htm" class="smalltext colors_text"> 
+<img src="/v/vspfiles/templates/266/images/Bullet_MoreInfo.gif" border="0" alt="more info"></a>
+<a href="/shoppingcart.asp?ProductCode=TMH%2DTRV%2DELEC%2DBLU%2DGARDEN"> 
+<IMG SRC="/v/vspfiles/templates/266/images/Buttons/btn_addtocart_small.gif" ALIGN=absmiddle BORDER=0></A> 
+</td> 
+</tr></table> 
+</div>
+</td> 
+<td valign="top" width="33%" class="v65-productDisplay-cell v65-productDetailInfo"> 
+<div>
+
+<table width="100%"cellpadding="0" cellspacing="0"><tr>
+<td width="64%" valign="top" class="v65-productDisplay-cell v65-productAvailability v65-infoButton">
+<div>
+<font class="pricecolor colors_productprice">    <div class="product_productprice">        <b><font class="text colors_text">:</font> $65.00 </b>    </div></font>
+</div>
+</td>
+<td width="36%" align="right"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-elec-blu-trellis.htm" class="smalltext colors_text"> 
+<img src="/v/vspfiles/templates/266/images/Bullet_MoreInfo.gif" border="0" alt="more info"></a>
+<a href="/shoppingcart.asp?ProductCode=TMH%2DTRV%2DELEC%2DBLU%2DTRELLIS"> 
+<IMG SRC="/v/vspfiles/templates/266/images/Buttons/btn_addtocart_small.gif" ALIGN=absmiddle BORDER=0></A> 
+</td> 
+</tr></table> 
+</div>
+</td> 
+<td valign="top" width="33%" class="v65-productDisplay-cell v65-productDetailInfo"> 
+<div>
+
+<table width="100%"cellpadding="0" cellspacing="0"><tr>
+<td width="64%" valign="top" class="v65-productDisplay-cell v65-productAvailability v65-infoButton">
+<div>
+<font class="pricecolor colors_productprice">    <div class="product_productprice">        <b><font class="text colors_text">:</font> $65.00 </b>    </div></font>
+</div>
+</td>
+<td width="36%" align="right"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-emerald-gem-mat.htm" class="smalltext colors_text"> 
+<img src="/v/vspfiles/templates/266/images/Bullet_MoreInfo.gif" border="0" alt="more info"></a>
+<a href="/shoppingcart.asp?ProductCode=TMH%2DTRV%2DEMERALD%2DGEM%2DMAT"> 
+<IMG SRC="/v/vspfiles/templates/266/images/Buttons/btn_addtocart_small.gif" ALIGN=absmiddle BORDER=0></A> 
+</td> 
+</tr></table> 
+</div>
+</td> 
+</tr> 
+<tr class="v65-productDisplay-row"> 
+<td valign="top" class="v65-productDisplay-cell v65-productPhoto" width="33%" align="center"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-elec-blu-garden.htm" title="Electric Blue Garden Double-Sided Travel Mahjong Mat" alt="Electric Blue Garden Double-Sided Travel Mahjong Mat">
+<img src="//cdn4.volusion.store/srulk-fqudj/v/vspfiles/photos/TMH-TRV-ELEC-BLU-GARDEN-1.jpg?v-cache=1784423852" border=0 alt="Electric Blue Garden Double-Sided Travel Mahjong Mat" title="Electric Blue Garden Double-Sided Travel Mahjong Mat"></a>
+<script type="text/javascript">if(window.VCompare){VCompare('TMH-TRV-ELEC-BLU-GARDEN', 2);}</script>
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productPhoto" width="33%" align="center"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-elec-blu-trellis.htm" title="Electric Blue Trellis Double-Sided Travel Mahjong Mat" alt="Electric Blue Trellis Double-Sided Travel Mahjong Mat">
+<img src="//cdn4.volusion.store/srulk-fqudj/v/vspfiles/photos/TMH-TRV-ELEC-BLU-TRELLIS-1.jpg?v-cache=1784423852" border=0 alt="Electric Blue Trellis Double-Sided Travel Mahjong Mat" title="Electric Blue Trellis Double-Sided Travel Mahjong Mat"></a>
+<script type="text/javascript">if(window.VCompare){VCompare('TMH-TRV-ELEC-BLU-TRELLIS', 2);}</script>
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productPhoto" width="33%" align="center"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-emerald-gem-mat.htm" title="Emerald Gem Double-Sided Travel Mahjong Mat" alt="Emerald Gem Double-Sided Travel Mahjong Mat">
+<img src="//cdn4.volusion.store/srulk-fqudj/v/vspfiles/photos/TMH-TRV-EMERALD-GEM-MAT-1.jpg?v-cache=1784423852" border=0 alt="Emerald Gem Double-Sided Travel Mahjong Mat" title="Emerald Gem Double-Sided Travel Mahjong Mat"></a>
+<script type="text/javascript">if(window.VCompare){VCompare('TMH-TRV-EMERALD-GEM-MAT', 2);}</script>
+</td> 
+</tr> 
+<tr> 
+<td class="v65-productDisplay-cell v65-productRow-divider v65-product-colspan" background="/v/vspfiles/templates/266/images/Grid_Divider_Horizontal.gif" colspan="5"> 
+<img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="3" height="9" alt=""> 
+</td> 
+</tr> 
+<tr class="v65-productDisplay-row"> 
+<td valign="top" class="v65-productDisplay-cell v65-productName" width="33%"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-emerald-table-mat.htm" class="productnamecolor colors_productname" title="Emerald Table Double-Sided Travel Mahjong Mat, TMH-TRV-EMERALD-TABLE-MAT"> 
+Emerald Table Double-Sided Travel Mahjong Mat
+</a>
+</td> 
+<td class="v65-productDisplay-cell v65-productColumn-divider v65-product-rowspan" rowspan="3" background="/v/vspfiles/templates/266/images/Grid_Divider_Vertical.gif"> 
+<img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="9" height="3" alt=""> 
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productName" width="33%"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-lilac-garden-mat.htm" class="productnamecolor colors_productname" title="Lilac Garden Double-Sided Travel Mahjong Mat, TMH-TRV-LILAC-GARDEN-MAT"> 
+Lilac Garden Double-Sided Travel Mahjong Mat
+</a>
+</td> 
+<td class="v65-productDisplay-cell v65-productColumn-divider v65-product-rowspan" rowspan="3" background="/v/vspfiles/templates/266/images/Grid_Divider_Vertical.gif"> 
+<img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="9" height="3" alt=""> 
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productName" width="33%"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-lilac-trellis-mat.htm" class="productnamecolor colors_productname" title="Lilac Trellis Double-Sided Travel Mahjong Mat, TMH-TRV-LILAC-TRELLIS-MAT"> 
+Lilac Trellis Double-Sided Travel Mahjong Mat
+</a>
+</td> 
+</tr> 
+<tr class="v65-productDisplay-row"> 
+<td valign="top" width="33%" class="v65-productDisplay-cell v65-productDetailInfo"> 
+<div>
+
+<table width="100%"cellpadding="0" cellspacing="0"><tr>
+<td width="64%" valign="top" class="v65-productDisplay-cell v65-productAvailability v65-infoButton">
+<div>
+<font class="pricecolor colors_productprice">    <div class="product_productprice">        <b><font class="text colors_text">:</font> $65.00 </b>    </div></font>
+</div>
+</td>
+<td width="36%" align="right"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-emerald-table-mat.htm" class="smalltext colors_text"> 
+<img src="/v/vspfiles/templates/266/images/Bullet_MoreInfo.gif" border="0" alt="more info"></a>
+<a href="/shoppingcart.asp?ProductCode=TMH%2DTRV%2DEMERALD%2DTABLE%2DMAT"> 
+<IMG SRC="/v/vspfiles/templates/266/images/Buttons/btn_addtocart_small.gif" ALIGN=absmiddle BORDER=0></A> 
+</td> 
+</tr></table> 
+</div>
+</td> 
+<td valign="top" width="33%" class="v65-productDisplay-cell v65-productDetailInfo"> 
+<div>
+
+<table width="100%"cellpadding="0" cellspacing="0"><tr>
+<td width="64%" valign="top" class="v65-productDisplay-cell v65-productAvailability v65-infoButton">
+<div>
+<font class="pricecolor colors_productprice">    <div class="product_productprice">        <b><font class="text colors_text">:</font> $65.00 </b>    </div></font>
+</div>
+</td>
+<td width="36%" align="right"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-lilac-garden-mat.htm" class="smalltext colors_text"> 
+<img src="/v/vspfiles/templates/266/images/Bullet_MoreInfo.gif" border="0" alt="more info"></a>
+<a href="/shoppingcart.asp?ProductCode=TMH%2DTRV%2DLILAC%2DGARDEN%2DMAT"> 
+<IMG SRC="/v/vspfiles/templates/266/images/Buttons/btn_addtocart_small.gif" ALIGN=absmiddle BORDER=0></A> 
+</td> 
+</tr></table> 
+</div>
+</td> 
+<td valign="top" width="33%" class="v65-productDisplay-cell v65-productDetailInfo"> 
+<div>
+
+<table width="100%"cellpadding="0" cellspacing="0"><tr>
+<td width="64%" valign="top" class="v65-productDisplay-cell v65-productAvailability v65-infoButton">
+<div>
+<font class="pricecolor colors_productprice">    <div class="product_productprice">        <b><font class="text colors_text">:</font> $65.00 </b>    </div></font>
+</div>
+</td>
+<td width="36%" align="right"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-lilac-trellis-mat.htm" class="smalltext colors_text"> 
+<img src="/v/vspfiles/templates/266/images/Bullet_MoreInfo.gif" border="0" alt="more info"></a>
+<a href="/shoppingcart.asp?ProductCode=TMH%2DTRV%2DLILAC%2DTRELLIS%2DMAT"> 
+<IMG SRC="/v/vspfiles/templates/266/images/Buttons/btn_addtocart_small.gif" ALIGN=absmiddle BORDER=0></A> 
+</td> 
+</tr></table> 
+</div>
+</td> 
+</tr> 
+<tr class="v65-productDisplay-row"> 
+<td valign="top" class="v65-productDisplay-cell v65-productPhoto" width="33%" align="center"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-emerald-table-mat.htm" title="Emerald Table Double-Sided Travel Mahjong Mat" alt="Emerald Table Double-Sided Travel Mahjong Mat">
+<img src="//cdn4.volusion.store/srulk-fqudj/v/vspfiles/photos/TMH-TRV-EMERALD-TABLE-MAT-1.jpg?v-cache=1784423852" border=0 alt="Emerald Table Double-Sided Travel Mahjong Mat" title="Emerald Table Double-Sided Travel Mahjong Mat"></a>
+<script type="text/javascript">if(window.VCompare){VCompare('TMH-TRV-EMERALD-TABLE-MAT', 2);}</script>
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productPhoto" width="33%" align="center"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-lilac-garden-mat.htm" title="Lilac Garden Double-Sided Travel Mahjong Mat" alt="Lilac Garden Double-Sided Travel Mahjong Mat">
+<img src="//cdn4.volusion.store/srulk-fqudj/v/vspfiles/photos/TMH-TRV-LILAC-GARDEN-MAT-1.jpg?v-cache=1784423852" border=0 alt="Lilac Garden Double-Sided Travel Mahjong Mat" title="Lilac Garden Double-Sided Travel Mahjong Mat"></a>
+<script type="text/javascript">if(window.VCompare){VCompare('TMH-TRV-LILAC-GARDEN-MAT', 2);}</script>
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productPhoto" width="33%" align="center"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-lilac-trellis-mat.htm" title="Lilac Trellis Double-Sided Travel Mahjong Mat" alt="Lilac Trellis Double-Sided Travel Mahjong Mat">
+<img src="//cdn4.volusion.store/srulk-fqudj/v/vspfiles/photos/TMH-TRV-LILAC-TRELLIS-MAT-1.jpg?v-cache=1784423852" border=0 alt="Lilac Trellis Double-Sided Travel Mahjong Mat" title="Lilac Trellis Double-Sided Travel Mahjong Mat"></a>
+<script type="text/javascript">if(window.VCompare){VCompare('TMH-TRV-LILAC-TRELLIS-MAT', 2);}</script>
+</td> 
+</tr> 
+<tr> 
+<td class="v65-productDisplay-cell v65-productRow-divider v65-product-colspan" background="/v/vspfiles/templates/266/images/Grid_Divider_Horizontal.gif" colspan="5"> 
+<img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="3" height="9" alt=""> 
+</td> 
+</tr> 
+<tr class="v65-productDisplay-row"> 
+<td valign="top" class="v65-productDisplay-cell v65-productName" width="33%"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-plum-garden-mat.htm" class="productnamecolor colors_productname" title="Plum Garden Double-Sided Travel Mahjong Mat, TMH-TRV-PLUM-GARDEN-MAT"> 
+Plum Garden Double-Sided Travel Mahjong Mat
+</a>
+</td> 
+<td class="v65-productDisplay-cell v65-productColumn-divider v65-product-rowspan" rowspan="3" background="/v/vspfiles/templates/266/images/Grid_Divider_Vertical.gif"> 
+<img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="9" height="3" alt=""> 
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productName" width="33%"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-plum-trellis-mat.htm" class="productnamecolor colors_productname" title="Plum Trellis Double-Sided Travel Mahjong Mat, TMH-TRV-PLUM-TRELLIS-MAT"> 
+Plum Trellis Double-Sided Travel Mahjong Mat
+</a>
+</td> 
+<td class="v65-productDisplay-cell v65-productColumn-divider v65-product-rowspan" rowspan="3" background="/v/vspfiles/templates/266/images/Grid_Divider_Vertical.gif"> 
+<img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="9" height="3" alt=""> 
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productName" width="33%"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-purp-red-grn.htm" class="productnamecolor colors_productname" title="Purple/Red &amp; Green Double Sided Travel Mahjong Mat, TMH-TRV-PURP-RED-GRN"> 
+Purple/Red & Green Double Sided Travel Mahjong Mat
+</a>
+</td> 
+</tr> 
+<tr class="v65-productDisplay-row"> 
+<td valign="top" width="33%" class="v65-productDisplay-cell v65-productDetailInfo"> 
+<div>
+
+<table width="100%"cellpadding="0" cellspacing="0"><tr>
+<td width="64%" valign="top" class="v65-productDisplay-cell v65-productAvailability v65-infoButton">
+<div>
+<font class="pricecolor colors_productprice">    <div class="product_productprice">        <b><font class="text colors_text">:</font> $65.00 </b>    </div></font>
+</div>
+</td>
+<td width="36%" align="right"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-plum-garden-mat.htm" class="smalltext colors_text"> 
+<img src="/v/vspfiles/templates/266/images/Bullet_MoreInfo.gif" border="0" alt="more info"></a>
+<a href="/shoppingcart.asp?ProductCode=TMH%2DTRV%2DPLUM%2DGARDEN%2DMAT"> 
+<IMG SRC="/v/vspfiles/templates/266/images/Buttons/btn_addtocart_small.gif" ALIGN=absmiddle BORDER=0></A> 
+</td> 
+</tr></table> 
+</div>
+</td> 
+<td valign="top" width="33%" class="v65-productDisplay-cell v65-productDetailInfo"> 
+<div>
+
+<table width="100%"cellpadding="0" cellspacing="0"><tr>
+<td width="64%" valign="top" class="v65-productDisplay-cell v65-productAvailability v65-infoButton">
+<div>
+<font class="pricecolor colors_productprice">    <div class="product_productprice">        <b><font class="text colors_text">:</font> $65.00 </b>    </div></font>
+</div>
+</td>
+<td width="36%" align="right"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-plum-trellis-mat.htm" class="smalltext colors_text"> 
+<img src="/v/vspfiles/templates/266/images/Bullet_MoreInfo.gif" border="0" alt="more info"></a>
+<a href="/shoppingcart.asp?ProductCode=TMH%2DTRV%2DPLUM%2DTRELLIS%2DMAT"> 
+<IMG SRC="/v/vspfiles/templates/266/images/Buttons/btn_addtocart_small.gif" ALIGN=absmiddle BORDER=0></A> 
+</td> 
+</tr></table> 
+</div>
+</td> 
+<td valign="top" width="33%" class="v65-productDisplay-cell v65-productDetailInfo"> 
+<div>
+
+<table width="100%"cellpadding="0" cellspacing="0"><tr>
+<td width="64%" valign="top" class="v65-productDisplay-cell v65-productAvailability v65-infoButton">
+<div>
+<font class="pricecolor colors_productprice">    <div class="product_productprice">        <b><font class="text colors_text">:</font> $65.00 </b>    </div></font>
+</div>
+</td>
+<td width="36%" align="right"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-purp-red-grn.htm" class="smalltext colors_text"> 
+<img src="/v/vspfiles/templates/266/images/Bullet_MoreInfo.gif" border="0" alt="more info"></a>
+<a href="/shoppingcart.asp?ProductCode=TMH%2DTRV%2DPURP%2DRED%2DGRN"> 
+<IMG SRC="/v/vspfiles/templates/266/images/Buttons/btn_addtocart_small.gif" ALIGN=absmiddle BORDER=0></A> 
+</td> 
+</tr></table> 
+</div>
+</td> 
+</tr> 
+<tr class="v65-productDisplay-row"> 
+<td valign="top" class="v65-productDisplay-cell v65-productPhoto" width="33%" align="center"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-plum-garden-mat.htm" title="Plum Garden Double-Sided Travel Mahjong Mat" alt="Plum Garden Double-Sided Travel Mahjong Mat">
+<img src="//cdn4.volusion.store/srulk-fqudj/v/vspfiles/photos/TMH-TRV-PLUM-GARDEN-MAT-1.jpg?v-cache=1784423852" border=0 alt="Plum Garden Double-Sided Travel Mahjong Mat" title="Plum Garden Double-Sided Travel Mahjong Mat"></a>
+<script type="text/javascript">if(window.VCompare){VCompare('TMH-TRV-PLUM-GARDEN-MAT', 2);}</script>
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productPhoto" width="33%" align="center"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-plum-trellis-mat.htm" title="Plum Trellis Double-Sided Travel Mahjong Mat" alt="Plum Trellis Double-Sided Travel Mahjong Mat">
+<img src="//cdn4.volusion.store/srulk-fqudj/v/vspfiles/photos/TMH-TRV-PLUM-TRELLIS-MAT-1.jpg?v-cache=1784423852" border=0 alt="Plum Trellis Double-Sided Travel Mahjong Mat" title="Plum Trellis Double-Sided Travel Mahjong Mat"></a>
+<script type="text/javascript">if(window.VCompare){VCompare('TMH-TRV-PLUM-TRELLIS-MAT', 2);}</script>
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productPhoto" width="33%" align="center"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-purp-red-grn.htm" title="Purple/Red &amp; Green Double Sided Travel Mahjong Mat" alt="Purple/Red &amp; Green Double Sided Travel Mahjong Mat">
+<img src="//cdn4.volusion.store/srulk-fqudj/v/vspfiles/photos/TMH-TRV-PURP-RED-GRN-1.jpg?v-cache=1784423852" border=0 alt="Purple/Red &amp; Green Double Sided Travel Mahjong Mat" title="Purple/Red &amp; Green Double Sided Travel Mahjong Mat"></a>
+<script type="text/javascript">if(window.VCompare){VCompare('TMH-TRV-PURP-RED-GRN', 2);}</script>
+</td> 
+</tr> 
+<tr> 
+<td class="v65-productDisplay-cell v65-productRow-divider v65-product-colspan" background="/v/vspfiles/templates/266/images/Grid_Divider_Horizontal.gif" colspan="5"> 
+<img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="3" height="9" alt=""> 
+</td> 
+</tr> 
+<tr class="v65-productDisplay-row"> 
+<td valign="top" class="v65-productDisplay-cell v65-productName" width="33%"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-ruby-gem-mat.htm" class="productnamecolor colors_productname" title="Ruby Gem Double-Sided Travel Mahjong Mat, TMH-TRV-RUBY-GEM-MAT"> 
+Ruby Gem Double-Sided Travel Mahjong Mat
+</a>
+</td> 
+<td class="v65-productDisplay-cell v65-productColumn-divider v65-product-rowspan" rowspan="3" background="/v/vspfiles/templates/266/images/Grid_Divider_Vertical.gif"> 
+<img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="9" height="3" alt=""> 
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productName" width="33%"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-ruby-table-mat.htm" class="productnamecolor colors_productname" title="Ruby Table Double-Sided Travel Mahjong Mat, TMH-TRV-RUBY-TABLE-MAT"> 
+Ruby Table Double-Sided Travel Mahjong Mat
+</a>
+</td> 
+<td class="v65-productDisplay-cell v65-productColumn-divider v65-product-rowspan" rowspan="3" background="/v/vspfiles/templates/266/images/Grid_Divider_Vertical.gif"> 
+<img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="9" height="3" alt=""> 
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productName" width="33%"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-sapphire-gem-mat.htm" class="productnamecolor colors_productname" title="Sapphire Gem Double-Sided Travel Mahjong Mat, TMH-TRV-SAPPHIRE-GEM-MAT"> 
+Sapphire Gem Double-Sided Travel Mahjong Mat
+</a>
+</td> 
+</tr> 
+<tr class="v65-productDisplay-row"> 
+<td valign="top" width="33%" class="v65-productDisplay-cell v65-productDetailInfo"> 
+<div>
+
+<table width="100%"cellpadding="0" cellspacing="0"><tr>
+<td width="64%" valign="top" class="v65-productDisplay-cell v65-productAvailability v65-infoButton">
+<div>
+<font class="pricecolor colors_productprice">    <div class="product_productprice">        <b><font class="text colors_text">:</font> $65.00 </b>    </div></font>
+</div>
+</td>
+<td width="36%" align="right"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-ruby-gem-mat.htm" class="smalltext colors_text"> 
+<img src="/v/vspfiles/templates/266/images/Bullet_MoreInfo.gif" border="0" alt="more info"></a>
+<a href="/shoppingcart.asp?ProductCode=TMH%2DTRV%2DRUBY%2DGEM%2DMAT"> 
+<IMG SRC="/v/vspfiles/templates/266/images/Buttons/btn_addtocart_small.gif" ALIGN=absmiddle BORDER=0></A> 
+</td> 
+</tr></table> 
+</div>
+</td> 
+<td valign="top" width="33%" class="v65-productDisplay-cell v65-productDetailInfo"> 
+<div>
+
+<table width="100%"cellpadding="0" cellspacing="0"><tr>
+<td width="64%" valign="top" class="v65-productDisplay-cell v65-productAvailability v65-infoButton">
+<div>
+<font class="pricecolor colors_productprice">    <div class="product_productprice">        <b><font class="text colors_text">:</font> $65.00 </b>    </div></font>
+</div>
+</td>
+<td width="36%" align="right"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-ruby-table-mat.htm" class="smalltext colors_text"> 
+<img src="/v/vspfiles/templates/266/images/Bullet_MoreInfo.gif" border="0" alt="more info"></a>
+<a href="/shoppingcart.asp?ProductCode=TMH%2DTRV%2DRUBY%2DTABLE%2DMAT"> 
+<IMG SRC="/v/vspfiles/templates/266/images/Buttons/btn_addtocart_small.gif" ALIGN=absmiddle BORDER=0></A> 
+</td> 
+</tr></table> 
+</div>
+</td> 
+<td valign="top" width="33%" class="v65-productDisplay-cell v65-productDetailInfo"> 
+<div>
+
+<table width="100%"cellpadding="0" cellspacing="0"><tr>
+<td width="64%" valign="top" class="v65-productDisplay-cell v65-productAvailability v65-infoButton">
+<div>
+<font class="pricecolor colors_productprice">    <div class="product_productprice">        <b><font class="text colors_text">:</font> $65.00 </b>    </div></font>
+</div>
+</td>
+<td width="36%" align="right"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-sapphire-gem-mat.htm" class="smalltext colors_text"> 
+<img src="/v/vspfiles/templates/266/images/Bullet_MoreInfo.gif" border="0" alt="more info"></a>
+<a href="/shoppingcart.asp?ProductCode=TMH%2DTRV%2DSAPPHIRE%2DGEM%2DMAT"> 
+<IMG SRC="/v/vspfiles/templates/266/images/Buttons/btn_addtocart_small.gif" ALIGN=absmiddle BORDER=0></A> 
+</td> 
+</tr></table> 
+</div>
+</td> 
+</tr> 
+<tr class="v65-productDisplay-row"> 
+<td valign="top" class="v65-productDisplay-cell v65-productPhoto" width="33%" align="center"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-ruby-gem-mat.htm" title="Ruby Gem Double-Sided Travel Mahjong Mat" alt="Ruby Gem Double-Sided Travel Mahjong Mat">
+<img src="//cdn4.volusion.store/srulk-fqudj/v/vspfiles/photos/TMH-TRV-RUBY-GEM-MAT-1.jpg?v-cache=1784423852" border=0 alt="Ruby Gem Double-Sided Travel Mahjong Mat" title="Ruby Gem Double-Sided Travel Mahjong Mat"></a>
+<script type="text/javascript">if(window.VCompare){VCompare('TMH-TRV-RUBY-GEM-MAT', 2);}</script>
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productPhoto" width="33%" align="center"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-ruby-table-mat.htm" title="Ruby Table Double-Sided Travel Mahjong Mat" alt="Ruby Table Double-Sided Travel Mahjong Mat">
+<img src="//cdn4.volusion.store/srulk-fqudj/v/vspfiles/photos/TMH-TRV-RUBY-TABLE-MAT-1.jpg?v-cache=1784423852" border=0 alt="Ruby Table Double-Sided Travel Mahjong Mat" title="Ruby Table Double-Sided Travel Mahjong Mat"></a>
+<script type="text/javascript">if(window.VCompare){VCompare('TMH-TRV-RUBY-TABLE-MAT', 2);}</script>
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productPhoto" width="33%" align="center"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-sapphire-gem-mat.htm" title="Sapphire Gem Double-Sided Travel Mahjong Mat" alt="Sapphire Gem Double-Sided Travel Mahjong Mat">
+<img src="//cdn4.volusion.store/srulk-fqudj/v/vspfiles/photos/TMH-TRV-SAPPHIRE-GEM-MAT-1.jpg?v-cache=1784423852" border=0 alt="Sapphire Gem Double-Sided Travel Mahjong Mat" title="Sapphire Gem Double-Sided Travel Mahjong Mat"></a>
+<script type="text/javascript">if(window.VCompare){VCompare('TMH-TRV-SAPPHIRE-GEM-MAT', 2);}</script>
+</td> 
+</tr> 
+<tr> 
+<td class="v65-productDisplay-cell v65-productRow-divider v65-product-colspan" background="/v/vspfiles/templates/266/images/Grid_Divider_Horizontal.gif" colspan="5"> 
+<img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="3" height="9" alt=""> 
+</td> 
+</tr> 
+<tr class="v65-productDisplay-row"> 
+<td valign="top" class="v65-productDisplay-cell v65-productName" width="33%"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-sapphire-table-mat.htm" class="productnamecolor colors_productname" title="Sapphire Table Double-Sided Travel Mahjong Mat, TMH-TRV-SAPPHIRE-TABLE-MAT"> 
+Sapphire Table Double-Sided Travel Mahjong Mat
+</a>
+</td> 
+<td class="v65-productDisplay-cell v65-productColumn-divider v65-product-rowspan" rowspan="3" background="/v/vspfiles/templates/266/images/Grid_Divider_Vertical.gif"> 
+<img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="9" height="3" alt=""> 
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productName" width="33%"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-teal-garden-mat.htm" class="productnamecolor colors_productname" title="Teal Garden Double-Sided Travel Mahjong Mat, TMH-TRV-TEAL-GARDEN-MAT"> 
+Teal Garden Double-Sided Travel Mahjong Mat
+</a>
+</td> 
+<td class="v65-productDisplay-cell v65-productColumn-divider v65-product-rowspan" rowspan="3" background="/v/vspfiles/templates/266/images/Grid_Divider_Vertical.gif"> 
+<img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="9" height="3" alt=""> 
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productName" width="33%"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-teal-trellis-mat.htm" class="productnamecolor colors_productname" title="Teal Trellis Double-Sided Travel Mahjong Mat, TMH-TRV-TEAL-TRELLIS-MAT"> 
+Teal Trellis Double-Sided Travel Mahjong Mat
+</a>
+</td> 
+</tr> 
+<tr class="v65-productDisplay-row"> 
+<td valign="top" width="33%" class="v65-productDisplay-cell v65-productDetailInfo"> 
+<div>
+
+<table width="100%"cellpadding="0" cellspacing="0"><tr>
+<td width="64%" valign="top" class="v65-productDisplay-cell v65-productAvailability v65-infoButton">
+<div>
+<font class="pricecolor colors_productprice">    <div class="product_productprice">        <b><font class="text colors_text">:</font> $65.00 </b>    </div></font>
+</div>
+</td>
+<td width="36%" align="right"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-sapphire-table-mat.htm" class="smalltext colors_text"> 
+<img src="/v/vspfiles/templates/266/images/Bullet_MoreInfo.gif" border="0" alt="more info"></a>
+<a href="/shoppingcart.asp?ProductCode=TMH%2DTRV%2DSAPPHIRE%2DTABLE%2DMAT"> 
+<IMG SRC="/v/vspfiles/templates/266/images/Buttons/btn_addtocart_small.gif" ALIGN=absmiddle BORDER=0></A> 
+</td> 
+</tr></table> 
+</div>
+</td> 
+<td valign="top" width="33%" class="v65-productDisplay-cell v65-productDetailInfo"> 
+<div>
+
+<table width="100%"cellpadding="0" cellspacing="0"><tr>
+<td width="64%" valign="top" class="v65-productDisplay-cell v65-productAvailability v65-infoButton">
+<div>
+<font class="pricecolor colors_productprice">    <div class="product_productprice">        <b><font class="text colors_text">:</font> $65.00 </b>    </div></font>
+</div>
+</td>
+<td width="36%" align="right"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-teal-garden-mat.htm" class="smalltext colors_text"> 
+<img src="/v/vspfiles/templates/266/images/Bullet_MoreInfo.gif" border="0" alt="more info"></a>
+<a href="/shoppingcart.asp?ProductCode=TMH%2DTRV%2DTEAL%2DGARDEN%2DMAT"> 
+<IMG SRC="/v/vspfiles/templates/266/images/Buttons/btn_addtocart_small.gif" ALIGN=absmiddle BORDER=0></A> 
+</td> 
+</tr></table> 
+</div>
+</td> 
+<td valign="top" width="33%" class="v65-productDisplay-cell v65-productDetailInfo"> 
+<div>
+
+<table width="100%"cellpadding="0" cellspacing="0"><tr>
+<td width="64%" valign="top" class="v65-productDisplay-cell v65-productAvailability v65-infoButton">
+<div>
+<font class="pricecolor colors_productprice">    <div class="product_productprice">        <b><font class="text colors_text">:</font> $65.00 </b>    </div></font>
+</div>
+</td>
+<td width="36%" align="right"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-teal-trellis-mat.htm" class="smalltext colors_text"> 
+<img src="/v/vspfiles/templates/266/images/Bullet_MoreInfo.gif" border="0" alt="more info"></a>
+<a href="/shoppingcart.asp?ProductCode=TMH%2DTRV%2DTEAL%2DTRELLIS%2DMAT"> 
+<IMG SRC="/v/vspfiles/templates/266/images/Buttons/btn_addtocart_small.gif" ALIGN=absmiddle BORDER=0></A> 
+</td> 
+</tr></table> 
+</div>
+</td> 
+</tr> 
+<tr class="v65-productDisplay-row"> 
+<td valign="top" class="v65-productDisplay-cell v65-productPhoto" width="33%" align="center"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-sapphire-table-mat.htm" title="Sapphire Table Double-Sided Travel Mahjong Mat" alt="Sapphire Table Double-Sided Travel Mahjong Mat">
+<img src="//cdn4.volusion.store/srulk-fqudj/v/vspfiles/photos/TMH-TRV-SAPPHIRE-TABLE-MAT-1.jpg?v-cache=1784423852" border=0 alt="Sapphire Table Double-Sided Travel Mahjong Mat" title="Sapphire Table Double-Sided Travel Mahjong Mat"></a>
+<script type="text/javascript">if(window.VCompare){VCompare('TMH-TRV-SAPPHIRE-TABLE-MAT', 2);}</script>
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productPhoto" width="33%" align="center"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-teal-garden-mat.htm" title="Teal Garden Double-Sided Travel Mahjong Mat" alt="Teal Garden Double-Sided Travel Mahjong Mat">
+<img src="//cdn4.volusion.store/srulk-fqudj/v/vspfiles/photos/TMH-TRV-TEAL-GARDEN-MAT-1.jpg?v-cache=1784423852" border=0 alt="Teal Garden Double-Sided Travel Mahjong Mat" title="Teal Garden Double-Sided Travel Mahjong Mat"></a>
+<script type="text/javascript">if(window.VCompare){VCompare('TMH-TRV-TEAL-GARDEN-MAT', 2);}</script>
+</td> 
+<td valign="top" class="v65-productDisplay-cell v65-productPhoto" width="33%" align="center"> 
+<a href="https://www.mccabestheaterandliving.com/product-p/tmh-trv-teal-trellis-mat.htm" title="Teal Trellis Double-Sided Travel Mahjong Mat" alt="Teal Trellis Double-Sided Travel Mahjong Mat">
+<img src="//cdn4.volusion.store/srulk-fqudj/v/vspfiles/photos/TMH-TRV-TEAL-TRELLIS-MAT-1.jpg?v-cache=1784423852" border=0 alt="Teal Trellis Double-Sided Travel Mahjong Mat" title="Teal Trellis Double-Sided Travel Mahjong Mat"></a>
+<script type="text/javascript">if(window.VCompare){VCompare('TMH-TRV-TEAL-TRELLIS-MAT', 2);}</script>
+</td> 
+</tr> 
+<tr> 
+<td class="v65-productDisplay-cell v65-productRow-bottom v65-product-colspan" background="/v/vspfiles/templates/266/images/Grid_Divider_Horizontal.gif" colspan="5"> 
+<img src="/v/vspfiles/templates/266/images/clear1x1.gif" width="3" height="9"> 
+</td> 
+</tr> 
+</table> 
+
+								
+								</td>
+							</tr>
+						</table>			
+						
+						
+
+              <table cellpadding="3" cellspacing="0" width="100%">
+                <tr> 
+                  <td height=10>&nbsp;</td>
+                  <td height=10>&nbsp;</td>
+                </tr>
+                <tr> 
+                  <td>&nbsp; </td>
+                  <td align="right"> 
+                    
+                  </td>
+                </tr>
+              </table>
+
+
+              </form>
+
+          </td>
+        </tr>
+      </table>
+</div>
+
+</section>
+          </div>
+        </div>
+
+        <footer class="footer" data-ui-block="footer-1">
+          <div class="footer__section pt--base">
+            <div class="container">
+              <div class="row">
+                <div class="flex-sm-and-up">
+                  <div class="footer__logo col-xs-12 col-sm-6 col-md-3 col-lg-2 text-center-xs"></div>
+
+                  <div class="col-xs-12 col-sm-6 col-md-3 col-lg-2 text-center-xs text-right-sm">
+                    <section class="microblock social" data-v-edit-region="Footer Social Media Links">
+                      <div class="microblock__body">
+                        <ul class="social__list list-unstyled">
+                          <li class="social__item">
+                            <a class="social__link facebook" href="//www.facebook.com/" target="_blank" title="Like McCabe's Theater & Living on Facebook">
+                              <p class="sr-only">Like McCabe's Theater & Living on Facebook</p>
+                              <i class="vol-theme-icon vol-theme-icon--facebook"></i>
+                            </a>
+                          </li>
+                          <li class="social__item">
+                            <a class="social__link twitter" href="//twitter.com/" target="_blank" title="Follow McCabe's Theater & Living on Twitter">
+                              <p class="sr-only">Follow McCabe's Theater & Living on Twitter</p>
+                              <i class="vol-theme-icon vol-theme-icon--twitter"></i>
+                            </a>
+                          </li>
+                          <li class="social__item">
+                            <a class="social__link instagram" href="//instagram.com/" target="_blank" title="Follow McCabe's Theater & Living on Instagram">
+                              <p class="sr-only">Follow McCabe's Theater & Living on Instagram</p>
+                              <i class="vol-theme-icon vol-theme-icon--instagram"></i>
+                            </a>
+                          </li>
+                          <li class="social__item">
+                            <a class="social__link pinterest" href="//www.pinterest.com/" target="_blank" title="Pin McCabe's Theater & Living to Pinterest">
+                              <p class="sr-only">Pin McCabe's Theater & Living to Pinterest</p>
+                              <i class="vol-theme-icon vol-theme-icon--pinterest"></i>
+                            </a>
+                          </li>
+                        </ul>
+                      </div>
+                    </section>
+                  </div>
+
+                  <div class="col-xs-12 text-center-sm-and-down text-right-md col-md-6 col-lg-4">
+                    <ul class="link-column list-unstyled clearfix" data-v-edit-region="Link Column 1">
+                      <li class="link-column__item"><a href="/aboutus.asp" title="About McCabe's Theater & Living">ABOUT</a></li>
+                      <li class="link-column__item"><a href="/myaccount.asp" title="My Account" rel="nofollow">MY ACCOUNT</a></li>
+                      <li class="link-column__item"><a href="/v/vspfiles/my-boards.html" title="My inspiration board">MY BOARDS</a></li>
+                      <li class="link-column__item"><a href="/Contact_Us_a/83.htm" title="Contact McCabe's Theater & Living">CONTACT</a></li>
+                    </ul>
+                  </div>
+
+                  <div class="elist__wrapper col-xs-12 col-lg-4 text-center-xs text-center-md text-right-lg">
+                    <div class="col-sm-8 col-sm-offset-2 col-md-6col-md-offset-3 col-lg-12 col-lg-offset-0 no-pad">
+                      <section class="microblock elist">
+                        <div class="microblock__body">
+                          <h2 class="footer__title elist__title" data-v-edit-region="Elist Title">NEWSLETTER</h2>
+                          <form class="elist__form" name="MailingList" method="post" action="/mailinglist_subscribe.asp">
+                            <label for="elistEmailAddress" class="elist__label sr-only">Enter your email Address</label>
+                            <div class="input-group">
+                              <input class="elist__input form-control" id="elistEmailAddress" type="text" name="emailaddress" value="" placeholder="Email Address" />
+                              <span class="input-group-btn">
+                                <button class="elist__submit btn" type="submit" name="Submit">SUBMIT</button>
+                              </span>
+                            </div>
+                          </form>
+                        </div>
+                      </section>
+                    </div>
+                  </div>
+
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="footer__section">
+            <div class="container">
+              <div class="row">
+                <div class="col-xs-12 col-md-6 text-center-xs">
+                  <section class="copyright microblock">
+                    <a href="/terms.asp" title="Terms">
+                      <span data-v-edit-region="Copyright">
+                        &copy; Copyright <span class="insertYear">2015</span>&nbsp;McCabe's Theater & Living.
+                      </span>
+                    </a>
+                    <span class="copyright__line" data-v-edit-region="Built With">
+                      All Rights Reserved.
+                      <span class="mc-vol-powered"><a href="http://www.volusion.com" target="_blank" rel="nofollow">Ecommerce Software by Volusion</a></span>
+                      Ecommerce Software by Volusion
+                    </span>
+                  </section>
+                </div>
+
+                <div class="col-xs-12 col-md-6 text-center-xs text-right-sm-and-up">
+                  <div class="credit-cards microblock">
+                    <i class="vol-theme-icon vol-theme-icon--paypal"></i>
+                    <i class="vol-theme-icon vol-theme-icon--visa"></i>
+                    <i class="vol-theme-icon vol-theme-icon--discover"></i>
+                    <i class="vol-theme-icon vol-theme-icon--mastercard"></i>
+                    <i class="vol-theme-icon vol-theme-icon--amex"></i>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </footer>
+
+      </div>
+    </section>
+  </article>
+
+  <!-- IE9 FIX - CATEGORY GRID LAYOUT -->
+  <!--[if IE 9]><script>"searchresults.asp"===PageName()&&!function(e){e(document).ready(function(){var r,t=0,n=0,i=new Array,h=0;e(".v-product").each(function(){if(r=e(this),h=r.position().top,n!=h){for(currentDiv=0;currentDiv<i.length;currentDiv++)i[currentDiv].height(t);i.length=0,n=h,t=r.height(),i.push(r)}else i.push(r),t=t<r.height()?r.height():t;for(currentDiv=0;currentDiv<i.length;currentDiv++)i[currentDiv].height(t)})})}($jQueryModern);</script><![endif]-->
+
+  <script src="/v/vspfiles/templates/266/js/min/template.min.js?v=20260706cart1"></script>
+  <script id="mc-cart-float-finalizer-20260706">
+  (function(w,d){
+    "use strict";
+    function fix(){
+      var nodes=d.querySelectorAll(".mc-cart-float,#mc-cart-float,a.mc-cart-float,[class*='mc-cart-float']");
+      for(var i=0;i<nodes.length;i++){
+        var el=nodes[i];
+        try{
+          el.style.setProperty("display","flex","important");
+          el.style.setProperty("align-items","center","important");
+          el.style.setProperty("justify-content","center","important");
+          el.style.setProperty("width","52px","important");
+          el.style.setProperty("height","52px","important");
+          el.style.setProperty("min-width","52px","important");
+          el.style.setProperty("max-width","52px","important");
+          el.style.setProperty("min-height","52px","important");
+          el.style.setProperty("max-height","52px","important");
+          el.style.setProperty("padding","0","important");
+          el.style.setProperty("border-radius","999px","important");
+          el.style.setProperty("overflow","hidden","important");
+          el.style.setProperty("line-height","0","important");
+        }catch(e){}
+        var svg=el.querySelector&&el.querySelector("svg");
+        if(svg){try{
+          svg.style.setProperty("position","static","important");
+          svg.style.setProperty("display","block","important");
+          svg.style.setProperty("width","20px","important");
+          svg.style.setProperty("height","20px","important");
+          svg.style.setProperty("margin","0","important");
+          svg.style.setProperty("transform","none","important");
+        }catch(e2){}}
+      }
+    }
+    fix();
+    if(d.readyState==="loading")d.addEventListener("DOMContentLoaded",fix);
+    w.addEventListener("load",fix);
+    [100,400,900,1600,2800,5000].forEach(function(ms){w.setTimeout(fix,ms);});
+    w.setInterval(fix,500);
+  })(window,document);
+  </script>
+
+
+
+
+
+
+
+<!-- MC removed 20260630: Palliser leather modal, swatch grid, room planner, member login gate — archived under archive/removed-pdp-features-20260630/ -->
+<style id="mc-removed-features-kill-switch">
+#mcPlannerLoginGate,.mc-planner-login-gate,#mcPlannerMemberPriceAboveAtc,#mcLeatherSwatchStrip,#mcLeatherPicker,#mcLeatherRow,#mcPlannerRow,#mcPlannerRow2,#mcPlannerBtn,#mc-inline-config,#mcConfigurationBlock,.wm-overlay,#wmOpen,.mc-pdp-room-planner-box,.mc-configuration-rh,.mc-pdp-member-pricing--planner,#mccabe-room-planner-pricing-summary{display:none!important;visibility:hidden!important;height:0!important;max-height:0!important;margin:0!important;padding:0!important;overflow:hidden!important;opacity:0!important;pointer-events:none!important}
+</style>
+<script id="mc-pdp-auth-loader-minimal">
+(function () {
+  var FP = "20260624A";
+  if (String(window.__MC_DEPLOY_FP__ || "") === FP) {
+  } else if (
+    !document.documentElement.getAttribute("data-mc-pdp-auth-reload") &&
+    !document.documentElement.getAttribute("data-mc-pdp-auth-head-boot") &&
+    !document.querySelector('script[src*="mc-pdp-auth-cta-fix.js"]')
+  ) {
+    /* mc-pdp-auth-cta-boot (above, in <head>) is the primary loader. This block only
+       fires as a fallback when that loader did not already inject the script — it must
+       never remove/re-inject a copy that is already present, or the PDP script runs twice
+       (MC_PDP_AUTH_DUPLICATE_LOAD_FIX_20260713). */
+    document.documentElement.setAttribute("data-mc-pdp-auth-reload", "1");
+    var s = document.createElement("script");
+    s.src = "/v/vspfiles/js/mc-pdp-auth-cta-fix.js?mcrd=" + Date.now();
+    s.async = false;
+    (document.head || document.documentElement).appendChild(s);
+  }
+  window.openPlannerOverlay = function () {};
+  window.mcEnsurePlannerLoginGate = function () { return null; };
+  window.mcSetPlannerLoginGateVisible = function () {};
+  window.mcApplyPlannerAtcDisabledState = function () {};
+  window.mcOpenWmLeatherModal = function () {};
+  window.mcOpenWmLeatherOverlay = function () { return false; };
+  window.mcForceInitWmLeather = function () { return false; };
+  window.mcTryInitWmLeather = function () { return false; };
+  window.mcMountInlineConfig = function () {};
+})();
+</script>
+
+<!-- ========= HOMEPAGE-ONLY HERO + MENU CONTROL (CLEAN) ========= -->
+
+<script>
+(function () {
+  try {
+    if (typeof window.mcSyncHomeBodyClass === "function") window.mcSyncHomeBodyClass();
+    else if (typeof window.mcPathIsHomepage === "function") {
+      if (window.mcPathIsHomepage()) document.body.classList.add("is-home");
+      else document.body.classList.remove("is-home");
+    }
+  } catch (e) {}
+})();
+</script>
+
+<style>
+/* ===============================
+   HERO MENU (HOMEPAGE ONLY)
+   Clear of home/cart icons, proportional to viewport
+   =============================== */
+
+#slideshow-container .hero-menu {
+  padding-left: max(40px, 5vw);
+  padding-right: max(40px, 5vw);
+  gap: clamp(14px, 2.5vw, 22px);
+  box-sizing: border-box;
+  max-width: 100%;
+}
+
+.hero-nav {
+  display: flex;
+  gap: clamp(14px, 2.5vw, 22px);
+}
+
+.hero-nav a,
+.hero-cart,
+#slideshow-container .hero-menu a,
+#slideshow-container .hero-nav a {
+  color: #fff !important;
+  -webkit-text-fill-color: #fff !important;
+  font-size: clamp(12px, 1.4vw, 15px);
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-decoration: none;
+  padding: 0 clamp(4px, 0.5vw, 8px);
+  position: relative;
+  z-index: 2;
+  transition: background 0.15s ease, color 0.15s ease;
+  border-radius: 4px;
+}
+
+.hero-nav a:hover,
+.hero-nav a:focus-visible {
+  background: rgba(255, 255, 255, 0.22);
+  color: #fff;
+}
+
+body.is-home .hero-menu::before {
+  content: "";
+  position: absolute;
+  inset: -15px -800px;
+  background: rgba(0,0,0,0.65);
+  backdrop-filter: blur(0px);
+  border-radius: 10px;
+  opacity: 0;
+  transition: opacity 100ms ease;
+  z-index: 1;
+  pointer-events: none;
+}
+
+body.is-home .hero-menu:hover::before {
+  opacity: 1;
+}
+
+/* ===============================
+   HERO VIDEO (HOMEPAGE ONLY)
+   =============================== */
+body:not(.is-home) .mc-hero-video {
+  display: none !important;
+}
+
+/* ===============================
+   VOLUSION MENU LOGIC
+   =============================== */
+
+
+/* Show Volusion menu on non-home */
+body:not(.is-home) #display_menu_1,
+body:not(.is-home) header.header nav.menu {
+  display: block !important;
+}
+
+/* Non-home: keep menu in flow so header flex can center it (no position: absolute / left: 117%) */
+body:not(.is-home) #display_menu_1 {
+  position: relative !important;
+  top: auto !important;
+  left: auto !important;
+  transform: none !important;
+  z-index: 1 !important;
+  width: 100% !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+/* Center the nav list, single row, no stacking (match hero menu gap) */
+body:not(.is-home) #display_menu_1 {
+  display: flex !important;
+  flex-direction: row !important;
+  flex-wrap: nowrap !important;
+  justify-content: center !important;
+  align-items: center !important;
+}
+body:not(.is-home) #display_menu_1 .main-menu .vnav--level1,
+body:not(.is-home) #display_menu_1 .main-menu .vnav--horizontal.vnav--level1,
+body:not(.is-home) #display_menu_1 > ul.vnav--level1,
+body:not(.is-home) #display_menu_1 > ul.vnav--horizontal.vnav--level1,
+body:not(.is-home) #display_menu_1 > ul {
+  position: static !important;
+  transform: none !important;
+  top: auto !important;
+  left: auto !important;
+  display: flex !important;
+  flex-direction: row !important;
+  flex-wrap: nowrap !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 32px !important;
+  padding-left: max(80px, 8vw) !important;
+  padding-right: max(80px, 8vw) !important;
+  box-sizing: border-box !important;
+  margin: 0 auto !important;
+  width: 100% !important;
+  max-width: 100% !important;
+}
+body:not(.is-home) .microblock.main-menu {
+  padding: 0 !important;
+  box-sizing: border-box !important;
+}
+body:not(.is-home) #display_menu_1 > ul > li,
+body:not(.is-home) #display_menu_1 .vnav--level1 > li {
+  display: flex !important;
+  flex: 0 0 auto !important;
+  margin: 0 6px !important;
+  padding: 0 !important;
+}
+body:not(.is-home) #display_menu_1 > ul > li > a,
+body:not(.is-home) #display_menu_1 .vnav--level1 > li > a {
+  white-space: nowrap !important;
+  padding: 0 8px !important;
+}
+
+/* Remove hidden cart list item from nav flow so centering math stays correct */
+body:not(.is-home) #display_menu_1 li.mc-vnav-cart,
+body:not(.is-home) #display_menu_1 .mc-vnav-cart {
+  display: none !important;
+  width: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+
+
+/* Typography match for non-home */
+body:not(.is-home) #display_menu_1 .vnav--level1 > li > a,
+body:not(.is-home) #display_menu_1 .vnav--horizontal.vnav--level1 > li > a,
+body:not(.is-home) #display_menu_1 .vnav__link,
+body:not(.is-home) #display_menu_1 .vnav__label {
+  color: #2a2a2a !important;
+  font-family: "Cormorant Garamond", Georgia, "Times New Roman", serif !important;
+  font-size: 15px !important;
+  font-weight: 500 !important;
+  letter-spacing: 0.12em !important;
+  text-transform: uppercase !important;
+  text-decoration: none !important;
+  padding: 0 8px !important;
+  white-space: nowrap !important;
+  line-height: 1.2 !important;
+  transition: color 0.15s ease !important;
+}
+
+body:not(.is-home) #display_menu_1 .vnav--level1 > li > a:hover,
+body:not(.is-home) #display_menu_1 .vnav--horizontal.vnav--level1 > li > a:hover,
+body:not(.is-home) #display_menu_1 .vnav__link:hover,
+body:not(.is-home) #display_menu_1 .vnav__label:hover,
+body:not(.is-home) #display_menu_1 .vnav--level1 > li > a:focus-visible,
+body:not(.is-home) #display_menu_1 .vnav__link:focus-visible,
+body:not(.is-home) #display_menu_1 .vnav__label:focus-visible {
+  color: #0a0a0a !important;
+  background: rgba(0, 0, 0, 0.08) !important;
+  border-radius: 4px !important;
+}
+
+/* Submenu typography on non-home — left-aligned, lighter than top level */
+body:not(.is-home) #display_menu_1 .vnav--level2,
+body:not(.is-home) #display_menu_1 .vnav--level3,
+body:not(.is-home) #display_menu_1 .vnav__submenu {
+  text-align: left !important;
+}
+
+body:not(.is-home) #display_menu_1 .vnav--level2 a,
+body:not(.is-home) #display_menu_1 .vnav--level3 a,
+body:not(.is-home) #display_menu_1 .vnav__submenu a {
+  color: #2a2a2a !important;
+  font-family: "Cormorant Garamond", Georgia, "Times New Roman", serif !important;
+  font-size: 14px !important;
+  font-weight: 400 !important;
+  letter-spacing: 0.08em !important;
+  text-transform: uppercase !important;
+  text-decoration: none !important;
+  text-align: left !important;
+  transition: color 0.15s ease !important;
+}
+
+body:not(.is-home) #display_menu_1 .vnav--level2 a:hover,
+body:not(.is-home) #display_menu_1 .vnav--level3 a:hover,
+body:not(.is-home) #display_menu_1 .vnav__submenu a:hover,
+body:not(.is-home) #display_menu_1 .vnav--level2 a:focus-visible,
+body:not(.is-home) #display_menu_1 .vnav--level3 a:focus-visible,
+body:not(.is-home) #display_menu_1 .vnav__submenu a:focus-visible {
+  color: #0a0a0a !important;
+  background: rgba(0, 0, 0, 0.07) !important;
+}
+
+
+/* Mobile */
+@media (max-width: 991px) {
+  body.is-home .hero-menu {
+    display: none !important;
+  }
+}
+</style>
+<style>
+/* ===== PRODUCT PAGE FIXES ===== */
+body.mc-product-page #content_area h1,
+body.mc-product-page #content_area h2,
+body.mc-product-page #content_area h3,
+body.mc-product-page #content_area h4,
+body.mc-product-page #content_area .tab,
+body.mc-product-page #content_area .tab a,
+body.mc-product-page #content_area .resp-tab-item,
+body.mc-product-page #content_area .resp-tabs-list li {
+  font-style: normal !important;
+}
+
+/* option labels – EXACT same font for every option header (NUMBER OF SEATS, CONFIGURATION, SELECT A LEATHER) + padding */
+body.productdetails #content_area #options_table label,
+body.mc-product-page #content_area #options_table label,
+body.productdetails #v65-product-parent #options_table label,
+body.mc-product-page #v65-product-parent #options_table label,
+body.productdetails #content_area #options_table .productoptionname,
+body.mc-product-page #content_area #options_table .productoptionname,
+body.productdetails #content_area #options_table td.productoptionname,
+body.mc-product-page #content_area #options_table td.productoptionname,
+body.productdetails #content_area #options_table td[align="right"],
+body.mc-product-page #content_area #options_table td[align="right"],
+body.productdetails #content_area #options_table td:first-child,
+body.mc-product-page #content_area #options_table td:first-child,
+body.productdetails #content_area #options_table select:not(.mc-native-leather),
+body.mc-product-page #content_area #options_table select:not(.mc-native-leather),
+body.productdetails #v65-product-parent #options_table select:not(.mc-native-leather),
+body.mc-product-page #v65-product-parent #options_table select:not(.mc-native-leather),
+body.productdetails #content_area table[id*="options_table"] label,
+body.mc-product-page #content_area table[id*="options_table"] label,
+body.productdetails #content_area table[id*="options_table"] .productoptionname,
+body.mc-product-page #content_area table[id*="options_table"] .productoptionname,
+body.productdetails #content_area table[id*="options_table"] td[align="right"],
+body.mc-product-page #content_area table[id*="options_table"] td[align="right"],
+body.productdetails #content_area table[id*="options_table"] td:first-child,
+body.mc-product-page #content_area table[id*="options_table"] td:first-child,
+body.productdetails #content_area table[id*="options_table"] select:not(.mc-native-leather),
+body.mc-product-page #content_area table[id*="options_table"] select:not(.mc-native-leather),
+body.productdetails #content_area #mcLeatherHeader,
+body.mc-product-page #content_area #mcLeatherHeader,
+body.productdetails #content_area .mc-option-accordion__label,
+body.mc-product-page #content_area .mc-option-accordion__label,
+body.productdetails #content_area .mc-option-accordion__header,
+body.mc-product-page #content_area .mc-option-accordion__header {
+  font-style: normal !important;
+  font-weight: 400 !important;
+  font-size: 13px !important;
+  letter-spacing: 0.16em !important;
+  text-transform: uppercase !important;
+  color: #777 !important;
+  text-align: left !important;
+  margin-left: 0 !important;
+  padding: 10px 14px 10px 0 !important;
+  line-height: 1.2 !important;
+}
+body.mc-theater-seating-pdp #mcConfigurationBlock .mc-configuration-rh__pieces,
+body.mc-theater-seating-pdp #mcConfigurationBlock .mc-configuration-rh__pieces *,
+html.mc-paragon-pdp body #mcConfigurationBlock .mc-configuration-rh__pieces,
+html.mc-paragon-pdp body #mcConfigurationBlock .mc-configuration-rh__pieces * {
+  font-size: 13px !important;
+  line-height: 1.45 !important;
+}
+/* Product tabs – more padding so labels are not too short */
+body.mc-product-page #content_area .tab,
+body.mc-product-page #content_area .tab a,
+body.mc-product-page #content_area .resp-tab-item,
+body.mc-product-page #content_area .resp-tabs-list li {
+  padding: 12px 18px !important;
+}
+
+/* Prevent options running off at ~1205px */
+@media (max-width: 1205px) {
+  body.mc-product-page #content_area,
+  body.mc-product-page #content_area .product-details,
+  body.mc-product-page #content_area table[cellpadding] {
+    max-width: 102% !important;
+    box-sizing: border-box !important;
+  }
+  body.mc-product-page #content_area #options_table,
+  body.mc-product-page #content_area table[id*="options_table"] {
+    width: 100% !important;
+    max-width: 100% !important;
+    table-layout: fixed !important;
+  }
+  body.mc-product-page #content_area .mc-pdp-options-td {
+    max-width: 100% !important;
+  }
+}
+
+/* Product detail: tab table spacing and tab label height */
+#vCSS_mainform > table:nth-child(4) > tbody:nth-child(1) > tr:nth-child(1) > td:nth-child(1) > table:nth-child(1) > tbody:nth-child(1) > tr:nth-child(1) > td:nth-child(1) > table:nth-child(1) {
+  display: inline-block !important;
+  margin-top: 2px !important;
+  margin-bottom: 9px !important;
+  margin-left: 48px !important;
+}
+#Header_ProductDetail_ProductDetails_span {
+  height: 40px !important;
+  display: none !important;
+  margin-left: 4px;
+  padding: 15px;
+}
+
+/* At 962px and up: keep accordion UI visible with aligned ">" (same behavior desktop/mobile) */
+@media (min-width: 962px) {
+  body.mc-product-page #content_area #options_table .mc-accordion-row td:first-child,
+  body.mc-product-page #content_area table[id*="options_table"] .mc-accordion-row td:first-child {
+    display: none !important;
+    visibility: hidden !important;
+  }
+  body.mc-product-page #content_area .mc-option-accordion .mc-option-accordion__header,
+  body.mc-product-page #content_area .mc-option-accordion .mc-option-accordion__selected,
+  body.mc-product-page #content_area .mc-option-accordion .mc-option-accordion__panel {
+    display: block !important;
+  }
+  body.mc-product-page #content_area .mc-option-accordion .mc-option-accordion-native,
+  body.mc-product-page #content_area .mc-option-accordion select {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    clip: rect(0,0,0,0) !important;
+    overflow: hidden !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+  }
+  body.mc-product-page #content_area .mc-option-accordion__header {
+    display: flex !important;
+    align-items: center !important;
+    justify-content: space-between !important;
+  }
+}
+
+/* At 961px and below: accordion only; hide table label cell (label is in accordion header); panel closed by default.
+ * Do NOT clip raw #options_table selects — wrapSelectsAsAccordions may be unused; clipping would hide all native options. */
+@media (max-width: 961px) {
+  body.mc-product-page #content_area #options_table .mc-accordion-row td:first-child,
+  body.mc-product-page #content_area table[id*="options_table"] .mc-accordion-row td:first-child {
+    display: none !important;
+  }
+  body.mc-product-page #content_area .mc-option-accordion .mc-option-accordion-native,
+  body.mc-product-page #content_area .mc-option-accordion select {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    clip: rect(0,0,0,0) !important;
+    overflow: hidden !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+  }
+  body.mc-product-page #content_area .mc-option-accordion__header {
+    display: flex !important;
+    align-items: center !important;
+    justify-content: space-between !important;
+    width: 100% !important;
+    cursor: pointer !important;
+    padding: 10px 0 !important;
+    border-bottom: 1px solid #eee !important;
+    font-size: 13px !important;
+    font-weight: 400 !important;
+    letter-spacing: 0.06em !important;
+    text-transform: uppercase !important;
+    color: #686868 !important;
+    line-height: 1.2 !important;
+  }
+  body.mc-product-page #content_area .mc-option-accordion__label {
+    font-size: 13px !important;
+    font-weight: 400 !important;
+    letter-spacing: 0.06em !important;
+    text-transform: uppercase !important;
+    color: #686868 !important;
+  }
+  body.mc-product-page #content_area .mc-option-accordion__toggle {
+    flex-shrink: 0 !important;
+    margin-left: 8px !important;
+    cursor: pointer !important;
+    -webkit-appearance: none !important;
+    appearance: none !important;
+    border: none !important;
+    background: none !important;
+    background-color: transparent !important;
+    padding: 0 !important;
+    min-width: 20px !important;
+    width: 20px !important;
+    height: 20px !important;
+    font-size: 20px !important;
+    line-height: 20px !important;
+    color: #686868 !important;
+    outline: none !important;
+    box-shadow: none !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    align-self: center !important;
+    margin-top: 0 !important;
+    vertical-align: middle !important;
+    font-family: Arial, sans-serif !important;
+    position: relative !important;
+    top: -1px !important;
+  }
+  body.mc-product-page #content_area .mc-option-accordion__toggle:hover,
+  body.mc-product-page #content_area .mc-option-accordion__toggle:focus {
+    border: none !important;
+    background: none !important;
+    box-shadow: none !important;
+    outline: none !important;
+  }
+  body.mc-product-page #content_area .mc-option-accordion__selected {
+    display: block !important;
+    padding: 4px 0 0 0 !important;
+    margin: 0 !important;
+    background: transparent !important;
+    border: none !important;
+    font-weight: normal !important;
+    font-size: 13px !important;
+    color: #333 !important;
+  }
+  body.mc-product-page #content_area .mc-option-accordion__panel {
+    display: none !important;
+    padding: 8px 0 12px 0 !important;
+    border: none !important;
+    background: transparent !important;
+  }
+  body.mc-product-page #content_area .mc-option-accordion__panel.mc-option-accordion__panel--open {
+    display: block !important;
+  }
+  body.mc-product-page #content_area .mc-option-accordion__choice {
+    display: block !important;
+    width: 100% !important;
+    text-align: left !important;
+    padding: 8px 12px !important;
+    margin: 0 0 4px 0 !important;
+    border: 1px solid #ddd !important;
+    border-radius: 6px !important;
+    background: #fff !important;
+    cursor: pointer !important;
+    font-size: 14px !important;
+  }
+  body.mc-product-page #content_area .mc-option-accordion__choice:hover {
+    background: #f5f5f5 !important;
+    border-color: #999 !important;
+  }
+}
+
+/* Hide "No planner selections" box; show summary only when there are selections */
+body.mc-product-page #content_area #mcPlannerSummary {
+  display: none !important;
+}
+body.mc-product-page #content_area #mcPlannerSummary.mc-has-selections {
+  display: flex !important;
+  align-items: center !important;
+  min-width: 0 !important;
+  flex: 1 1 auto !important;
+}
+
+/* Add to Cart: same look as Room Planner – one white button with cart icon inside */
+body.mc-product-page #content_area .mc-atc-row {
+  display: flex !important;
+  align-items: center !important;
+  flex-wrap: nowrap !important;
+  gap: 0 !important;
+  background: transparent !important;
+  border: none !important;
+  padding: 0 !important;
+}
+/* Wrapper = visual button (matches #mcPlannerBtn exactly) */
+body.mc-product-page #content_area .mc-atc-button-wrap {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 8px !important;
+  min-width: 150px !important;
+  max-width: 100% !important;
+  padding: 10px 14px !important;
+  border: 1px solid #000 !important;
+  border-radius: 10px !important;
+  background: #000 !important;
+  background-color: #000 !important;
+  color: #fff !important;
+  font-size: 14px !important;
+  font-weight: 300 !important;
+  letter-spacing: 0.15em !important;
+  text-transform: uppercase !important;
+  text-align: center !important;
+  cursor: pointer !important;
+  box-sizing: border-box !important;
+  font-family: inherit !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+  margin-top: 30px;
+}
+body.mc-product-page #content_area .mc-atc-button-wrap:hover {
+  background: #000 !important;
+  background-color: #000 !important;
+  color: #fff !important;
+  border-color: #000 !important;
+}
+/* Input inside wrapper: no box, same font so it aligns with icon */
+body.mc-product-page #content_area .mc-atc-button-wrap input[type="submit"],
+body.mc-product-page #content_area .mc-atc-button-wrap button[name="btnaddtocart"] {
+  display: inline-block !important;
+  flex: 0 0 auto !important;
+  width: 100% !important;
+  max-width: 100% !important;
+  min-width: 0 !important;
+  padding: 0 !important;
+  border: none !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  background-color: transparent !important;
+  background-image: none !important;
+  -webkit-appearance: none !important;
+  appearance: none !important;
+  box-shadow: none !important;
+  color: inherit !important;
+  font-size: inherit !important;
+  font-weight: inherit !important;
+  letter-spacing: inherit !important;
+  text-transform: inherit !important;
+  cursor: pointer !important;
+  font-family: inherit !important;
+}
+body.mc-product-page #content_area .mc-atc-button-wrap .mc-cart-icon-wrapper,
+body.mc-product-page #content_area .mc-atc-button-wrap .mc-cart-icon {
+  flex-shrink: 0 !important;
+  display: inline-block !important;
+  vertical-align: middle !important;
+}
+
+/* No separate container – every wrapper of Add to Cart transparent */
+body.mc-product-page #content_area .v65-product-addtocart,
+body.mc-product-page #content_area .v65-product-addtocart div,
+body.mc-product-page #v65-product-parent .v65-product-addtocart,
+body.mc-product-page #v65-product-parent .v65-product-addtocart div,
+body.mc-product-page #content_area td:has(input[name="btnaddtocart"]),
+body.mc-product-page #content_area tr:has(input[name="btnaddtocart"]),
+body.mc-product-page #content_area div:has(input[name="btnaddtocart"]),
+body.mc-product-page #content_area form:has(input[name="btnaddtocart"]),
+body.mc-product-page #content_area table:has(input[name="btnaddtocart"]),
+body.mc-product-page #content_area tbody:has(input[name="btnaddtocart"]),
+body.mc-product-page #content_area [itemprop="offers"],
+body.mc-product-page #v65-product-parent td:has(input[name="btnaddtocart"]),
+body.mc-product-page #v65-product-parent tr:has(input[name="btnaddtocart"]),
+body.mc-product-page #v65-product-parent form:has(input[name="btnaddtocart"]),
+body.mc-product-page #v65-product-parent table:has(input[name="btnaddtocart"]) {
+  background: transparent !important;
+  background-color: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+}
+
+/* Room Planner + Product Summary: same pill button (not the leather ">" button).
+   Include #v65-product-parent — on some PDPs #mc-inline-config is not under #content_area. */
+body.mc-product-page #content_area #mcPlannerBtn,
+body.mc-product-page #content_area #mcProductSummaryBtn,
+body.mc-product-page #v65-product-parent #mcPlannerBtn,
+body.mc-product-page #v65-product-parent #mcProductSummaryBtn,
+body.productdetails #content_area #mcPlannerBtn,
+body.productdetails #content_area #mcProductSummaryBtn,
+body.productdetails #v65-product-parent #mcPlannerBtn,
+body.productdetails #v65-product-parent #mcProductSummaryBtn,
+body.mc-theater-seating-pdp #content_area #mcPlannerBtn,
+body.mc-theater-seating-pdp #content_area #mcProductSummaryBtn,
+body.mc-theater-seating-pdp #v65-product-parent #mcPlannerBtn,
+body.mc-theater-seating-pdp #v65-product-parent #mcProductSummaryBtn {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 12px !important;
+  min-width: 200px !important;
+  max-width: 50% !important;
+  padding: 14px 28px !important;
+  border: 1px solid #d0d0d0 !important;
+  border-radius: 0px !important;
+  background: #fff !important;
+  color: #545454 !important;
+  font-size: 12px !important;
+  font-weight: 400 !important;
+  letter-spacing: 0.15em !important;
+  text-transform: uppercase !important;
+  text-align: center !important;
+  cursor: pointer !important;
+  box-sizing: border-box !important;
+  font-family: inherit !important;
+  height: 42px !important;
+  text-decoration: none !important;
+  -webkit-appearance: none !important;
+  appearance: none !important;
+}
+body.mc-product-page #content_area #mcPlannerBtn:hover,
+body.mc-product-page #content_area #mcProductSummaryBtn:hover,
+body.mc-product-page #v65-product-parent #mcPlannerBtn:hover,
+body.mc-product-page #v65-product-parent #mcProductSummaryBtn:hover,
+body.productdetails #content_area #mcPlannerBtn:hover,
+body.productdetails #content_area #mcProductSummaryBtn:hover,
+body.productdetails #v65-product-parent #mcPlannerBtn:hover,
+body.productdetails #v65-product-parent #mcProductSummaryBtn:hover,
+body.mc-theater-seating-pdp #content_area #mcPlannerBtn:hover,
+body.mc-theater-seating-pdp #content_area #mcProductSummaryBtn:hover,
+body.mc-theater-seating-pdp #v65-product-parent #mcPlannerBtn:hover,
+body.mc-theater-seating-pdp #v65-product-parent #mcProductSummaryBtn:hover {
+  background: #f5f5f5 !important;
+  color: #111 !important;
+  border-color: #333 !important;
+}
+body.mc-product-page #content_area #mcProductSummaryBtn:visited,
+body.mc-product-page #v65-product-parent #mcProductSummaryBtn:visited,
+body.productdetails #content_area #mcProductSummaryBtn:visited,
+body.productdetails #v65-product-parent #mcProductSummaryBtn:visited,
+body.mc-theater-seating-pdp #content_area #mcProductSummaryBtn:visited,
+body.mc-theater-seating-pdp #v65-product-parent #mcProductSummaryBtn:visited {
+  color: #111 !important;
+}
+
+/* Room Planner + WM configuration caption: theater seating PDPs only (overrides inline-flex rules above). */
+body:not(.mc-theater-seating-pdp).mc-product-page #content_area #mcPlannerBtn,
+body:not(.mc-theater-seating-pdp).productdetails #content_area #mcPlannerBtn,
+body:not(.mc-theater-seating-pdp).mc-product-page #v65-product-parent #mcPlannerBtn,
+body:not(.mc-theater-seating-pdp).productdetails #v65-product-parent #mcPlannerBtn,
+body:not(.mc-theater-seating-pdp).mc-product-page #content_area #mcConfigurationBlock,
+body:not(.mc-theater-seating-pdp).productdetails #content_area #mcConfigurationBlock,
+body:not(.mc-theater-seating-pdp).mc-product-page #v65-product-parent #mcConfigurationBlock,
+body:not(.mc-theater-seating-pdp).productdetails #v65-product-parent #mcConfigurationBlock {
+  display: none !important;
+  visibility: hidden !important;
+  pointer-events: none !important;
+}
+
+/* Select a Leather ">" button – 20px, vertically aligned, no box (matches accordion toggle) */
+body.mc-product-page #content_area #mcLeatherBtn {
+  -webkit-appearance: none !important;
+  appearance: none !important;
+  border: none !important;
+  background: none !important;
+  background-color: transparent !important;
+  box-shadow: none !important;
+  outline: none !important;
+  padding: 0 !important;
+  min-width: 20px !important;
+  width: 20px !important;
+  height: 20px !important;
+  color: #686868 !important;
+  font-size: 20px !important;
+  line-height: 20px !important;
+  cursor: pointer !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  align-self: center !important;
+  margin-top: 0 !important;
+  vertical-align: middle !important;
+  font-family: Arial, sans-serif !important;
+  position: relative !important;
+  top: -1px !important;
+}
+body.mc-product-page #content_area #mcLeatherHeaderRow {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: space-between !important;
+  gap: 8px !important;
+  flex-wrap: nowrap !important;
+  min-height: 20px !important;
+}
+body.mc-product-page #content_area .mc-option-accordion__header {
+  min-height: 20px !important;
+  align-items: center !important;
+}
+body.mc-product-page #content_area #mcLeatherBtn:hover,
+body.mc-product-page #content_area #mcLeatherBtn:focus {
+  border: none !important;
+  background: none !important;
+  background-color: transparent !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+/* Accordion ">" toggle – 20px, vertically aligned, no box */
+body.mc-product-page #content_area .mc-option-accordion__toggle {
+  -webkit-appearance: none !important;
+  appearance: none !important;
+  border: none !important;
+  background: none !important;
+  background-color: transparent !important;
+  box-shadow: none !important;
+  outline: none !important;
+  padding: 0 !important;
+  min-width: 20px !important;
+  width: 20px !important;
+  height: 20px !important;
+  font-size: 20px !important;
+  line-height: 20px !important;
+  color: #686868 !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  align-self: center !important;
+  margin-top: 0 !important;
+  vertical-align: middle !important;
+  font-family: Arial, sans-serif !important;
+  position: relative !important;
+  top: -1px !important;
+}
+body.mc-product-page #content_area .mc-option-accordion__toggle:hover,
+body.mc-product-page #content_area .mc-option-accordion__toggle:focus {
+  border: none !important;
+  background: none !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+/* Mini leather swatches – no grey boxes, strictly uniform size */
+body.mc-product-page #content_area #mcLeatherSwatchStrip {
+  display: flex !important;
+  align-items: center !important;
+  gap: 6px !important;
+  flex-wrap: wrap !important;
+}
+body.mc-product-page #content_area #mcLeatherSwatchStrip .wm-swatch,
+body.mc-product-page #content_area #mcLeatherSwatchStrip > *,
+body.mc-product-page #content_area #mcLeatherSwatchStrip a {
+  border: none !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  width: 32px !important;
+  height: 32px !important;
+  min-width: 32px !important;
+  min-height: 32px !important;
+  max-width: 32px !important;
+  max-height: 32px !important;
+  flex-shrink: 0 !important;
+  flex-grow: 0 !important;
+  display: block !important;
+  padding: 0 !important;
+  box-sizing: border-box !important;
+  overflow: hidden !important;
+}
+body.mc-product-page #content_area #mcLeatherSwatchStrip .wm-swatch img,
+body.mc-product-page #content_area #mcLeatherSwatchStrip img {
+  border-radius: 50% !important;
+  width: 32px !important;
+  height: 32px !important;
+  min-width: 32px !important;
+  min-height: 32px !important;
+  max-width: 32px !important;
+  max-height: 32px !important;
+  object-fit: cover !important;
+  display: block !important;
+}
+body.mc-product-page #content_area .wm-swatch {
+  border: 1px solid #ddd !important;
+  border-radius: 6px !important;
+  overflow: hidden !important;
+}
+body.mc-product-page #content_area .wm-swatch img {
+  width: 100% !important;
+  height: 100% !important;
+  object-fit: cover !important;
+  display: block !important;
+}
+
+/* tabs inline on desktop */
+@media (min-width: 992px){
+  body.mc-product-page #content_area .resp-tabs-list,
+  body.mc-product-page #content_area ul.resp-tabs-list,
+  body.mc-product-page #content_area .ui-tabs-nav,
+  body.mc-product-page #content_area .TabbedPanelsTabGroup {
+    display: flex !important;
+    flex-wrap: nowrap !important;
+    align-items: center !important;
+    gap: 8px !important;
+    overflow-x: auto !important;
+    padding: 0 !important;
+    margin: 0 0 12px 0 !important;
+  }
+
+  body.mc-product-page #content_area .resp-tabs-list li,
+  body.mc-product-page #content_area .ui-tabs-nav li,
+  body.mc-product-page #content_area .TabbedPanelsTab {
+    float: none !important;
+    width: auto !important;
+    display: inline-block !important;
+    white-space: nowrap !important;
+    margin: 0 !important;
+  }
+
+  .productdetails table:has(td[class*="vCSS_tab"]) {
+    display: block !important;
+    margin-bottom: -12px !important;
+    margin-top: 5px !important;
+    margin-left: 0 !important;
+    overflow: visible !important;
+  }
+  .productdetails tbody:has(td[class*="vCSS_tab"]) {
+    display: block !important;
+  }
+  .productdetails tr:has(> td[class*="vCSS_tab"]) {
+    display: flex !important;
+    flex-wrap: nowrap !important;
+    height: auto !important;
+    align-items: stretch !important;
+    gap: 0 !important;
+  }
+  .productdetails td[class*="vCSS_tab"] {
+    display: inline-flex !important;
+    align-items: center !important;
+    float: none !important;
+    width: auto !important;
+    height: 60px !important;
+    vertical-align: bottom !important;
+    white-space: nowrap !important;
+    overflow: visible !important;
+    padding: 15px !important;
+    margin: 0 16px 0 0 !important;
+  }
+  .productdetails td[class*="vCSS_tab"]:last-child {
+    margin-right: 0 !important;
+  }
+  .productdetails td[class*="vCSS_tab"] span,
+  .productdetails td[class*="vCSS_tab"] a,
+  .productdetails td[class*="vCSS_tab"] div {
+    white-space: nowrap !important;
+    overflow: visible !important;
+    width: auto !important;
+    height: auto !important;
+    display: inline !important;
+    max-width: none !important;
+  }
+  .productdetails span#Header_ProductDetail_ProductDetails_span,
+  .productdetails span#Header_ProductDetail_TechSpecs_span,
+  .productdetails span#Header_ProductDetail_ExtInfo_span,
+  .productdetails td#Header_ProductDetail_ProductDetails.vCSS_tab_unselected span#Header_ProductDetail_ProductDetails_span,
+  .productdetails td#Header_ProductDetail_TechSpecs.vCSS_tab_unselected span#Header_ProductDetail_TechSpecs_span,
+  .productdetails td#Header_ProductDetail_ExtInfo.vCSS_tab_unselected span#Header_ProductDetail_ExtInfo_span {
+    margin-bottom: 0 !important;
+    min-height: 60px !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    line-height: 1.2 !important;
+    padding: 15px;
+    margin-left: 0 !important;
+  }
+  .productdetails td[class*="vCSS_tab"] > span,
+  .productdetails td[class*="vCSS_tab"] > a,
+  .productdetails td[class*="vCSS_tab"] > div {
+    min-height: 60px !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    margin-bottom: 0 !important;
+    line-height: 1.2 !important;
+  }
+
+  /* Tab row: flex layout (works with or without :has()) */
+  #content_area tr.mc-tabs-row,
+  .productdetails tr.mc-tabs-row {
+    display: flex !important;
+    flex-wrap: nowrap !important;
+    align-items: stretch !important;
+    gap: 0 !important;
+    margin-bottom: 8px !important;
+  }
+
+  /* Same tab styles without body/productdetails so they always apply when present */
+  #content_area td[class*="vCSS_tab"] {
+    display: inline-flex !important;
+    align-items: center !important;
+    float: none !important;
+    width: auto !important;
+    height: 60px !important;
+    white-space: nowrap !important;
+    overflow: visible !important;
+    padding: 16px 30px !important;
+    margin: 0 16px 0 0 !important;
+    vertical-align: bottom !important;
+  }
+  #content_area td[class*="vCSS_tab"]:last-child {
+    margin-right: 0 !important;
+  }
+  #content_area td[class*="vCSS_tab"] span,
+  #content_area td[class*="vCSS_tab"] a,
+  #content_area td[class*="vCSS_tab"] div {
+    white-space: nowrap !important;
+    overflow: visible !important;
+    width: auto !important;
+    max-width: none !important;
+    display: inline !important;
+  }
+}
+
+/* Desktop PDP media layout: vspfiles/css/custom-safe.css (single float-based block at file end). */
+
+/* Stack media above options from 962px down (so 962px = stacked + desktop-style options) */
+@media (max-width: 991px){
+  html body.productdetails #content_area #v65-product-parent [itemprop="offers"],
+  html body.mc-product-page #content_area #v65-product-parent [itemprop="offers"],
+  html body.productdetails #content_area [itemprop="offers"],
+  html body.mc-product-page #content_area [itemprop="offers"] {
+    margin-left: 0 !important;
+    margin-top: 12px !important;
+    clear: both !important;
+  }
+  body.mc-product-page #content_area .mc-pdp-media-td,
+  body.mc-product-page #content_area .mc-pdp-options-td {
+    display: block !important;
+    width: 100% !important;
+    float: none !important;
+    max-width: 100% !important;
+    box-sizing: border-box !important;
+  }
+
+  body.mc-product-page #content_area .mc-pdp-media-td {
+    text-align: center !important;
+    margin: 0 0 4px 0 !important;
+    padding: 0 0 0 0 !important;
+    clear: both !important;
+    display: flex !important;
+    flex-direction: column !important;
+    align-items: center !important;
+  }
+
+  body.mc-product-page #content_area #product_photo,
+  body.mc-product-page #content_area .vcss_img_wrap,
+  body.mc-product-page #content_area .vCSS_img_wrap,
+  body.mc-product-page #content_area .main-image,
+  body.mc-product-page #content_area #product_photo_td {
+    display: block !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    margin: 0 auto 12px auto !important;
+    float: none !important;
+    clear: both !important;
+    text-align: center !important;
+    box-sizing: border-box !important;
+    order: 1 !important;
+  }
+
+  body.mc-product-page #content_area #product_photo img,
+  body.mc-product-page #content_area .vcss_img_wrap img,
+  body.mc-product-page #content_area .vCSS_img_wrap img,
+  body.mc-product-page #content_area .main-image img,
+  body.mc-product-page #content_area img#main-image {
+    display: block !important;
+    width: auto !important;
+    max-width: 100% !important;
+    height: auto !important;
+    margin: 0 auto !important;
+  }
+
+  /* Mobile: main image centered first, then alt images – up to 4 per row, single centered column */
+  body.mc-product-page #content_area .mc-pdp-media-td,
+  body.mc-product-page #content_area [id*="product_photo_td"],
+  body.mc-product-page #content_area td:has(#product_photo),
+  body.mc-product-page #content_area td:has(.vcss_img_wrap),
+  body.mc-product-page #content_area td:has(.main-image) {
+    display: flex !important;
+    flex-direction: column !important;
+    align-items: center !important;
+    width: 100% !important;
+    padding-bottom: 0 !important;
+    margin-bottom: 0 !important;
+  }
+  body.mc-product-page #content_area .mc-pdp-options-td,
+  body.mc-product-page #content_area td:has(.colors_pricebox),
+  body.mc-product-page #content_area td:has(#priceWithOptions) {
+    padding-top: 4px !important;
+    margin-top: 0 !important;
+  }
+  /* Collapse large gaps: any row that contains both media and price */
+  body.mc-product-page #content_area table[cellpadding] tr,
+  #content_area #v65-product-parent tr,
+  .productdetails #v65-product-parent tbody tr {
+    min-height: 0 !important;
+  }
+  /* Alt images: centered under main (block + inline-block; no flex / broad altview selectors) */
+  body.mc-product-page #content_area #altviews,
+  body.mc-product-page #content_area .altviews,
+  body.mc-product-page #content_area span#altviews,
+  .productdetails #content_area #altviews,
+  .productdetails #content_area .altviews,
+  #content_area #altviews,
+  #content_area .altviews {
+    display: block !important;
+    text-align: center !important;
+    margin: 8px auto 36px auto !important;
+    padding: 0 !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    float: none !important;
+    clear: both !important;
+    order: 2 !important;
+    box-sizing: border-box !important;
+  }
+  body.mc-product-page #content_area #altviews a,
+  body.mc-product-page #content_area .altviews a,
+  body.mc-product-page #content_area #altviews > div,
+  body.mc-product-page #content_area .altviews > div,
+  body.mc-product-page #content_area span#altviews a,
+  body.mc-product-page #content_area span#altviews > div,
+  .productdetails #content_area #altviews a,
+  .productdetails #content_area .altviews a,
+  #content_area #altviews a,
+  #content_area .altviews a,
+  #content_area #altviews > div,
+  #content_area .altviews > div {
+    display: inline-block !important;
+    width: 64px !important;
+    min-width: 64px !important;
+    max-width: 64px !important;
+    vertical-align: top !important;
+    margin: 0 5px 8px 5px !important;
+  }
+  body.mc-product-page #content_area #altviews img,
+  body.mc-product-page #content_area .altviews img,
+  body.mc-product-page #content_area span#altviews img,
+  .productdetails #content_area #altviews img,
+  #content_area #altviews img,
+  #content_area .altviews img {
+    width: 100% !important;
+    max-width: 64px !important;
+    height: auto !important;
+    max-height: 64px !important;
+    object-fit: contain !important;
+    display: block !important;
+  }
+  /* Wrapper for centering alt thumbnails – applied by JS */
+  #content_area .mc-altviews-outer {
+    display: block !important;
+    text-align: center !important;
+    width: 100% !important;
+    margin: 4px 0 !important;
+    padding: 0 !important;
+    order: 2 !important;
+  }
+  /* Force any cell containing altviews to full width and center its content */
+  #content_area td:has(#altviews),
+  #content_area td:has(.altviews) {
+    display: block !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    text-align: center !important;
+  }
+  /* Tighter gap: options/price block — clear below alt thumbnails (no overlap) */
+  #content_area .mc-pdp-options-td,
+  #content_area td:has(.colors_pricebox),
+  #content_area td:has(#priceWithOptions) {
+    padding-top: 12px !important;
+    margin-top: 8px !important;
+  }
+
+  body.mc-product-page #content_area .option_pricing,
+  body.productdetails #content_area .option_pricing,
+  body.mc-product-page #v65-product-parent .option_pricing,
+  body.productdetails #v65-product-parent .option_pricing,
+  body.mc-product-page #content_area #priceWithOptions,
+  body.productdetails #content_area #priceWithOptions,
+  body.mc-product-page #v65-product-parent #priceWithOptions,
+  body.productdetails #v65-product-parent #priceWithOptions,
+  body.mc-product-page #content_area #priceWithOptions ~ div,
+  body.productdetails #content_area #priceWithOptions ~ div,
+  body.mc-product-page #v65-product-parent #priceWithOptions ~ div,
+  body.productdetails #v65-product-parent #priceWithOptions ~ div {
+    margin-top: 14px !important;
+    clear: both !important;
+    text-align: left !important;
+  }
+  #content_area .mc-pdp-media-td,
+  #content_area [id*="product_photo_td"] {
+    margin-bottom: 4px !important;
+    padding-bottom: 0 !important;
+  }
+
+  /* Hide duplicate/second price on mobile */
+  body.mc-product-page #content_area .product_productprice,
+  body.mc-product-page #content_area .product_list_price,
+  body.mc-product-page #v65-product-parent .product_productprice,
+  body.mc-product-page #v65-product-parent .product_list_price {
+    display: none !important;
+  }
+
+  nav.push-menu,
+  #push-nav__menu,
+  .push-menu__menu-wrapper {
+    left: 0 !important;
+    right: 0 !important;
+    width: 100vw !important;
+    max-width: 100vw !important;
+    box-sizing: border-box !important;
+    overflow-x: hidden !important;
+  }
+
+  #push-nav__menu ul,
+  .push-menu__menu-wrapper ul,
+  .mc-mobile-vnav,
+  .mc-mobile-vnav__sub,
+  .mc-mobile-vnav__item,
+  .mc-mobile-vnav__row,
+  .mc-mobile-vnav__link {
+    width: 100% !important;
+    max-width: 100% !important;
+    box-sizing: border-box !important;
+  }
+
+  .mc-mobile-vnav__link {
+    display: block !important;
+    white-space: normal !important;
+    overflow-wrap: anywhere !important;
+    word-break: break-word !important;
+    padding-right: 36px !important;
+  }
+
+  .productdetails table:has(td[class*="vCSS_tab"]) {
+    display: block !important;
+  }
+  .productdetails tbody:has(td[class*="vCSS_tab"]) {
+    display: block !important;
+  }
+  .productdetails tr:has(> td[class*="vCSS_tab"]) {
+    display: flex !important;
+    flex-wrap: nowrap !important;
+    height: auto !important;
+    align-items: stretch !important;
+  }
+  .productdetails td[class*="vCSS_tab"] {
+    display: inline-flex !important;
+    align-items: center !important;
+    float: none !important;
+    width: auto !important;
+    height: auto !important;
+    white-space: nowrap !important;
+    overflow: visible !important;
+    padding: 6px 12px !important;
+    margin: 0 !important;
+    box-sizing: border-box !important;
+  }
+  .productdetails td[class*="vCSS_tab"] a,
+  .productdetails td[class*="vCSS_tab"] span,
+  .productdetails td[class*="vCSS_tab"] div {
+    white-space: nowrap !important;
+    overflow: visible !important;
+    text-overflow: unset !important;
+    width: auto !important;
+    height: auto !important;
+    display: inline !important;
+    max-width: none !important;
+  }
+}
+
+@media only screen and (max-width: 767px) {
+  .productdetails span#Header_ProductDetail_ProductDetails_span,
+  .productdetails span#Header_ProductDetail_TechSpecs_span,
+  .productdetails span#Header_ProductDetail_ExtInfo_span,
+  .productdetails td#Header_ProductDetail_ProductDetails.vCSS_tab_unselected span#Header_ProductDetail_ProductDetails_span,
+  .productdetails td#Header_ProductDetail_TechSpecs.vCSS_tab_unselected span#Header_ProductDetail_TechSpecs_span,
+  .productdetails td#Header_ProductDetail_ExtInfo.vCSS_tab_unselected span#Header_ProductDetail_ExtInfo_span {
+    width: 32%;
+    margin-left: 4px;
+  }
+}
+
+body, body * {
+  font-weight: 300;
+  letter-spacing: 1.1px;
+
+}
+
+.option_pricing {
+  font-size: 16px !important;
+}
+#priceWithOptions {
+  font-size: 24px !important;
+}
+
+@media (min-width: 992px) {
+  .vCSS_img_mfg_logo {
+    margin-left: 100px;
+  }
+}
+
+table.colors_pricebox:nth-child(5) > tbody:nth-child(1) > tr:nth-child(1) > td:nth-child(1) > table:nth-child(1) > tbody:nth-child(1) > tr:nth-child(3) > td:nth-child(2) > table:nth-child(1) > tbody:nth-child(1) > tr:nth-child(1) > td:nth-child(1) {
+  text-align: left !important;
+width: 400px !important;
+}
+
+
+@media (min-width: 992px) {
+  .productdetails #v65-product-parent > tbody > tr:first-child + tr > td[align="center"] > table[width="100%"] > tbody,
+  .productdetails #v65-product-parent > tbody > tr:first-child + tr > td[align="center"] > table[width="100%"] > tbody > tr,
+  .productdetails #v65-product-parent > tbody > tr:first-child + tr > td[align="center"] > table[width="100%"] > tbody > tr > td[align="center"] {
+    margin-right: 0 !important;
+  }
+}
+
+.productdetails #ProductDetail_ProductDetails_div2 .colors_descriptionbox > tbody > tr:nth-child(3) > td[width="100%"],
+.productdetails form .colors_descriptionbox {
+  background: transparent;
+  padding: 10px 15px;
+  border-width: 1px;
+  border-style: solid;
+  border-collapse: separate;
+  width: 80% !important;
+  margin-left: 173px !important;
+}
+
+.productdetails form .colors_descriptionbox td,
+.productdetails form .colors_descriptionbox td span {
+  color: #545454;
+
+}
+
+.productdetails span[itemprop="description"] {
+  font-size: 16px;
+
+}
+
+body.productdetails span[itemprop="name"],
+body.mc-product-page span[itemprop="name"],
+body.productdetails .productnamecolorLARGE.colors_productname,
+body.mc-product-page .productnamecolorLARGE.colors_productname {
+  font-size: 13px !important;
+  font-weight: 400 !important;
+  line-height: 1.2 !important;
+  letter-spacing: 0.16em !important;
+  text-transform: uppercase !important;
+  color: #777 !important;
+  margin-left: 72px !important;
+}
+
+.mc-price-caption-moved {
+  font-size: 14px !important;
+  color: rgb(69, 69, 69) !important;
+  margin-top: 50px !important;
+  text-align: left !important;
+  margin-left: -10px;
+}
+
+</style>
+<script>
+(function () {
+  function killLegacyCategoryBar() {
+    var isCategory =
+      document.body.classList.contains('category') ||
+      document.documentElement.className.indexOf('category') !== -1 ||
+      location.pathname.indexOf('-s/') !== -1;
+
+    if (!isCategory) return;
+
+    function looksLikeProductTable(tbl) {
+      if (!tbl || !tbl.querySelector) return false;
+      if (tbl.querySelector('a[href*="-p/"], a[href*="product-p/"], a.productnamecolor, .v-product, .productnamecolor')) return true;
+      var imgs = tbl.querySelectorAll('img');
+      var i;
+      for (i = 0; i < imgs.length; i++) {
+        var src = (imgs[i].getAttribute('src') || '').toLowerCase();
+        if (src && src.indexOf('clear1x1') === -1) return true;
+      }
+      return false;
+    }
+
+    // Remove the exact spacer table pattern you pasted
+    document.querySelectorAll('#content_area table.colors_backgroundlight[width="215"]').forEach(function (el) {
+      if (looksLikeProductTable(el)) return;
+      el.remove();
+    });
+
+    // Remove parent wrappers that only contain clear1x1 spacer gifs
+    document.querySelectorAll('#content_area table.colors_backgroundlight').forEach(function (tbl) {
+      if (looksLikeProductTable(tbl)) return;
+      var spacer = tbl.querySelector('img[src*="clear1x1.gif"][width="15"][height="15"]');
+      if (spacer) {
+        tbl.remove();
+      }
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', killLegacyCategoryBar);
+  } else {
+    killLegacyCategoryBar();
+  }
+
+  window.addEventListener('load', killLegacyCategoryBar);
+  setTimeout(killLegacyCategoryBar, 250);
+  setTimeout(killLegacyCategoryBar, 800);
+})();
+</script>
+<script>
+(function () {
+  var PAGER_ID = 'mc-category-pager';
+  var STICKY_ID = 'mc-category-pager-sticky';
+  var lastPagerSig = null;
+  var pagerObsCooldownUntil = 0;
+
+  function isRoomPlannerActivePage() {
+    try {
+      var p = String(location.pathname || '');
+      var h = String(location.hash || '');
+      if (p.indexOf('room-planner') !== -1 || h.indexOf('room-planner') !== -1) return true;
+    } catch (eRp) {}
+    return false;
+  }
+
+  function updateCategoryStickyPager(prevHref, nextHref) {
+    /* Disabled — canonical bottom pager only; sticky tiny Next removed at source. */
+    var gone = document.getElementById(STICKY_ID);
+    if (gone && gone.parentNode) {
+      try {
+        gone.parentNode.removeChild(gone);
+      } catch (eRmSticky) {}
+    }
+  }
+
+  function isCategoryListing() {
+    if (document.body.classList.contains('productdetails')) return false;
+    if (document.documentElement.classList.contains('category')) return true;
+    if (document.body.classList.contains('category')) return true;
+    if (/\bvol-list\b/i.test(document.documentElement.className)) return true;
+    if (/-s\//.test(location.pathname)) return true;
+    if (/categoryid=/i.test(location.search || '')) return true;
+    return false;
+  }
+
+  function isCategoryPath() {
+    return /-s\//.test(location.pathname) || /categoryid=/i.test(location.search || '');
+  }
+
+  /** Page index from query string (regex first — Volusion uses PageNum= ; split-parse missed some encodings). */
+  function pageFromSearch(search) {
+    if (!search || search === '?') return 1;
+    var q = search.charAt(0) === '?' ? search : '?' + search;
+    var rm = q.match(/[?&](?:PageNum|pagenum|pagenumber|page)=(\d+)/i);
+    if (rm) {
+      var rv = parseInt(rm[1], 10);
+      if (!isNaN(rv) && rv >= 1) return rv;
+    }
+    var raw = search.charAt(0) === '?' ? search.slice(1) : search;
+    var pairs = raw.split('&');
+    for (var i = 0; i < pairs.length; i++) {
+      var eq = pairs[i].indexOf('=');
+      if (eq < 0) continue;
+      var k = decodeURIComponent(pairs[i].slice(0, eq)).toLowerCase().replace(/^\uFEFF/, '').trim();
+      var v = parseInt(decodeURIComponent(pairs[i].slice(eq + 1)), 10);
+      if (isNaN(v) || v < 1) continue;
+      if (k === 'pagenum' || k === 'page' || k === 'pagenumber') return v;
+    }
+    return 1;
+  }
+
+  function currentPageNum() {
+    try {
+      var u = new URL(location.href);
+      var fromQ = pageFromSearch(u.search || '');
+      var fromPath = pageFromPathname(u.pathname || '');
+      return Math.max(fromQ, fromPath, 1);
+    } catch (eCurr) {
+      return Math.max(pageFromSearch(location.search || ''), pageFromPathname(location.pathname || ''), 1);
+    }
+  }
+
+  /** Volusion SEO path paging: ...-s/106-2.htm or .html (optional). */
+  function pageFromPathname(pathname) {
+    if (!pathname) return 1;
+    var m = pathname.match(/-s\/\d+-(\d+)\.html?$/i);
+    if (m) {
+      var pv = parseInt(m[1], 10);
+      if (!isNaN(pv) && pv >= 1) return pv;
+    }
+    return 1;
+  }
+
+  function pageFromHref(href) {
+    try {
+      var u = new URL(href, location.href);
+      var fromQ = pageFromSearch(u.search || '');
+      var fromPath = pageFromPathname(u.pathname || '');
+      return Math.max(fromQ, fromPath, 1);
+    } catch (e) {
+      return 1;
+    }
+  }
+
+  /** Normalize href for stable pager signatures (avoids rebuilds on trivial URL string drift). */
+  function pagerHrefKey(href) {
+    if (!href) return '';
+    try {
+      var u = new URL(href, location.href);
+      var path = u.pathname;
+      if (path.length > 1 && path.charAt(path.length - 1) === '/') path = path.slice(0, -1);
+      return path + u.search;
+    } catch (eHk) {
+      return href;
+    }
+  }
+
+  function outsideProductGrid(a) {
+    if (!a.closest) return true;
+    if (a.closest('#mc-category-pager')) return false;
+    if (a.closest('#mc-category-pager-top')) return false;
+    if (a.closest('#mc-category-pager-sticky')) return false;
+    if (a.closest('.v-product-grid, ul.v-product-grid, li.v-product, .v-product__details')) return false;
+    return true;
+  }
+
+  function sameCategoryPath(href) {
+    try {
+      return new URL(href, location.href).pathname === location.pathname;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /** Volusion: pretty URL `/Name-s/106.htm` vs classic `/category.asp?categoryid=106&PageNum=2` — same listing, different pathname. */
+  function listingMetaFromHref(href) {
+    var out = { cid: '', sid: '', path: '' };
+    try {
+      var u = new URL(href, location.href);
+      out.path = (u.pathname || '').replace(/\/+$/, '').toLowerCase();
+      var q = u.search || '';
+      if (q.charAt(0) === '?') q = q.slice(1);
+      var pairs = q.split('&');
+      var i;
+      for (i = 0; i < pairs.length; i++) {
+        var eq = pairs[i].indexOf('=');
+        if (eq < 0) continue;
+        var k = decodeURIComponent(pairs[i].slice(0, eq)).toLowerCase();
+        if (k === 'categoryid') {
+          out.cid = decodeURIComponent(pairs[i].slice(eq + 1));
+          break;
+        }
+      }
+      var sm = u.pathname.match(/-s\/(\d+)/i);
+      if (sm) out.sid = sm[1];
+      else {
+        var hm = u.pathname.match(/(\d+)\.htm$/i);
+        if (hm) out.sid = hm[1];
+      }
+    } catch (eMeta) {}
+    return out;
+  }
+
+  function sameListingContext(href) {
+    try {
+      var A = listingMetaFromHref(href);
+      var B = listingMetaFromHref(location.href);
+      if (A.cid && B.cid && A.cid === B.cid) return true;
+      if (A.sid && B.sid && A.sid === B.sid) return true;
+      if (A.cid && B.sid && A.cid === B.sid) return true;
+      if (A.sid && B.cid && A.sid === B.cid) return true;
+      return A.path && B.path && A.path === B.path;
+    } catch (eSl) {
+      return false;
+    }
+  }
+
+  /** Smallest page index > curr among pagination links for this listing (handles asp vs SEO URLs). */
+  function findSmallestNextPageHref(root, currPage) {
+    var bestP = Infinity;
+    var bestHref = null;
+    if (!root) return null;
+    currPage = currPage > 0 ? currPage : 1;
+    function consider(a) {
+      if (!a.href || /^javascript:/i.test(a.href)) return;
+      if (!hrefHasPagingParam(a.href)) return;
+      if (!sameListingContext(a.href)) return;
+      var p2 = pageFromHref(a.href);
+      if (p2 <= currPage || p2 >= bestP) return;
+      bestP = p2;
+      bestHref = a.href;
+    }
+    var scopes = root.querySelectorAll(
+      '.v65-pagepagination, ul.pagination, [class*="pagepagination"], [class*="PagePagination"], nav.pagination'
+    );
+    var si;
+    if (scopes.length) {
+      for (si = 0; si < scopes.length; si++) {
+        var pag = scopes[si];
+        if (pag.closest && pag.closest('.v-product-grid, li.v-product, .v-product__details')) continue;
+        pag.querySelectorAll('a[href]').forEach(consider);
+      }
+    } else {
+      root
+        .querySelectorAll(
+          '#content_area a[href*="PageNum="], #content_area a[href*="pagenum="], #content_area a[href*="pagenumber="]'
+        )
+        .forEach(consider);
+    }
+    return bestHref;
+  }
+
+  /** Read which paging query key Volusion uses on real pagination links (avoids wrong `page=` vs `PageNum=`). */
+  function inferPagingKeyFromDom() {
+    var scopes = document.querySelectorAll(
+      '#content_area .v65-pagepagination, #content_area ul.pagination, .v65-pagepagination, ul.pagination'
+    );
+    var si;
+    for (si = 0; si < scopes.length; si++) {
+      var box = scopes[si];
+      if (box.closest && box.closest('.v-product-grid, li.v-product, .v-product__details')) continue;
+      var links = box.querySelectorAll('a[href]');
+      var li;
+      for (li = 0; li < links.length; li++) {
+        var h = links[li].href || '';
+        if (/[?&]PageNum=/i.test(h)) return 'PageNum';
+        if (/[?&]pagenum=/i.test(h)) return 'pagenum';
+        if (/[?&]pagenumber=/i.test(h)) return 'pagenumber';
+        if (/[?&]page=\d/i.test(h)) return 'page';
+      }
+    }
+    return null;
+  }
+
+  /** Match Volusion paging param on this URL or in category links. */
+  function detectPagingKey() {
+    var domKey = inferPagingKeyFromDom();
+    if (domKey) return domKey;
+    if (/(^|[?&])PageNum=/i.test(location.search || '')) return 'PageNum';
+    if (/(^|[?&])pagenum=/i.test(location.search || '')) return 'pagenum';
+    if (/(^|[?&])pagenumber=/i.test(location.search || '')) return 'pagenumber';
+    if (/(^|[?&])page=\d/i.test(location.search || '')) return 'page';
+    var probe = document.querySelector('#content_area a[href*="PageNum="], a[href*="PageNum="]');
+    if (probe && probe.href) return 'PageNum';
+    probe = document.querySelector('#content_area a[href*="pagenum="], a[href*="pagenum="]');
+    if (probe && probe.href) return 'pagenum';
+    probe = document.querySelector('a[href*="pagenumber="]');
+    if (probe && probe.href) return 'pagenumber';
+    probe = document.querySelector('a[href*="page="]');
+    if (probe && probe.href && /[?&]page=\d/i.test(probe.href)) return 'page';
+    return 'PageNum';
+  }
+
+  /** Use a real Volusion pagination link as the URL base so path + hidden query params match the store. */
+  function listingBaseUrlForPaging() {
+    var links = document.querySelectorAll(
+      '#content_area .v65-pagepagination a[href], #content_area ul.pagination a[href], .v65-pagepagination a[href], ul.pagination a[href]'
+    );
+    var i;
+    for (i = 0; i < links.length; i++) {
+      var href = links[i].href;
+      if (!href || /^javascript:/i.test(href)) continue;
+      if (!hrefHasPagingParam(href)) continue;
+      if (!sameListingContext(href)) continue;
+      return href;
+    }
+    return location.href;
+  }
+
+  /** Volusion SEO: page 2+ often uses …-s/{id}-{n}.htm while page 1 is …-s/{id}.htm (query PageNum alone may not advance pageFromHref). */
+  function applySeoPathPageIfNeeded(u, page) {
+    if (!u || page < 2) return;
+    try {
+      var p = String(u.pathname || '').replace(/\/+$/, '');
+      var ext = /\.html$/i.test(p) ? '.html' : '.htm';
+      var m2 = p.match(/^(.*-s\/)(\d+)-(\d+)\.html?$/i);
+      if (m2) {
+        u.pathname = m2[1] + m2[2] + '-' + page + ext;
+      } else {
+        var m1 = p.match(/^(.*-s\/)(\d+)\.html?$/i);
+        if (m1) {
+          u.pathname = m1[1] + m1[2] + '-' + page + ext;
+        } else {
+          return;
+        }
+      }
+      ['PageNum', 'pagenum', 'page', 'pagenumber', 'Page'].forEach(function (k) {
+        try {
+          u.searchParams.delete(k);
+        } catch (eDel) {}
+      });
+    } catch (eSeo) {}
+  }
+
+  function buildUrlForPage(page) {
+    var u = new URL(listingBaseUrlForPaging(), location.href);
+    var key = detectPagingKey();
+    ['PageNum', 'pagenum', 'page', 'pagenumber', 'Page'].forEach(function (k) {
+      try {
+        u.searchParams.delete(k);
+      } catch (e) {}
+    });
+    if (page > 1) {
+      u.searchParams.set(key, String(page));
+      if (pageFromHref(u.href) < page) {
+        var fallbacks = ['PageNum', 'pagenum', 'pagenumber', 'page'];
+        var fi;
+        for (fi = 0; fi < fallbacks.length; fi++) {
+          if (fallbacks[fi] === key) continue;
+          try {
+            var u2 = new URL(listingBaseUrlForPaging(), location.href);
+            ['PageNum', 'pagenum', 'page', 'pagenumber', 'Page'].forEach(function (k2) {
+              try {
+                u2.searchParams.delete(k2);
+              } catch (e2) {}
+            });
+            u2.searchParams.set(fallbacks[fi], String(page));
+            if (pageFromHref(u2.href) >= page) {
+              u.href = u2.href;
+              break;
+            }
+          } catch (eFb) {}
+        }
+      }
+      if (pageFromHref(u.href) < page) {
+        applySeoPathPageIfNeeded(u, page);
+      }
+    }
+    return u.href;
+  }
+
+  function hrefHasPagingParam(href) {
+    if (!href || typeof href !== 'string') return false;
+    if (/[?&](?:pagenum|pagenumber|page|PageNum)=/i.test(href)) return true;
+    try {
+      var u = new URL(href, location.href);
+      if (/-s\/\d+-\d+\.html?$/i.test(u.pathname || '')) return true;
+    } catch (eHp) {}
+    return false;
+  }
+
+  function findNextPrevFromDom(root, currPage) {
+    var nextHref = null;
+    var prevHref = null;
+    if (!root) return { next: null, prev: null };
+    currPage = currPage > 0 ? currPage : 1;
+
+    var nextRel = root.querySelector('a[rel="next"][href]');
+    var prevRel = root.querySelector('a[rel="prev"][href]');
+    if (nextRel && nextRel.href && outsideProductGrid(nextRel)) nextHref = nextRel.href;
+    if (prevRel && prevRel.href && outsideProductGrid(prevRel)) prevHref = prevRel.href;
+
+    root.querySelectorAll('a[href]').forEach(function (a) {
+      if (!outsideProductGrid(a)) return;
+      if (!a.href || /^javascript:/i.test(a.href)) return;
+      var t = (a.textContent || '').replace(/\s+/g, ' ').trim().toLowerCase();
+      var ti = (a.getAttribute('title') || '').toLowerCase();
+      if (!nextHref && (t === 'next' || t === '>' || t === '»' || /next\s+page/i.test(t) || ti.indexOf('next') >= 0)) {
+        nextHref = a.href;
+      }
+      if (!prevHref && (t === 'previous' || t === 'prev' || t === '<' || t === '«' || ti.indexOf('prev') >= 0)) {
+        prevHref = a.href;
+      }
+    });
+
+    var pag = root.querySelector('ul.pagination');
+    if (pag) {
+      var items = pag.querySelectorAll('li');
+      if (items.length >= 2) {
+        var firstLi = items[0];
+        var lastLi = items[items.length - 1];
+        var firstA = firstLi.querySelector('a[href]');
+        var lastA = lastLi.querySelector('a[href]');
+        if (firstA && !firstLi.classList.contains('disabled') && !firstLi.classList.contains('active')) {
+          var ft = (firstA.textContent || '').toLowerCase();
+          var fp = pageFromHref(firstA.href);
+          if (ft.indexOf('prev') >= 0 || ft === '‹' || ft === '«' || ft === '<') prevHref = firstA.href;
+          else if (hrefHasPagingParam(firstA.href) && fp > 0 && fp < currPage) prevHref = firstA.href;
+        }
+        if (lastA && !lastLi.classList.contains('disabled')) {
+          var lt = (lastA.textContent || '').toLowerCase();
+          var lp = pageFromHref(lastA.href);
+          if (lt.indexOf('next') >= 0 || lt === '›' || lt === '»' || lt === '>') nextHref = lastA.href;
+          else if (hrefHasPagingParam(lastA.href) && lp > currPage) nextHref = lastA.href;
+        }
+      }
+    }
+
+    return { next: nextHref, prev: prevHref };
+  }
+
+  /** Volusion `.v65-pagepagination` / `ul.pagination` (not filtered by product-grid rules). */
+  function findNextPrevFromVolusionPagination(root, currPage) {
+    var nextHref = null;
+    var prevHref = null;
+    if (!root) return { next: null, prev: null };
+    currPage = currPage > 0 ? currPage : 1;
+    var scopes = root.querySelectorAll(
+      '.v65-pagepagination, ul.pagination, [class*="pagepagination"], [class*="PagePagination"], nav.pagination'
+    );
+    var si;
+    for (si = 0; si < scopes.length; si++) {
+      var pag = scopes[si];
+      if (pag.closest && pag.closest('.v-product-grid, li.v-product, .v-product__details')) continue;
+
+      var nextRel = pag.querySelector('a[rel="next"][href]');
+      var prevRel = pag.querySelector('a[rel="prev"][href]');
+      if (nextRel && nextRel.href) nextHref = nextRel.href;
+      if (prevRel && prevRel.href) prevHref = prevRel.href;
+
+      var items = pag.querySelectorAll('li');
+      if (items.length >= 2) {
+        var firstLi = items[0];
+        var lastLi = items[items.length - 1];
+        var firstA = firstLi.querySelector('a[href]');
+        var lastA = lastLi.querySelector('a[href]');
+        if (!prevHref && firstA && !firstLi.classList.contains('disabled') && !firstLi.classList.contains('active')) {
+          var ft = (firstA.textContent || '').toLowerCase();
+          var fp = pageFromHref(firstA.href);
+          if (ft.indexOf('prev') >= 0 || ft === '‹' || ft === '«' || ft === '<') prevHref = firstA.href;
+          else if (hrefHasPagingParam(firstA.href) && fp > 0 && fp < currPage) prevHref = firstA.href;
+        }
+        if (!nextHref && lastA && !lastLi.classList.contains('disabled')) {
+          var lt = (lastA.textContent || '').toLowerCase();
+          var lp = pageFromHref(lastA.href);
+          if (lt.indexOf('next') >= 0 || lt === '›' || lt === '»' || lt === '>') nextHref = lastA.href;
+          else if (hrefHasPagingParam(lastA.href) && lp > currPage) nextHref = lastA.href;
+        }
+      }
+
+      pag.querySelectorAll('a[href]').forEach(function (a) {
+        if (!a.href || /^javascript:/i.test(a.href)) return;
+        var t = (a.textContent || '').replace(/\s+/g, ' ').trim().toLowerCase();
+        var ti = (a.getAttribute('title') || '').toLowerCase();
+        if (!nextHref && (t === 'next' || t === '>' || t === '»' || /next\s+page/i.test(t) || ti.indexOf('next') >= 0)) {
+          nextHref = a.href;
+        }
+        if (!prevHref && (t === 'previous' || t === 'prev' || t === '<' || t === '«' || ti.indexOf('prev') >= 0)) {
+          prevHref = a.href;
+        }
+      });
+    }
+    return { next: nextHref, prev: prevHref };
+  }
+
+  /** Largest page index linked from Volusion category pagination (boosts maxP when numeric links use ?PageNum=). */
+  function maxPageFromVolusionPagination(root) {
+    var maxPg = 1;
+    if (!root) return maxPg;
+    var scopes = root.querySelectorAll(
+      '.v65-pagepagination, ul.pagination, [class*="pagepagination"], [class*="PagePagination"], nav.pagination'
+    );
+    var si;
+    for (si = 0; si < scopes.length; si++) {
+      var pag = scopes[si];
+      if (pag.closest && pag.closest('.v-product-grid, li.v-product, .v-product__details')) continue;
+      pag.querySelectorAll('a[href]').forEach(function (a) {
+        if (!a.href || /^javascript:/i.test(a.href)) return;
+        if (!hrefHasPagingParam(a.href)) return;
+        if (!sameListingContext(a.href)) return;
+        var p = pageFromHref(a.href);
+        if (p > maxPg) maxPg = p;
+      });
+    }
+    return maxPg;
+  }
+
+  function inferFromPageParams(root, curr) {
+    var nextHref = null;
+    var prevHref = null;
+    var nextPage = Infinity;
+    var prevPage = 0;
+    if (!root) return { next: null, prev: null };
+
+    root.querySelectorAll('a[href]').forEach(function (a) {
+      if (!outsideProductGrid(a)) return;
+      if (!a.href || /^javascript:/i.test(a.href)) return;
+      if (!sameListingContext(a.href)) return;
+      var lo = a.href;
+      if (!hrefHasPagingParam(lo)) return;
+      var p = pageFromHref(a.href);
+      if (p < 1) return;
+      if (p > curr && p < nextPage) {
+        nextPage = p;
+        nextHref = a.href;
+      }
+      if (p < curr && p > prevPage) {
+        prevPage = p;
+        prevHref = a.href;
+      }
+    });
+    return { next: nextHref, prev: prevHref };
+  }
+
+  function maxPageSeenOnPage(root) {
+    var maxP = 1;
+    if (!root) return 1;
+    root.querySelectorAll('a[href]').forEach(function (a) {
+      if (!outsideProductGrid(a)) return;
+      if (!a.href || /^javascript:/i.test(a.href)) return;
+      if (!hrefHasPagingParam(a.href)) return;
+      if (!sameListingContext(a.href)) return;
+      try {
+        var p = pageFromHref(a.href);
+        if (p > maxP) maxP = p;
+      } catch (e) {}
+    });
+    return maxP;
+  }
+
+  function findCategoryPageTextRow(ca) {
+    if (!ca) return null;
+    var candidates = ca.querySelectorAll('td, div, span, p, td b, font, strong');
+    var i;
+    var el;
+    for (i = 0; i < candidates.length; i++) {
+      el = candidates[i];
+      if (el.getAttribute && el.getAttribute('data-mc-pager-hidden') === '1') continue;
+      if (el.closest && el.closest('.v-product-grid')) continue;
+      if (el.closest && el.closest('#mc-category-pager')) continue;
+      if (el.closest && el.closest('#mc-category-pager-top')) continue;
+      if (el.closest && el.closest('#relateditems')) continue;
+      var t = (el.textContent || '').replace(/\s+/g, ' ').trim();
+      if (t.length > 160) continue;
+      if (
+        /\bpage\s+\d+/i.test(t) ||
+        /\bpage\s+\d+\s+of\s+\d+/i.test(t) ||
+        /\bshowing\s+\d+\s*[-–]\s*\d+/i.test(t) ||
+        /^page\s*:/i.test(t)
+      ) {
+        return el;
+      }
+    }
+    return null;
+  }
+  function parseTotalPagesFromText(txt) {
+    if (!txt) return 0;
+    var s = String(txt).replace(/\s+/g, ' ');
+    var m =
+      s.match(/\bpage\s+\d+\s+of\s+(\d+)\b/i) ||
+      s.match(/\bpage\s*\d+\s*of\s*(\d+)\b/i) ||
+      s.match(/\bpage\s+\d+\s*\/\s*(\d+)\b/i);
+    return m ? parseInt(m[1], 10) : 0;
+  }
+
+  /** "Showing 1 - 24 of 96" → at least ceil(96/24) pages (Volusion often omits "Page X of Y"). */
+  function minPagesFromShowingOfTotal(root) {
+    if (!root) return 1;
+    var blob = String(root.textContent || '').replace(/\s+/g, ' ');
+    var m =
+      blob.match(/\b\d+\s*[-–]\s*\d+\s+of\s+(\d+)\b/i) ||
+      blob.match(/\b(?:showing|displaying|viewing)\s*:?\s*\d+\s*[-–]\s*\d+\s+of\s+(\d+)\b/i);
+    if (!m) return 1;
+    var total = parseInt(m[1], 10);
+    if (isNaN(total) || total < 2) return 1;
+    var m2 =
+      blob.match(/\b(\d+)\s*[-–]\s*\d+\s+of\s+\d+/i) ||
+      blob.match(/\b(?:showing|displaying|viewing)\s*:?\s*(\d+)\s*[-–]\s*\d+\s+of\s+\d+/i);
+    var per = m2 ? parseInt(m2[1], 10) : 24;
+    if (isNaN(per) || per < 1) per = 24;
+    return Math.max(1, Math.ceil(total / per));
+  }
+
+  function inferTotalPages(ca, curr, maxP, hasNext) {
+    var pt = findCategoryPageTextRow(ca);
+    if (pt) {
+      var n0 = parseTotalPagesFromText(pt.textContent || '');
+      if (n0 >= curr) return n0;
+    }
+    try {
+      var blob = ca ? String(ca.textContent || '') : '';
+      var m =
+        blob.match(/\bpage\s+\d+\s+of\s+(\d+)\b/i) ||
+        blob.match(/\bpage\s*\d+\s*of\s*(\d+)\b/i) ||
+        blob.match(/\bpage\s+\d+\s*\/\s*(\d+)\b/i);
+      if (m) {
+        var n1 = parseInt(m[1], 10);
+        if (n1 >= curr) return n1;
+      }
+    } catch (e0) {}
+    var minShow = Math.max(minPagesFromShowingOfTotal(ca), minPagesFromShowingOfTotal(document.body));
+    if (minShow > 1) return Math.max(minShow, maxP, curr);
+    if (maxP >= curr && maxP > 1) return maxP;
+    if (hasNext) return Math.max(curr + 1, maxP);
+    return Math.max(curr, 1);
+  }
+
+  function volusionPaginationSuggestsMorePages(root, currPage) {
+    if (!root) return false;
+    currPage = currPage > 0 ? currPage : 1;
+    var blocks = root.querySelectorAll(
+      '.v65-pagepagination, ul.pagination, [class*="pagepagination"], [class*="PagePagination"], nav.pagination'
+    );
+    var bi;
+    for (bi = 0; bi < blocks.length; bi++) {
+      var p = blocks[bi];
+      if (p.closest && p.closest('.v-product-grid, li.v-product, .v-product__details')) continue;
+      var saw = 0;
+      p.querySelectorAll('a[href]').forEach(function (a) {
+        if (!a.href || /^javascript:/i.test(a.href)) return;
+        var li = a.closest && a.closest('li');
+        if (li && li.classList && li.classList.contains('disabled')) return;
+        var t = (a.textContent || '').replace(/\s+/g, ' ').trim();
+        var ti = ((a.getAttribute && a.getAttribute('title')) || '').toLowerCase();
+        if (/^next\b|^›|^»|^>$/i.test(t) || /next\s+page/i.test(t) || ti.indexOf('next') >= 0) saw++;
+        if (/^\d+$/.test(t) && parseInt(t, 10) > currPage) saw++;
+        if (hrefHasPagingParam(a.href) && sameListingContext(a.href) && pageFromHref(a.href) > currPage) saw++;
+        var im = a.querySelector && a.querySelector('img[alt]');
+        if (im && /next/i.test(im.getAttribute('alt') || '')) saw++;
+      });
+      if (saw > 0) return true;
+    }
+    return false;
+  }
+
+  /** Count PLP tiles on the current page; fallback from “Showing a–b of …” when the grid is nonstandard. */
+  function countCategoryProductsShownOnPage(root) {
+    if (!root) return 0;
+    var dom = 0;
+    try {
+      var sel = root.querySelectorAll(
+        'ul.v-product-grid > li.v-product, ul.v-product-grid > li.v-product-grid-item, .v-product-grid > li.v-product, .v-product-grid > .v-product, table.v-product-grid td.v65-productDisplay-cell'
+      );
+      dom = sel.length;
+    } catch (eCnt) {}
+    var fromTxt = 0;
+    try {
+      var blob = String(root.textContent || '').replace(/\s+/g, ' ');
+      var m = blob.match(/\b(\d+)\s*[-–]\s*(\d+)\s+of\s+\d+/i);
+      if (m) {
+        var lo = parseInt(m[1], 10);
+        var hi = parseInt(m[2], 10);
+        if (!isNaN(lo) && !isNaN(hi) && hi >= lo) fromTxt = hi - lo + 1;
+      }
+    } catch (eTxt) {}
+    return Math.max(dom, fromTxt);
+  }
+
+  /** “Showing 1 - 24 of 96” → 96 (category size when grid count is below per-page threshold). */
+  function totalProductsInCategoryFromDom(root) {
+    if (!root) return 0;
+    try {
+      var blob = String(root.textContent || '').replace(/\s+/g, ' ');
+      var m =
+        blob.match(/\b\d+\s*[-–]\s*\d+\s+of\s+(\d+)\b/i) ||
+        blob.match(/\b(?:showing|displaying|viewing)\s*:?\s*\d+\s*[-–]\s*\d+\s+of\s+(\d+)\b/i);
+      if (!m) return 0;
+      var n = parseInt(m[1], 10);
+      return isNaN(n) ? 0 : n;
+    } catch (eTot) {
+      return 0;
+    }
+  }
+
+  /** Any paging link in the listing (ignores outsideProductGrid — some themes nest oddly). */
+  function scanBestNextHrefFromContentArea(root, currPage) {
+    if (!root) return null;
+    currPage = currPage > 0 ? currPage : 1;
+    var bestP = Infinity;
+    var bestHref = null;
+    try {
+      root.querySelectorAll('a[href]').forEach(function (a) {
+        if (!a.href || /^javascript:/i.test(a.href)) return;
+        if (a.closest && a.closest('li.v-product')) return;
+        if (/productdetails|shoppingcart|\.asp\?search=/i.test(a.href)) return;
+        if (!hrefHasPagingParam(a.href)) return;
+        if (!sameListingContext(a.href)) return;
+        var p = pageFromHref(a.href);
+        if (p <= currPage || p >= bestP) return;
+        bestP = p;
+        bestHref = a.href;
+      });
+    } catch (eSc) {}
+    return bestHref;
+  }
+
+  function hideCategoryVolusionPageLabel(root) {
+    if (!root) return;
+    var pt = findCategoryPageTextRow(root);
+    if (pt) {
+      try {
+        pt.setAttribute('data-mc-pager-hidden', '1');
+      } catch (eH) {}
+    }
+  }
+
+  function revealMcPagerHiddenLabels(root) {
+    if (!root || !root.querySelectorAll) return;
+    try {
+      root.querySelectorAll('[data-mc-pager-hidden="1"]').forEach(function (el) {
+        el.removeAttribute('data-mc-pager-hidden');
+      });
+    } catch (eR) {}
+  }
+
+  function teardownCustomCategoryPager(ca) {
+    var existing = document.getElementById(PAGER_ID);
+    if (existing && existing.parentNode) {
+      try {
+        existing.parentNode.removeChild(existing);
+      } catch (e1) {}
+    }
+    var top = document.getElementById('mc-category-pager-top');
+    if (top && top.parentNode) {
+      try {
+        top.parentNode.removeChild(top);
+      } catch (e2) {}
+    }
+    var sticky = document.getElementById(STICKY_ID);
+    if (sticky && sticky.parentNode) {
+      try {
+        sticky.parentNode.removeChild(sticky);
+      } catch (e3) {}
+    }
+    revealMcPagerHiddenLabels(ca);
+    lastPagerSig = null;
+  }
+
+  function mountPoint() {
+    var ca =
+      document.getElementById('content_area') ||
+      document.querySelector('.content_area-wrapper') ||
+      document.body;
+    if (!ca) return null;
+    var grid = ca.querySelector('#mc-products-start') || ca.querySelector('.v-product-grid');
+    if (grid && grid.parentNode) return { el: grid, parent: grid.parentNode };
+    var table = ca.querySelector('table.v65-productDisplay');
+    if (table && table.parentNode) return { el: table, parent: table.parentNode };
+    var seo = ca.querySelector('.mc-seo-footer');
+    if (seo && seo.parentNode) return { el: seo, parent: seo.parentNode };
+    return { el: ca, parent: ca };
+  }
+
+  function renderPager() {
+    try {
+      if (!isCategoryListing()) return;
+      if (isRoomPlannerActivePage()) {
+        try {
+          teardownCustomCategoryPager(
+            document.getElementById('content_area') ||
+              document.querySelector('.content_area-wrapper') ||
+              document.querySelector('[role="main"]') ||
+              document.body
+          );
+        } catch (ePlanner) {}
+        return;
+      }
+      var ca =
+        document.getElementById('content_area') ||
+        document.querySelector('.content_area-wrapper') ||
+        document.querySelector('[role="main"]') ||
+        document.body;
+      if (!ca) return;
+
+      var shownOnPage = countCategoryProductsShownOnPage(ca);
+      var categoryTotalN = totalProductsInCategoryFromDom(ca);
+      /* Per-page >30 OR Volusion “of N” total >30 so 24/page categories still get Next/Prev. */
+      if (shownOnPage <= 30 && categoryTotalN <= 30) {
+        teardownCustomCategoryPager(ca);
+        return;
+      }
+
+      var curr = currentPageNum();
+      var body = document.body;
+      var path = location.pathname;
+      var onCat = isCategoryPath();
+
+      var d1 = findNextPrevFromDom(ca, curr);
+      var d1b = findNextPrevFromDom(body, curr);
+      var d2 = inferFromPageParams(ca, curr);
+      var d2b = inferFromPageParams(body, curr);
+      var dVol = findNextPrevFromVolusionPagination(ca, curr);
+      var dVolBody = findNextPrevFromVolusionPagination(body, curr);
+
+      var nextHref = d1.next || d1b.next || d2.next || d2b.next || dVol.next || dVolBody.next;
+      var prevHref = d1.prev || d1b.prev || d2.prev || d2b.prev || dVol.prev || dVolBody.prev;
+
+      if (!nextHref) {
+        var candNext = findSmallestNextPageHref(ca, curr) || findSmallestNextPageHref(body, curr);
+        if (candNext) nextHref = candNext;
+      }
+      if (!nextHref) {
+        /* Do not scan document.body — tens of thousands of anchors + URL parsing freezes the tab; ca is enough. */
+        var scanNext = scanBestNextHrefFromContentArea(ca, curr);
+        if (scanNext) nextHref = scanNext;
+      }
+
+      if (curr <= 1) prevHref = null;
+      else prevHref = prevHref || buildUrlForPage(curr - 1);
+
+      var maxP = maxPageSeenOnPage(body);
+      maxP = Math.max(maxP, maxPageFromVolusionPagination(ca), maxPageFromVolusionPagination(body));
+      maxP = Math.max(
+        maxP,
+        minPagesFromShowingOfTotal(ca),
+        minPagesFromShowingOfTotal(body)
+      );
+
+      if (!nextHref) {
+        if (curr < maxP) nextHref = buildUrlForPage(curr + 1);
+        else if (curr === 1 && maxP > 1) nextHref = buildUrlForPage(2);
+      }
+
+      if (!nextHref && onCat && curr > 1 && curr < maxP) nextHref = buildUrlForPage(curr + 1);
+
+      if (!nextHref && onCat && volusionPaginationSuggestsMorePages(ca, curr)) {
+        nextHref = buildUrlForPage(curr + 1);
+      }
+      if (!nextHref && onCat && volusionPaginationSuggestsMorePages(body, curr)) {
+        nextHref = buildUrlForPage(curr + 1);
+      }
+
+      if (nextHref) {
+        try {
+          if (new URL(nextHref, location.href).href === new URL(location.href).href) {
+            nextHref = null;
+          }
+        } catch (eSame) {}
+      }
+      if (nextHref) {
+        var pnNext = pageFromHref(nextHref);
+        if (hrefHasPagingParam(nextHref) && pnNext > 0 && pnNext <= curr) nextHref = null;
+      }
+
+      var hasNextPrelim = !!nextHref;
+      var totalP = inferTotalPages(ca, curr, maxP, hasNextPrelim);
+      if (totalP < curr) totalP = curr;
+      if (!nextHref && totalP > curr) {
+        nextHref = buildUrlForPage(curr + 1);
+      }
+      if (!nextHref && onCat && categoryTotalN > 0 && shownOnPage > 0) {
+        var estPagesFromTotal = Math.ceil(categoryTotalN / shownOnPage);
+        if (estPagesFromTotal > curr) {
+          nextHref = buildUrlForPage(curr + 1);
+        }
+      }
+
+      var hasNext = !!nextHref;
+
+      hideCategoryVolusionPageLabel(ca);
+
+      var locKey = path + '|' + (location.search || '');
+      var sig =
+        locKey +
+        '|' +
+        curr +
+        '|' +
+        shownOnPage +
+        '|' +
+        categoryTotalN +
+        '|' +
+        pagerHrefKey(nextHref) +
+        '|' +
+        pagerHrefKey(prevHref);
+
+      if (lastPagerSig === sig) {
+        updateCategoryStickyPager(prevHref, nextHref);
+        return;
+      }
+
+      pagerObsCooldownUntil = Date.now() + 1600;
+
+      var existing = document.getElementById(PAGER_ID);
+      if (existing && existing.parentNode) {
+        try {
+          existing.parentNode.removeChild(existing);
+        } catch (eRmNav) {}
+      }
+
+      if (!hasNext && !prevHref) {
+        var otOnly = document.getElementById('mc-category-pager-top');
+        if (otOnly && otOnly.parentNode) {
+          try {
+            otOnly.parentNode.removeChild(otOnly);
+          } catch (eOt) {}
+        }
+        updateCategoryStickyPager(null, null);
+        lastPagerSig = sig;
+        return;
+      }
+
+      var oldTop = document.getElementById('mc-category-pager-top');
+      if (oldTop && oldTop.parentNode) {
+        try {
+          oldTop.parentNode.removeChild(oldTop);
+        } catch (eOldTop) {}
+      }
+
+      updateCategoryStickyPager(null, null);
+
+      if (!hasNext && !prevHref) {
+        lastPagerSig = sig;
+        return;
+      }
+
+      var m = mountPoint();
+      if (!m || !m.parent) {
+        lastPagerSig = sig;
+        return;
+      }
+
+      var wrap = document.createElement('nav');
+      wrap.id = PAGER_ID;
+      wrap.className = 'mc-category-pager';
+      wrap.setAttribute('aria-label', 'Category pages');
+
+      if (prevHref) {
+        var pa = document.createElement('a');
+        pa.className = 'mc-category-pager__btn mc-category-pager__btn--prev';
+        pa.href = prevHref;
+        pa.textContent = 'Previous';
+        wrap.appendChild(pa);
+      }
+      if (hasNext) {
+        var na = document.createElement('a');
+        na.className = 'mc-category-pager__btn mc-category-pager__btn--next';
+        na.href = nextHref;
+        na.textContent = 'Next';
+        wrap.appendChild(na);
+      }
+
+      if (!wrap.querySelector('a')) {
+        lastPagerSig = sig;
+        return;
+      }
+
+      if (m.el === m.parent || m.el.id === 'content_area') {
+        m.parent.appendChild(wrap);
+      } else if (m.el.nextSibling) {
+        m.parent.insertBefore(wrap, m.el.nextSibling);
+      } else {
+        m.parent.appendChild(wrap);
+      }
+
+      lastPagerSig = sig;
+    } catch (err) {}
+  }
+
+  function boot() {
+    renderPager();
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', boot);
+  else boot();
+  window.addEventListener('load', function () {
+    renderPager();
+    setTimeout(renderPager, 350);
+    setTimeout(renderPager, 1100);
+  });
+
+  var ca0 =
+    document.getElementById('content_area') ||
+    document.querySelector('.content_area-wrapper') ||
+    document.body;
+  if (ca0 && typeof MutationObserver !== 'undefined' && !isRoomPlannerActivePage()) {
+    var t = null;
+    function isPagerOwned(el) {
+      if (!el || el.nodeType !== 1) return false;
+      var p = el;
+      while (p) {
+        var id = p.id;
+        if (id === PAGER_ID || id === 'mc-category-pager-top') return true;
+        if (id === 'roomPlannerApp' || id === 'mcPlannerModalBody') return true;
+        p = p.parentElement;
+      }
+      return false;
+    }
+    function shouldIgnoreMutations(records) {
+      var i;
+      var j;
+      for (i = 0; i < records.length; i++) {
+        var r = records[i];
+        for (j = 0; j < r.addedNodes.length; j++) {
+          var n = r.addedNodes[j];
+          if (n.nodeType === 1 && !isPagerOwned(n)) return false;
+        }
+        for (j = 0; j < r.removedNodes.length; j++) {
+          var n2 = r.removedNodes[j];
+          if (n2.nodeType === 1 && !isPagerOwned(n2)) return false;
+        }
+      }
+      return true;
+    }
+    var obs = new MutationObserver(function (mutations) {
+      if (Date.now() < pagerObsCooldownUntil) return;
+      if (shouldIgnoreMutations(mutations)) return;
+      clearTimeout(t);
+      t = setTimeout(renderPager, 1000);
+    });
+    obs.observe(ca0, { childList: true, subtree: true });
+  }
+})();
+</script>
+<script>
+(function () {
+  function removeHomepageSecondMenu() {
+    // homepage only (you already use this class)
+    if (!document.body.classList.contains('is-home')) return;
+
+    // remove top-level category UL rows (the duplicated menu row)
+    document.querySelectorAll('#display_menu_1 ul.vnav--horizontal.vnav--level1, #display_menu_1 ul.vnav--level1').forEach(function (ul) {
+      ul.remove();
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', removeHomepageSecondMenu);
+  } else {
+    removeHomepageSecondMenu();
+  }
+
+  window.addEventListener('load', removeHomepageSecondMenu);
+  setTimeout(removeHomepageSecondMenu, 300);
+})();
+</script>
+
+
+<script>
+(function () {
+  function syncHeroCartCount() {
+    var heroCount = document.getElementById('heroCartCount');
+    if (!heroCount) return;
+
+    var nativeCount = document.querySelector('.microblock.cart [data-v-observable="cart-count"], .microblock.cart .cart__count');
+    if (!nativeCount) return;
+
+    var update = function () {
+      var v = (nativeCount.textContent || '').replace(/[^\d]/g, '');
+      heroCount.textContent = v ? v : '0';
+    };
+
+    update();
+
+    var obs = new MutationObserver(update);
+    obs.observe(nativeCount, { childList: true, subtree: true, characterData: true });
+
+    setInterval(update, 1000);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', syncHeroCartCount);
+  } else {
+    syncHeroCartCount();
+  }
+  window.addEventListener('load', syncHeroCartCount);
+})();
+</script>
+
+<script>
+(function () {
+  function mcCategoryGridCols() {
+    var mq1 = window.matchMedia('(max-width: 575px)');
+    var mq2 = window.matchMedia('(min-width: 576px) and (max-width: 991px)');
+    if (mq1.matches) {
+      return { cols: 'minmax(0, 1fr)', gap: '12px' };
+    }
+    if (mq2.matches) {
+      return { cols: 'repeat(2, minmax(0, 1fr))', gap: '16px' };
+    }
+    return { cols: 'repeat(3, minmax(0, 1fr))', gap: '20px' };
+  }
+
+  function mcGridIsListingCandidate(grid) {
+    if (!grid) return false;
+    if (grid.closest && grid.closest('#footer')) return false;
+    if (grid.closest && grid.closest('.sidebar-wrapper')) return false;
+    if (grid.closest && grid.closest('.sidebar')) return false;
+    /* PDP Related Items often use .v-product-grid inside #content_area; mcFixCategoryGrid + observer caused repeat reflow/flash. */
+    if (
+      grid.closest &&
+      (grid.closest('#related-products') ||
+        grid.closest('#relateditems') ||
+        grid.closest('table.relateditems') ||
+        grid.closest('#v65-product-related') ||
+        grid.closest('.v65-product-related') ||
+        grid.closest('#related_products_content') ||
+        grid.closest('.mc-related-carousel') ||
+        grid.closest('.mc-related-carousel__viewport'))
+    ) {
+      return false;
+    }
+    if (!grid.querySelector || !grid.querySelector('.v-product, li.v-product, li')) return false;
+    return true;
+  }
+
+  function mcFindListingGrids() {
+    var ca = document.getElementById('content_area');
+    if (!ca) return [];
+
+    /* Fix EVERY listing grid in main content — not only the first / v65 match. Volusion splits rows or omits v65 wrapper; a single-grid fallback hid most products. */
+    var all = ca.querySelectorAll('.v-product-grid');
+    var out = [];
+    var seen = new WeakSet();
+    var i;
+    for (i = 0; i < all.length; i++) {
+      var g = all[i];
+      if (!mcGridIsListingCandidate(g)) continue;
+      if (seen.has(g)) continue;
+      seen.add(g);
+      out.push(g);
+    }
+    return out;
+  }
+
+  function fixCategoryGrid() {
+    var b = document.body;
+    if (!b) return;
+    /* Do not skip when body has productdetails — Volusion sometimes sets it wrongly; rely on presence of a listing grid */
+    var grids = mcFindListingGrids();
+    if (!grids.length) return;
+
+    document.documentElement.classList.add('category');
+    b.classList.add('category');
+
+    var spec = mcCategoryGridCols();
+    var gi;
+    for (gi = 0; gi < grids.length; gi++) {
+      var grid = grids[gi];
+      var gs = grid.style;
+      gs.setProperty('display', 'grid', 'important');
+      gs.setProperty('grid-auto-flow', 'row', 'important');
+      gs.setProperty('grid-template-columns', spec.cols, 'important');
+      gs.setProperty('gap', spec.gap, 'important');
+      gs.setProperty('width', '100%', 'important');
+      gs.setProperty('max-width', '100%', 'important');
+      gs.setProperty('min-width', '0', 'important');
+      gs.setProperty('float', 'none', 'important');
+      gs.setProperty('clear', 'both', 'important');
+
+      var ch = grid.children;
+      var ci;
+      for (ci = 0; ci < ch.length; ci++) {
+        var card = ch[ci];
+        if (!card.classList) continue;
+        var isUlLi = grid.tagName === 'UL' && card.tagName === 'LI';
+        var isCard =
+          card.classList.contains('v-product') ||
+          card.classList.contains('v-product-grid-item') ||
+          isUlLi;
+        if (!isCard) continue;
+
+        var s = card.style;
+        s.removeProperty('grid-column');
+        s.removeProperty('grid-row');
+        s.removeProperty('grid-area');
+        s.removeProperty('width');
+        s.removeProperty('max-width');
+        s.removeProperty('display');
+        s.setProperty('display', 'flex', 'important');
+        s.setProperty('flex-direction', 'column', 'important');
+        s.setProperty('align-items', 'stretch', 'important');
+        s.setProperty('box-sizing', 'border-box', 'important');
+        s.setProperty('width', '100%', 'important');
+        s.setProperty('max-width', '100%', 'important');
+        s.setProperty('min-width', '100%', 'important');
+        s.setProperty('float', 'none', 'important');
+      }
+    }
+  }
+
+  function run() {
+    fixCategoryGrid();
+
+    if (!window.__mcGridObserver) {
+      var debounce;
+      var obsRoot = document.getElementById('content_area') || document.documentElement;
+      window.__mcGridObserver = new MutationObserver(function () {
+        clearTimeout(debounce);
+        debounce = setTimeout(fixCategoryGrid, 48);
+      });
+      window.__mcGridObserver.observe(obsRoot, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['class', 'style']
+      });
+    }
+
+    if (!window.__mcGridResizeBound) {
+      window.__mcGridResizeBound = true;
+      window.addEventListener('resize', function () {
+        fixCategoryGrid();
+      });
+    }
+
+    setTimeout(fixCategoryGrid, 50);
+    setTimeout(fixCategoryGrid, 200);
+    setTimeout(fixCategoryGrid, 600);
+    setTimeout(fixCategoryGrid, 1500);
+    setTimeout(fixCategoryGrid, 3000);
+    setTimeout(fixCategoryGrid, 5000);
+    setTimeout(fixCategoryGrid, 8000);
+
+    if (typeof window.mcApplyCategoryPlpThumbMat === 'function') {
+      window.mcApplyCategoryPlpThumbMat();
+    }
+
+    if (!window.__mcGridPoll) {
+      window.__mcGridPoll = setInterval(function () {
+        fixCategoryGrid();
+      }, 1500);
+      setTimeout(function () {
+        if (window.__mcGridPoll) {
+          clearInterval(window.__mcGridPoll);
+          window.__mcGridPoll = null;
+        }
+      }, 24000);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', run);
+  } else {
+    run();
+  }
+  window.addEventListener('load', run);
+  window.mcFixCategoryGrid = fixCategoryGrid;
+})();
+</script>
+
+
+
+<script>
+(function(){
+  function isMobile(){ return window.matchMedia('(max-width: 991px)').matches; }
+  function isHome(){ return document.body.classList.contains('is-home'); }
+  function qs(sel, root){ return (root||document).querySelector(sel); }
+  function qsa(sel, root){ return Array.from((root||document).querySelectorAll(sel)); }
+
+  function target(){
+    return qs('#push-nav__menu') || qs('.push-menu__menu-wrapper');
+  }
+
+  function buildFromVnav(ul){
+    var out = document.createElement('ul');
+    out.className = 'mc-mobile-vnav';
+
+    qsa(':scope > li', ul).forEach(function(li){
+      var a = qs(':scope > a', li);
+      if (!a) return;
+
+      var item = document.createElement('li');
+      item.className = 'mc-mobile-vnav__item';
+
+      var row = document.createElement('div');
+      row.className = 'mc-mobile-vnav__row';
+
+      var link = document.createElement('a');
+      link.className = 'mc-mobile-vnav__link';
+      link.href = a.getAttribute('href') || '#';
+      link.textContent = (a.textContent||'').trim();
+      row.appendChild(link);
+
+      var sub = qs(':scope > ul', li);
+      if (sub){
+        item.classList.add('mc-has-sub');
+
+        var btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'mc-sub-toggle';
+        btn.setAttribute('aria-expanded','false');
+        btn.textContent = '▾';
+        row.appendChild(btn);
+
+        var subList = buildFromVnav(sub);
+        subList.classList.add('mc-mobile-vnav__sub');
+        item.appendChild(subList);
+      }
+
+      item.insertBefore(row, item.firstChild);
+      out.appendChild(item);
+    });
+
+    return out;
+  }
+
+  function buildFromHero(){
+    var out = document.createElement('ul');
+    out.className = 'mc-mobile-vnav';
+
+    qsa('#slideshow-container .hero-menu a').forEach(function(a){
+      var txt = (a.textContent||'').trim();
+      var href = a.getAttribute('href') || '';
+      if (!txt || !href) return;
+
+      var li = document.createElement('li');
+      li.className = 'mc-mobile-vnav__item';
+
+      var row = document.createElement('div');
+      row.className = 'mc-mobile-vnav__row';
+
+      var link = document.createElement('a');
+      link.className = 'mc-mobile-vnav__link';
+      link.href = href;
+      link.textContent = txt;
+
+      row.appendChild(link);
+      li.appendChild(row);
+      out.appendChild(li);
+    });
+
+    return out;
+  }
+
+  function ensureHomeItem(ul){
+    // HOME at top
+    var hasHome = qsa('a', ul).some(function(a){ return (a.textContent||'').trim().toUpperCase()==='HOME'; });
+    if (!hasHome){
+      var li = document.createElement('li');
+      li.className = 'mc-mobile-vnav__item';
+
+      var row = document.createElement('div');
+      row.className = 'mc-mobile-vnav__row';
+
+      var a = document.createElement('a');
+      a.className = 'mc-mobile-vnav__link';
+      a.href = '/default.asp';
+      a.textContent = 'HOME';
+
+      row.appendChild(a);
+      li.appendChild(row);
+      ul.insertBefore(li, ul.firstChild);
+    }
+  }
+
+  function ensureSingleCart(ul){
+    var carts = qsa('a', ul).filter(function(a){ return (a.textContent||'').trim().toUpperCase()==='MY CART'; });
+    if (carts.length === 0){
+      var li = document.createElement('li');
+      li.className = 'mc-mobile-vnav__item';
+
+      var row = document.createElement('div');
+      row.className = 'mc-mobile-vnav__row';
+
+      var a = document.createElement('a');
+      a.className = 'mc-mobile-vnav__link';
+      a.href = '/shoppingcart.asp';
+      a.textContent = 'MY CART';
+
+      row.appendChild(a);
+      li.appendChild(row);
+      ul.appendChild(li);
+    } else {
+      for (var i=1;i<carts.length;i++){
+        var n = carts[i].closest('li');
+        if (n) n.remove(); else carts[i].remove();
+      }
+    }
+  }
+
+  function renderMenu(){
+    if (!isMobile()) return;
+    var t = target();
+    if (!t) return;
+
+    // If already rendered, stop
+    if (qs('ul.mc-mobile-vnav', t)) return;
+
+    var ul;
+    if (isHome()){
+      ul = buildFromHero();
+    } else {
+      var src = qs('#display_menu_1 ul.vnav--level1');
+      if (!src) return;
+      ul = buildFromVnav(src);
+    }
+
+    t.innerHTML = '';
+    t.appendChild(ul);
+  }
+
+  // Toggle submenu open/close
+  document.addEventListener('click', function(e){
+    if (!isMobile()) return;
+
+    var btn = e.target.closest('button.mc-sub-toggle');
+    if (btn){
+      e.preventDefault();
+      var li = btn.closest('li.mc-has-sub');
+      if (!li) return;
+      var open = li.classList.toggle('mc-open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      return;
+    }
+
+    if (e.target.closest('#nav-toggle, .menu-toggle, .menu-toggle__link, .menu-toggle__text')){
+      setTimeout(renderMenu, 0);
+      setTimeout(renderMenu, 200);
+      setTimeout(renderMenu, 800);
+    }
+  }, true);
+
+  document.addEventListener('DOMContentLoaded', function(){
+    setTimeout(renderMenu, 300);
+  });
+
+})();
+</script>
+<script>
+(function(){
+  function isMobile(){ return window.matchMedia('(max-width: 991px)').matches; }
+  function qs(sel){ return document.querySelector(sel); }
+
+  function forceCloseGlyph(){
+    var btn = qs('nav.push-menu .push-menu__close-btn');
+    if (!btn) return;
+
+    if (!btn.querySelector('.mc-close-x')) {
+      btn.innerHTML = '<span class="mc-close-x" aria-hidden="true">&#215;</span>';
+    }
+
+    btn.style.display = 'block';
+    btn.style.position = 'absolute';
+    btn.style.top = '10px';
+    btn.style.right = '12px';
+    btn.style.width = '32px';
+    btn.style.height = '32px';
+    btn.style.zIndex = '2147483647';
+    btn.style.background = 'transparent';
+    btn.style.border = '0';
+    btn.style.color = '#fff';
+    btn.style.cursor = 'pointer';
+    btn.style.textAlign = 'center';
+    btn.style.lineHeight = '32px';
+    btn.style.fontFamily = 'Arial, Helvetica, sans-serif';
+    btn.style.fontSize = '28px';
+    btn.style.fontWeight = '400';
+  }
+
+  function getPanel(){ return qs('nav.push-menu'); }
+
+  function isOpen(){
+    return document.body.classList.contains('push-menu-open') ||
+           document.documentElement.classList.contains('push-menu-open');
+  }
+
+  function setOpen(openNow){
+    forceCloseGlyph();
+
+    document.documentElement.classList.toggle('push-menu-open', openNow);
+    document.body.classList.toggle('push-menu-open', openNow);
+
+    var toggle = qs('.menu-toggle');
+    if (toggle){
+      toggle.classList.toggle('push-menu--open', openNow);
+      toggle.classList.toggle('push-menu--closed', !openNow);
+
+      var txt = toggle.querySelector('.menu-toggle__text');
+      if (txt){
+        txt.classList.toggle('push-menu--open', openNow);
+        txt.classList.toggle('push-menu--closed', !openNow);
+      }
+    }
+
+    var panel = getPanel();
+    if (panel){
+      /* force panel on top of video/page */
+      panel.style.position = 'fixed';
+      panel.style.left = '0';
+      panel.style.right = '0';
+      panel.style.width = '100%';
+      panel.style.zIndex = '999999';
+      panel.style.display = 'block';
+
+      if (openNow){
+        panel.style.top = '0';
+        panel.style.visibility = 'visible';
+        panel.style.opacity = '1';
+        panel.style.pointerEvents = 'auto';
+      } else {
+        panel.style.top = '-120vh';
+        panel.style.visibility = 'hidden';
+        panel.style.opacity = '0';
+        panel.style.pointerEvents = 'none';
+      }
+    }
+  }
+
+  function toggleMenu(){
+    setOpen(!isOpen());
+  }
+
+  function bootCloseGlyph(){
+    forceCloseGlyph();
+    setTimeout(forceCloseGlyph, 100);
+    setTimeout(forceCloseGlyph, 400);
+    setTimeout(forceCloseGlyph, 900);
+  }
+
+  document.addEventListener('click', function(e){
+    /* X close button */
+    if (e.target.closest('.push-menu__close-btn')){
+      e.preventDefault();
+      e.stopPropagation();
+      setOpen(false);
+      return;
+    }
+
+    /* SELECT A CATEGORY toggle */
+    if (e.target.closest('#nav-toggle, .menu-toggle, .menu-toggle__link, .menu-toggle__text')){
+      e.preventDefault();
+      e.stopPropagation();
+      toggleMenu();
+      return;
+    }
+
+    /* tap outside closes */
+    var panel = getPanel();
+    if (!panel) return;
+    if (!isOpen()) return;
+    if (panel.contains(e.target)) return;
+
+    setOpen(false);
+  }, true);
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bootCloseGlyph);
+  } else {
+    bootCloseGlyph();
+  }
+
+  window.addEventListener('load', bootCloseGlyph);
+
+  /* Start closed on mobile */
+  document.addEventListener('DOMContentLoaded', function(){
+    if (!isMobile()) return;
+    setOpen(false);
+  });
+
+  /* If resizing to desktop, force closed */
+  window.addEventListener('resize', function(){
+    if (!isMobile()) setOpen(false);
+  });
+})();
+</script>
+
+<script>
+(function () {
+  function hoistPushMenu() {
+    var panel = document.querySelector('nav.push-menu');
+    if (!panel) return;
+
+    if (panel.parentNode !== document.body) {
+      document.body.appendChild(panel);
+    }
+  }
+
+  function closePushMenu() {
+    document.documentElement.classList.remove('push-menu-open');
+    document.body.classList.remove('push-menu-open');
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', hoistPushMenu);
+  } else {
+    hoistPushMenu();
+  }
+
+  window.addEventListener('load', hoistPushMenu);
+  setTimeout(hoistPushMenu, 300);
+  setTimeout(hoistPushMenu, 1000);
+
+  document.addEventListener('click', function (e) {
+    var x = e.target.closest('.push-menu__close-btn');
+    if (!x) return;
+    e.preventDefault();
+    e.stopPropagation();
+    closePushMenu();
+  }, true);
+})();
+</script>
+<script>
+(function () {
+  function isMobile() {
+    return window.matchMedia('(max-width: 991px)').matches;
+  }
+
+  function stripSubmenus(scope) {
+    if (!scope) return;
+
+    /* remove all submenu toggle buttons/icons in MOBILE menu only */
+    scope.querySelectorAll(
+      '.vnav__icon, .vnav__arrow, .vnav__caret, .vnav__toggle, .vnav__expand, .mc-sub-toggle, .mc-mobile-vnav__toggle'
+    ).forEach(function (el) {
+      el.remove();
+    });
+
+    /* remove nested ULs in MOBILE menu only */
+    scope.querySelectorAll('li > ul').forEach(function (ul) {
+      ul.remove();
+    });
+
+    scope.querySelectorAll('li').forEach(function (li) {
+      li.classList.remove('mc-has-sub', 'has-sub', 'mc-open', 'is-open');
+    });
+  }
+
+  function run() {
+    if (!isMobile()) return;
+
+    stripSubmenus(document.querySelector('#push-nav__menu'));
+    stripSubmenus(document.querySelector('.push-menu__menu-wrapper'));
+
+    setTimeout(function () {
+      if (!isMobile()) return;
+      stripSubmenus(document.querySelector('#push-nav__menu'));
+      stripSubmenus(document.querySelector('.push-menu__menu-wrapper'));
+    }, 200);
+
+    setTimeout(function () {
+      if (!isMobile()) return;
+      stripSubmenus(document.querySelector('#push-nav__menu'));
+      stripSubmenus(document.querySelector('.push-menu__menu-wrapper'));
+    }, 800);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', run);
+  } else {
+    run();
+  }
+
+  window.addEventListener('load', run);
+  window.addEventListener('resize', run);
+
+  if (!window.__mcStripSubmenusObserver) {
+    window.__mcStripSubmenusObserver = new MutationObserver(function () {
+      if (!isMobile()) return;
+      run();
+    });
+    window.__mcStripSubmenusObserver.observe(document.documentElement, {
+      childList: true,
+      subtree: true
+    });
+  }
+})();
+</script>
+<script>
+(function(){
+  function removeCartFromDesktopNav(){
+    // Only on desktop
+    if (window.matchMedia('(max-width: 991px)').matches) return;
+
+    var scope = document.querySelector('#display_menu_1');
+    if (!scope) return;
+
+    scope.querySelectorAll('li, a').forEach(function(node){
+      var txt = (node.textContent || '').trim().toUpperCase();
+      if (txt === 'MY CART') {
+        var li = node.closest('li');
+        if (li && scope.contains(li)) li.remove();
+      }
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', removeCartFromDesktopNav);
+  window.addEventListener('load', removeCartFromDesktopNav);
+  setTimeout(removeCartFromDesktopNav, 300);
+  setTimeout(removeCartFromDesktopNav, 1000);
+})();
+</script>
+<script>
+(function () {
+  function q(sel, root){ return (root || document).querySelector(sel); }
+  function qa(sel, root){ return Array.from((root || document).querySelectorAll(sel)); }
+  function isMobile(){ return window.matchMedia('(max-width: 991px)').matches; }
+  /** Same logic as global parseMcCurrency; IIFE cannot rely on another script block’s scope on Volusion. */
+  function mcParseCurrency(text){
+    if (typeof window.parseMcCurrency === 'function') return window.parseMcCurrency(text);
+    var src = text == null ? '' : String(text);
+    var m = src.match(/\$[\d,]+(?:\.\d+)?/);
+    if (!m) {
+      var raw = src.replace(/[^0-9.]/g, '');
+      var parsed = parseFloat(raw);
+      return isNaN(parsed) ? 0 : parsed;
+    }
+    return parseFloat(m[0].replace(/[$,]/g, '')) || 0;
+  }
+
+  function markProductPage() {
+    /* Volusion injects #content_area asynchronously; don’t rely only on ProductCode timing. */
+    var pcInp =
+      document.querySelector('input[name="ProductCode"]') ||
+      document.querySelector('input[name="productcode"]');
+    var hasMarker =
+      pcInp ||
+      document.querySelector('#v65-product-parent') ||
+      document.querySelector('.colors_pricebox');
+    if (!hasMarker) return false;
+    document.body.classList.add('mc-product-page');
+    try { document.body.classList.remove('mc-hide-native-options-until-mc'); } catch (eMcH) {}
+    try {
+      if (typeof window.isSectionalProductPage === "function" && window.isSectionalProductPage()) {
+        document.documentElement.classList.add("is-sectional-product");
+        document.body.classList.remove("mc-hide-native-options-until-mc");
+      }
+    } catch (ePdSec) {}
+    try { document.body.classList.remove('is-home'); } catch (eH) {}
+    try {
+      if (typeof isBeanBagProductPage === 'function' && isBeanBagProductPage()) {
+        document.body.classList.add('mc-bean-bag-pdp');
+      }
+    } catch (eBbCls) {}
+    return true;
+  }
+
+  function forceNoItalics(scope){
+    qa(
+      'h1, h2, h3, h4, .productnamecolor, .productnamecolorLARGE, .colors_productname,' +
+      '.tab, .tab a, .resp-tab-item, .resp-tabs-list li, .TabbedPanelsTab, .ui-tabs-nav li,' +
+      'label, .productoptionname, td.productoptionname',
+      scope
+    ).forEach(function(el){
+      el.style.setProperty('font-style','normal','important');
+      el.style.setProperty('font-family','inherit','important');
+    });
+  }
+
+  function forceOptionLabel(scope){
+    var secPg =
+      document.documentElement.classList.contains("is-sectional-product") ||
+      (typeof window.isSectionalProductPage === "function" && window.isSectionalProductPage());
+    qa(
+      '#options_table .productoptionname, #options_table td.productoptionname, #options_table td[align="right"], #options_table label,' +
+      'table[id*="options_table"] .productoptionname, table[id*="options_table"] td.productoptionname, table[id*="options_table"] td[align="right"], table[id*="options_table"] label,' +
+      (secPg ? '' : '#mcLeatherHeader,'),
+      scope
+    ).forEach(function(el){
+      if (secPg && (el.id === "mcLeatherHeader" || (el.closest && el.closest("#mcLeatherRow")))) {
+        return;
+      }
+      el.style.setProperty('text-align','left','important');
+      el.style.setProperty('padding-left','0','important');
+      el.style.setProperty('margin-left','0','important');
+      el.style.setProperty('display','block','important');
+      el.style.setProperty('width','auto','important');
+      el.style.setProperty('font-style','normal','important');
+
+      var raw = (el.textContent || '').replace(/\s+/g, ' ').trim();
+      var normalized = raw.toLowerCase().replace(/:$/, '').trim();
+      var hasField = !!q('select, input, textarea, button', el);
+      if (!hasField && (normalized === 'choose cover' || normalized === 'choose leather')) {
+        el.textContent = 'SELECT A LEATHER:';
+      }
+      // keep labels visible so desktop option headers always render
+    });
+  }
+
+  function hideLegacyOptionQuestions(scope){
+    var root = scope || document;
+    var nodes = qa('#content_area *', root);
+    nodes.forEach(function(el){
+      var txt = (el.textContent || '').replace(/\s+/g, ' ').trim().toLowerCase();
+      if (!txt) return;
+      if (txt === 'straight or curved?' || txt === 'straight or curved ?') {
+        el.style.setProperty('display','none','important');
+      }
+    });
+  }
+
+  function forceTabsInline(scope){
+    qa('.resp-tabs-list, ul.resp-tabs-list, .ui-tabs-nav, .TabbedPanelsTabGroup', scope).forEach(function(tabWrap){
+      tabWrap.style.setProperty('display','flex','important');
+      tabWrap.style.setProperty('flex-wrap','nowrap','important');
+      tabWrap.style.setProperty('align-items','center','important');
+      tabWrap.style.setProperty('gap','8px','important');
+      tabWrap.style.setProperty('overflow-x','auto','important');
+      tabWrap.style.setProperty('white-space','nowrap','important');
+      tabWrap.style.setProperty('padding','0','important');
+      tabWrap.style.setProperty('margin','0 0 12px 0','important');
+
+      qa('li, .resp-tab-item, .TabbedPanelsTab', tabWrap).forEach(function(tab){
+        tab.style.setProperty('float','none','important');
+        tab.style.setProperty('display','inline-block','important');
+        tab.style.setProperty('width','auto','important');
+        tab.style.setProperty('white-space','nowrap','important');
+        tab.style.setProperty('margin','0','important');
+      });
+    });
+
+    /* Volusion vCSS_tab strips stay hidden via custom-safe.css — do NOT set inline-flex on
+       td[class*="vCSS_tab"] here; inline !important defeats stylesheet hides (#content_area). */
+  }
+
+  function findMainMedia(scope) {
+    return (
+      q('#product_photo', scope) ||
+      q('img#product_photo', scope) ||
+      q('#product_photo_td', scope) ||
+      q('.vcss_img_wrap', scope) ||
+      q('.vCSS_img_wrap', scope) ||
+      q('.main-image', scope) ||
+      q('img#main-image', scope) ||
+      q('img[itemprop="image"]', scope)
+    );
+  }
+
+  function stackMediaAbovePricing(scope){
+    if (!isMobile()) return;
+
+    var media = findMainMedia(scope);
+    if (!media) return;
+
+    var mediaTd = media.closest('td');
+    var addBtn =
+      q('input[name="btnaddtocart"]', scope) ||
+      q('input[id*="btnaddtocart"]', scope) ||
+      qa('input[type="submit"], button', scope).find(function(el){
+        return /add to cart/i.test(el.value || el.textContent || '');
+      });
+
+    var pricingTd = addBtn ? addBtn.closest('td') : null;
+    if (!mediaTd || !pricingTd || mediaTd === pricingTd) return;
+
+    var row = mediaTd.parentNode;
+    if (!row || row !== pricingTd.parentNode) return;
+
+    row.insertBefore(mediaTd, pricingTd);
+
+    row.style.setProperty('display', 'block', 'important');
+    mediaTd.style.setProperty('display', 'block', 'important');
+    pricingTd.style.setProperty('display', 'block', 'important');
+    mediaTd.style.setProperty('width', '100%', 'important');
+    pricingTd.style.setProperty('width', '100%', 'important');
+    mediaTd.style.setProperty('float', 'none', 'important');
+    pricingTd.style.setProperty('float', 'none', 'important');
+    mediaTd.style.setProperty('margin-bottom', '4px', 'important');
+    mediaTd.style.setProperty('padding-bottom', '0', 'important');
+    pricingTd.style.setProperty('padding-top', '4px', 'important');
+    pricingTd.style.setProperty('margin-top', '0', 'important');
+  }
+
+  // --- Key fix: desktop wrapper exists? remove it on mobile ---
+  function unwrapDesktopMediaWrap(scope){
+    var wrap = q('.mc-prod-media-wrap', scope);
+    if (!wrap || !wrap.parentNode) return;
+
+    var parent = wrap.parentNode;
+    var thumbsEl =
+      q('#altviews', wrap) ||
+      q('#altviews', scope) ||
+      q('.altviews', wrap) ||
+      q('.altviews', scope);
+
+    var kids = Array.prototype.slice.call(wrap.childNodes);
+    var ki;
+    for (ki = 0; ki < kids.length; ki++) {
+      parent.insertBefore(kids[ki], wrap);
+    }
+    wrap.remove();
+
+    if (thumbsEl) {
+      thumbsEl.removeAttribute('style');
+      qa('a, img', thumbsEl).forEach(function (el) { el.removeAttribute('style'); });
+    }
+  }
+
+  function centerMainImageMobile(scope){
+    var media = findMainMedia(scope);
+    if (!media) return;
+
+    var img = (media.tagName === 'IMG')
+      ? media
+      : (q('img', media) || q('img#main-image', scope) || q('img#product_photo', scope));
+
+    media.style.setProperty('display', 'block', 'important');
+    media.style.setProperty('width', '100%', 'important');
+    media.style.setProperty('max-width', '100%', 'important');
+    media.style.setProperty('margin', '0 auto 12px auto', 'important');
+    media.style.setProperty('text-align', 'center', 'important');
+    media.style.setProperty('float', 'none', 'important');
+
+    if (!img) return;
+    img.style.setProperty('display', 'block', 'important');
+    img.style.setProperty('margin', '0 auto', 'important');
+    img.style.setProperty('width', '100%', 'important');
+    img.style.setProperty('max-width', '100%', 'important');
+    img.style.setProperty('height', 'auto', 'important');
+  }
+
+  function syncAltviewsToMainImage(scope){
+    if (!isMobile()) return;
+    var thumbs = q('#altviews', scope) || q('span#altviews', scope) || q('.altviews', scope);
+    if (!thumbs) return;
+
+    /* Drop orphaned wrappers left when Volusion re-parents #altviews (observer + interval were stacking empty shells). */
+    var altRoot = scope && scope.querySelectorAll ? scope : document;
+    qa('.mc-altviews-outer', altRoot).forEach(function (shell) {
+      if (shell.contains(thumbs)) return;
+      if (!shell.querySelector('#altviews, span#altviews, .altviews') && !(shell.textContent || '').replace(/\s+/g, '').length) {
+        try { shell.remove(); } catch (eRmShell) {}
+      }
+    });
+
+    var contentArea = scope && scope.id === 'content_area' ? scope : (q('#content_area') || document.body);
+    if (thumbs.getAttribute('data-mc-alt-ancestors') !== '1') {
+      var node = thumbs.parentNode;
+      while (node && node !== contentArea && node !== document.body) {
+        node.style.setProperty('width', '100%', 'important');
+        node.style.setProperty('max-width', '100%', 'important');
+        if (node.tagName === 'TR') node.style.setProperty('display', 'block', 'important');
+        if (node.tagName === 'TD' || node.tagName === 'TH') {
+          node.style.setProperty('display', 'block', 'important');
+          node.style.setProperty('text-align', 'center', 'important');
+        }
+        node = node.parentNode;
+      }
+      thumbs.setAttribute('data-mc-alt-ancestors', '1');
+    }
+
+    var outer = thumbs.closest ? thumbs.closest('.mc-altviews-outer') : null;
+    if (!outer) {
+      var parent = thumbs.parentNode;
+      if (parent && parent !== document.body) {
+        outer = document.createElement('div');
+        outer.className = 'mc-altviews-outer';
+        parent.insertBefore(outer, thumbs);
+        outer.appendChild(thumbs);
+      }
+    }
+    if (outer) {
+      outer.style.cssText = 'display:flex!important;justify-content:center!important;align-items:center!important;width:100%!important;margin:4px 0 8px 0!important;padding:0!important;order:2!important;';
+    }
+
+    /* No negative margins: they yank price/options under the hero and flash/jump when this runs (observer + interval). */
+    thumbs.style.cssText = 'display:flex!important;flex-wrap:wrap!important;justify-content:center!important;align-items:center!important;gap:10px!important;width:100%!important;max-width:100%!important;margin:0 auto 8px auto!important;padding:0!important;float:none!important;clear:both!important;position:static!important;left:auto!important;right:auto!important;transform:none!important;box-sizing:border-box!important;text-align:center!important;';
+    thumbs.setAttribute('data-mc-alt-synced', '1');
+
+    var allLinks = thumbs.querySelectorAll('a');
+    for (var i = 0; i < allLinks.length; i++) {
+      allLinks[i].style.cssText = 'display:block!important;flex:0 0 64px!important;width:64px!important;min-width:64px!important;max-width:64px!important;float:none!important;margin:0!important;padding:0!important;';
+    }
+    var kids = thumbs.children;
+    for (var k = 0; k < kids.length; k++) {
+      if (kids[k].tagName === 'DIV') kids[k].style.cssText = 'display:block!important;flex:0 0 64px!important;width:64px!important;min-width:64px!important;max-width:64px!important;margin:0!important;padding:0!important;';
+    }
+    var allImgs = thumbs.querySelectorAll('img');
+    for (var j = 0; j < allImgs.length; j++) {
+      allImgs[j].style.cssText = 'width:100%!important;max-width:64px!important;height:auto!important;max-height:64px!important;object-fit:contain!important;display:block!important;float:none!important;margin:0 auto!important;';
+    }
+  }
+
+  function wireAltThumbClicks(scope){
+    var thumbsRoot = q('#altviews', scope) || q('span#altviews', scope) || q('.altviews', scope);
+    if (!thumbsRoot) return;
+
+    qa('a', thumbsRoot).forEach(function(link){
+      if (link.getAttribute('data-mc-thumb-bound') === '1') return;
+      link.setAttribute('data-mc-thumb-bound', '1');
+
+      link.addEventListener('click', function(e){
+        e.preventDefault();
+        e.stopPropagation();
+        if (e.stopImmediatePropagation) e.stopImmediatePropagation();
+
+        var main =
+          q('img#product_photo', scope) ||
+          q('#product_photo', scope) ||
+          q('img#main-image', scope);
+
+        if (!main) return;
+
+        var thumbImg = q('img', link);
+        var href = link.getAttribute('href') || '';
+        if (/^javascript:/i.test(href) || href === '#') href = '';
+        if (!href && thumbImg) {
+          href =
+            thumbImg.getAttribute('data-zoom-image') ||
+            thumbImg.getAttribute('data-large') ||
+            thumbImg.getAttribute('data-full') ||
+            thumbImg.getAttribute('data-image') ||
+            thumbImg.currentSrc ||
+            thumbImg.getAttribute('src') ||
+            '';
+        }
+        href = href
+          .replace(/\/thumbnails\//i, '/')
+          .replace(/-(\d+)T(\.[a-z0-9]+)(\?.*)?$/i, '-$1$2$3');
+        if (!href) return;
+
+        main.setAttribute('src', href);
+        if (main.closest('a')) main.closest('a').setAttribute('href', href);
+        var zoomLink = q('a#product_photo_zoom_url', scope) || q('a#product_photo_zoom_url2', scope);
+        if (zoomLink) zoomLink.setAttribute('href', href);
+      }, true);
+    });
+  }
+  function fixAltViewsLayout(scope){
+    var altviews = q('#altviews', scope);
+    if (!altviews) return;
+
+    var photo = q('#product_photo', scope);
+    if (!photo) return;
+
+    // Walk up from photo to find the TD that directly contains both the inner
+    // image table and #altviews (the outer left TD in v65-product-parent).
+    var outerTd = altviews.parentNode;
+    if (!outerTd) return;
+
+    var innerTable = outerTd.querySelector('table');
+    if (!innerTable) return;
+
+    // Override CDN float layout: make the outer TD a flex column so thumbnails
+    // stack below the main image.
+    outerTd.style.setProperty('display', 'flex', 'important');
+    outerTd.style.setProperty('flex-direction', 'column', 'important');
+    outerTd.style.setProperty('align-items', 'stretch', 'important');
+
+    // Kill the CDN float on the inner image table.
+    innerTable.style.setProperty('float', 'none', 'important');
+    innerTable.style.setProperty('width', '100%', 'important');
+
+    // Make altviews a wrapping flex row of thumbnails.
+    altviews.style.setProperty('float', 'none', 'important');
+    altviews.style.setProperty('width', '100%', 'important');
+    altviews.style.setProperty('display', 'flex', 'important');
+    altviews.style.setProperty('flex-direction', 'row', 'important');
+    altviews.style.setProperty('flex-wrap', 'wrap', 'important');
+    altviews.style.setProperty('gap', '8px', 'important');
+
+    // Style each thumbnail anchor.
+    var thumbLinks = altviews.querySelectorAll('a');
+    thumbLinks.forEach(function(a){
+      a.style.setProperty('flex', '0 0 calc(25% - 6px)', 'important');
+      a.style.setProperty('width', 'calc(25% - 6px)', 'important');
+      a.style.setProperty('aspect-ratio', '1/1', 'important');
+      a.style.setProperty('overflow', 'hidden', 'important');
+      a.style.setProperty('display', 'block', 'important');
+      a.style.setProperty('margin', '0', 'important');
+    });
+
+    // Style each thumbnail image.
+    var thumbImgs = altviews.querySelectorAll('img');
+    thumbImgs.forEach(function(img){
+      img.style.setProperty('width', '100%', 'important');
+      img.style.setProperty('height', '100%', 'important');
+      img.style.setProperty('object-fit', 'cover', 'important');
+      img.style.setProperty('display', 'block', 'important');
+    });
+  }
+
+  function forceMediaLayout(scope){
+    wireAltThumbClicks(scope);
+
+    if (isMobile()) {
+      if (window.__mcMediaLayoutBusy) return;
+      window.__mcMediaLayoutBusy = true;
+      try {
+        unwrapDesktopMediaWrap(scope);
+        stackMediaAbovePricing(scope);
+        centerMainImageMobile(scope);
+        syncAltviewsToMainImage(scope);
+      } finally {
+        setTimeout(function () { window.__mcMediaLayoutBusy = false; }, 80);
+      }
+      return;
+    }
+
+    /* Desktop: strip legacy wrapper, then fix alt-thumbnail layout. */
+    unwrapDesktopMediaWrap(scope);
+    fixAltViewsLayout(scope);
+  }
+
+  function removeConfigurationDetails(scope){
+    if (typeof window.isSectionalProductPage === "function" && window.isSectionalProductPage()) return;
+    var optionsTable = q('#options_table', scope) || q('table[id*="options_table"]', scope);
+    if (!optionsTable) return;
+
+    var rows = qa('tr', optionsTable);
+    rows.forEach(function(row){
+      var txt = (row.textContent || '').replace(/\s+/g, ' ').toLowerCase();
+      var configField = row.querySelector('input[title="Configuration Details"], textarea[title="Configuration Details"], input[name^="TEXTBOX___"], textarea[name^="TEXTBOX___"]');
+      if (configField && configField.name) window.__mcPlannerCartFieldName = configField.name;
+
+      // Any row that is the "Configuration Details" header, "please note..." text, or comment box
+      var isCommentRow = !!row.querySelector('textarea, input[title="Configuration Details"], textarea[title="Configuration Details"], input[name^="TEXTBOX___"], textarea[name^="TEXTBOX___"]');
+      if (txt.indexOf('configuration details') !== -1 ||
+          txt.indexOf("please note how you'd like your seats arranged") !== -1 ||
+          isCommentRow) {
+        if (row.parentNode) row.parentNode.removeChild(row);
+      }
+    });
+  }
+
+  function tagOptionRows(scope){
+    var optionsTable = q('#options_table', scope) || q('table[id*="options_table"]', scope);
+    if (!optionsTable) return;
+
+    qa('tr', optionsTable).forEach(function(row){
+      var hasLeatherControl = !!q('select.mc-native-leather', row);
+      if (hasLeatherControl) row.classList.add('mc-leather-option-row');
+
+      var hasConfigControl = !!q('select:not(.mc-native-leather), textarea, input[type="text"], input[type="number"]', row);
+      if (hasConfigControl) row.classList.add('mc-option-row');
+    });
+  }
+
+  function clampFloatingIcons(){
+    /* Cart/home position and size come from custom-safe.css (safe-area, no run-off) */
+    if (!isMobile()) return;
+  }
+
+  function enforceMobileGutters(scope){
+    if (!isMobile()) return;
+
+    var nodes = qa([
+      '.content_area-wrapper',
+      '#content_area',
+      '#v65-product-parent',
+      '#v65-product-parent td',
+      '#v65-product-parent th',
+      '#content_area .resp-tabs-container',
+      '#content_area .TabbedPanelsContentGroup',
+      '#content_area .tabcontent'
+    ].join(','), scope || document);
+
+    nodes.forEach(function(node){
+      node.style.setProperty('box-sizing', 'border-box', 'important');
+      node.style.setProperty('max-width', '100%', 'important');
+    });
+
+    qa('.content_area-wrapper, #content_area', scope || document).forEach(function(node){
+      node.style.setProperty('padding-left', '14px', 'important');
+      node.style.setProperty('padding-right', '14px', 'important');
+      node.style.setProperty('margin-left', '0', 'important');
+      node.style.setProperty('margin-right', '0', 'important');
+    });
+
+    qa('#v65-product-parent td, #v65-product-parent th, #content_area .tabcontent', scope || document).forEach(function(node){
+      node.style.setProperty('padding-left', '10px', 'important');
+      node.style.setProperty('padding-right', '10px', 'important');
+    });
+  }
+
+  function electsToLongestOption(scope){
+    var root = scope || document;
+    var table = q('#options_table', root) || q('table[id*="options_table"]', root);
+    if (!table) return;
+    var selects = qa('select', table).filter(function(sel){ return !sel.classList.contains('mc-native-leather'); });
+    selects.forEach(function(sel){
+      if (sel.closest('.mc-option-accordion')) return;
+      var opts = qa('option', sel);
+      var longest = 0;
+      opts.forEach(function(opt){
+        var t = (opt.textContent || opt.innerText || '').trim();
+        if (t.length > longest) longest = t.length;
+      });
+      if (longest > 0) {
+        var ch = Math.min(Math.max(longest + 2, 24), 42);
+        sel.style.setProperty('width', '100%', 'important');
+        sel.style.setProperty('max-width', ch + 'ch', 'important');
+        sel.style.setProperty('min-width', '0', 'important');
+        sel.style.setProperty('box-sizing', 'border-box', 'important');
+      }
+    });
+  }
+
+  function rowHasLeatherSelect(tr){
+    var sel = tr.querySelector('select.mc-native-leather');
+    if (sel) return true;
+    var selects = tr.querySelectorAll('select');
+    for (var i = 0; i < selects.length; i++) {
+      var n = (selects[i].name || '').toLowerCase();
+      var id = (selects[i].id || '').toLowerCase();
+      if (n.indexOf('cover') !== -1 || n.indexOf('leather') !== -1 || id.indexOf('cover') !== -1 || id.indexOf('leather') !== -1) return true;
+    }
+    return false;
+  }
+  function wrapSelectsAsAccordions(scope){
+    try {
+    var root = scope || document;
+    var tables = qa('#options_table, table[id*="options_table"]', root);
+    if (!tables.length) return;
+    tables.forEach(function(table){
+    var rows = qa('tr', table);
+    rows.forEach(function(tr){
+      var labelTd = tr.querySelector('td:first-child');
+      if (tr.querySelector('.mc-option-accordion')) {
+        if (labelTd) {
+          if (window.matchMedia('(max-width: 961px)').matches) labelTd.style.setProperty('display', 'none', 'important');
+          else labelTd.style.removeProperty('display');
+        }
+        return;
+      }
+      var sel = q('select:not(.mc-native-leather)', tr);
+      if (!sel) return;
+      var valueTd = tr.querySelector('td:last-child');
+      if (!valueTd || !labelTd) return;
+      var labelText = (labelTd.textContent || '').replace(/\s+/g, ' ').trim();
+      if (!labelText) {
+        var selName = (sel.name || '').toLowerCase();
+        var selId = (sel.id || '').toLowerCase();
+        var hasStraightCurved = /straight|curved|configuration/.test(selName + ' ' + selId);
+        if (!hasStraightCurved && sel.options) {
+          for (var oi = 0; oi < sel.options.length; oi++) {
+            var ot = (sel.options[oi].textContent || '').toLowerCase();
+            if (/straight|curved|configuration/.test(ot)) { hasStraightCurved = true; break; }
+          }
+        }
+        labelText = hasStraightCurved ? 'Configuration' : 'Option';
+      }
+      labelText = labelText.toUpperCase();
+      var options = [];
+      qa('option', sel).forEach(function(opt){
+        var t = (opt.textContent || '').replace(/\s+/g, ' ').trim();
+        var v = (opt.value || '').trim();
+        if (!v && !t) return;
+        options.push({ text: t, value: v, selected: opt.selected });
+      });
+      if (options.length === 0) return;
+      var curVal = sel.value;
+      var selectedOpt = options.filter(function(o){ return o.value === curVal; })[0] || options.filter(function(o){ return o.selected; })[0] || options[0];
+      var wrap = document.createElement('div');
+      wrap.className = 'mc-option-accordion';
+      wrap.innerHTML =
+        '<div class="mc-option-accordion__header">' +
+          '<span class="mc-option-accordion__label">' + escapeHtml(labelText) + '</span>' +
+          '<button type="button" class="mc-option-accordion__toggle" aria-expanded="false" aria-label="Open options">&#8250;</button>' +
+        '</div>' +
+        '<div class="mc-option-accordion__selected">' + escapeHtml(selectedOpt.text) + '</div>' +
+        '<div class="mc-option-accordion__panel" role="region" aria-hidden="true"></div>';
+      var selectedEl = wrap.querySelector('.mc-option-accordion__selected');
+      var panelEl = wrap.querySelector('.mc-option-accordion__panel');
+      var toggleBtn = wrap.querySelector('.mc-option-accordion__toggle');
+      options.forEach(function(o){
+        var btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'mc-option-accordion__choice';
+        btn.textContent = o.text;
+        btn.dataset.value = o.value;
+        btn.addEventListener('click', function(){
+          sel.value = o.value;
+          selectedEl.textContent = o.text;
+          toggleBtn.setAttribute('aria-expanded', 'false');
+          panelEl.setAttribute('aria-hidden', 'true');
+          panelEl.classList.remove('mc-option-accordion__panel--open');
+          sel.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+        panelEl.appendChild(btn);
+      });
+      toggleBtn.addEventListener('click', function(){
+        var open = panelEl.classList.toggle('mc-option-accordion__panel--open');
+        toggleBtn.setAttribute('aria-expanded', open);
+        panelEl.setAttribute('aria-hidden', !open);
+      });
+      sel.classList.add('mc-option-accordion-native');
+      valueTd.appendChild(wrap);
+      valueTd.appendChild(sel);
+      tr.classList.add('mc-accordion-row');
+      if (window.matchMedia('(max-width: 961px)').matches) labelTd.style.setProperty('display', 'none', 'important');
+      else labelTd.style.removeProperty('display');
+    });
+    });
+    } catch (e) { if (typeof console !== 'undefined' && console.warn) console.warn('wrapSelectsAsAccordions:', e); }
+  }
+  function escapeHtml(s){ var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+  function clearAddToCartWrapperBackground(scope) {
+    var btn = (scope || document).querySelector('input[name="btnaddtocart"], input[id*="btnaddtocart"], button[name="btnaddtocart"]');
+    if (!btn) return;
+    var el = btn.parentElement;
+    var stop = document.querySelector('#content_area') || document.querySelector('#v65-product-parent') || document.body;
+    while (el && el !== stop) {
+      el.style.setProperty('background', 'transparent', 'important');
+      el.style.setProperty('background-color', 'transparent', 'important');
+      el.style.setProperty('box-shadow', 'none', 'important');
+      el.style.setProperty('border', '0', 'important');
+      el.style.setProperty('padding', '0', 'important');
+      el = el.parentElement;
+    }
+    var atcWrap = btn.closest('.mc-atc-button-wrap');
+    if (atcWrap) {
+      atcWrap.style.setProperty('background', '#fff', 'important');
+      atcWrap.style.setProperty('background-color', '#fff', 'important');
+      atcWrap.style.setProperty('color', '#444', 'important');
+      atcWrap.style.setProperty('border', '1px solid #777', 'important');
+      atcWrap.style.setProperty('border-radius', '10px', 'important');
+    }
+    btn.style.setProperty('background', 'transparent', 'important');
+    btn.style.setProperty('background-color', 'transparent', 'important');
+    btn.style.setProperty('background-image', 'none', 'important');
+    btn.style.setProperty('-webkit-appearance', 'none', 'important');
+    btn.style.setProperty('appearance', 'none', 'important');
+    btn.style.setProperty('box-shadow', 'none', 'important');
+    btn.style.setProperty('padding', '0', 'important');
+    btn.style.setProperty('margin', '0', 'important');
+    btn.style.setProperty('border', 'none', 'important');
+    btn.style.setProperty('color', 'inherit', 'important');
+  }
+
+  var cartIconSvg = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="mc-cart-icon" aria-hidden="true"><circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"/></svg>';
+  function injectAddToCartIcon(scope) {
+    var root = scope || document;
+    var btn = root.querySelector('input[name="btnaddtocart"], input[id*="btnaddtocart"], button[name="btnaddtocart"]');
+    if (!btn) return;
+    if (btn.tagName === 'INPUT' && (btn.type || '').toLowerCase() === 'image') {
+      try { btn.type = 'submit'; } catch (e) {}
+      btn.removeAttribute('src');
+      if (!btn.value) btn.value = 'ADD TO CART';
+    }
+    var existingWrap = btn.closest('.mc-atc-button-wrap');
+    if (existingWrap) {
+      var hasIcon = !!existingWrap.querySelector('.mc-cart-icon-wrapper');
+      if (!hasIcon) {
+        var iconWrapExisting = document.createElement('span');
+        iconWrapExisting.innerHTML = cartIconSvg;
+        iconWrapExisting.classList.add('mc-cart-icon-wrapper');
+        existingWrap.appendChild(iconWrapExisting);
+      }
+      existingWrap.style.setProperty('display', 'inline-flex', 'important');
+      existingWrap.style.setProperty('align-items', 'center', 'important');
+      existingWrap.style.setProperty('gap', '8px', 'important');
+      var parentExisting = existingWrap.parentNode;
+      if (parentExisting && parentExisting.children) {
+        Array.prototype.slice.call(parentExisting.children).forEach(function(child){
+          if (child !== existingWrap && child.classList && child.classList.contains('mc-cart-icon-wrapper')) child.remove();
+        });
+      }
+      return;
+    }
+    var oldWrap = btn.closest('.mc-atc-wrap');
+    if (oldWrap) {
+      while (oldWrap.firstChild) oldWrap.parentNode.insertBefore(oldWrap.firstChild, oldWrap);
+      oldWrap.remove();
+    }
+    var parent = btn.parentNode;
+    if (!parent) return;
+    var wrapper = document.createElement('div');
+    wrapper.className = 'mc-atc-button-wrap';
+    parent.insertBefore(wrapper, btn);
+    wrapper.appendChild(btn);
+    var iconWrap = document.createElement('span');
+    iconWrap.innerHTML = cartIconSvg;
+    iconWrap.classList.add('mc-cart-icon-wrapper');
+    wrapper.appendChild(iconWrap);
+    wrapper.style.setProperty('display', 'inline-flex', 'important');
+    wrapper.style.setProperty('align-items', 'center', 'important');
+    wrapper.style.setProperty('gap', '8px', 'important');
+    parent.classList.add('mc-atc-row');
+    if (parent && parent.children) {
+      Array.prototype.slice.call(parent.children).forEach(function(child){
+        if (child !== wrapper && child.classList && child.classList.contains('mc-cart-icon-wrapper')) child.remove();
+      });
+    }
+  }
+
+  /** Exact query param value — avoids indexOf('c=103') matching c=1030 / categoryid=1039. */
+  function mcGetQueryParamValue(name) {
+    var q = (location.search || '').replace(/^\?/, '');
+    if (!q) return null;
+    var want = String(name || '').toLowerCase();
+    var parts = q.split('&');
+    var i;
+    for (i = 0; i < parts.length; i++) {
+      var p = parts[i].split('=');
+      var k = decodeURIComponent((p[0] || '').replace(/\+/g, ' ')).toLowerCase();
+      if (k === want) {
+        return decodeURIComponent((p.slice(1).join('=') || '').replace(/\+/g, ' '));
+      }
+    }
+    return null;
+  }
+
+  /** Volusion category listings use `...-s/{id}.htm` (or `.html`) — authoritative vs. stray hidden CategoryID fields in the page. */
+  function mcListingCategoryIdFromPath() {
+    try {
+      var path = (location.pathname || '').toLowerCase();
+      var m = path.match(/-s\/(\d+)\.html?/i);
+      if (m) return String(m[1]);
+    } catch (eLc) {}
+    return null;
+  }
+
+  /** Path id, else `categoryid` / `c` query (e.g. category.asp?categoryid=157) — needed so stray DOM fields don’t imply the wrong category. */
+  function mcListingCategoryIdFromVolusion() {
+    if (/\/category-s\/157\.htm/i.test(location.pathname || '')) {
+      return '157';
+    }
+    var path = (location.pathname || '').toLowerCase();
+    if (/\/category-s\/157\.html?/.test(path) || /\/stationary-loveseats-s\/157\.html?/.test(path)) {
+      return '157';
+    }
+    var fromPath =
+      typeof mcListingCategoryIdFromPath === 'function' ? mcListingCategoryIdFromPath() : null;
+    /* Some stores omit `-s/`; last `/157.htm` segment on a PLP is still the category id. Skip obvious non-PLP paths. */
+    if (
+      !fromPath &&
+      !/productdetail|shoppingcart|myaccount|onepagecheckout|login\.asp|searchresult/i.test(path)
+    ) {
+      var tm = path.match(/\/(\d{2,6})\.html?(?:#|\?|$)/i);
+      if (tm) fromPath = String(tm[1]);
+    }
+    var cid =
+  mcGetQueryParamValue('categoryid') ||
+  mcGetQueryParamValue('category_id');
+
+var cParam = mcGetQueryParamValue('c');
+var catParam = mcGetQueryParamValue('cat');
+
+var fromQuery = null;
+if (cid && /^\d+$/.test(String(cid).trim())) fromQuery = String(cid).trim();
+else if (cParam && /^\d+$/.test(String(cParam).trim())) fromQuery = String(cParam).trim();
+else if (catParam && /^\d+$/.test(String(catParam).trim())) fromQuery = String(catParam).trim();
+    if (fromPath && fromQuery && fromPath !== fromQuery) return fromPath;
+    return fromPath || fromQuery || null;
+  }
+
+  /** Ensures PLP member block reorder + category-scoped CSS apply (fixCategoryGrid may run after first paint). */
+  function mcEnsureCategoryListingClasses() {
+    try {
+      var b = document.body;
+      if (!b || b.classList.contains('productdetails')) return;
+      if (b.classList.contains('is-home')) return;
+      var id = mcListingCategoryIdFromVolusion();
+      var path = (location.pathname || '').toLowerCase();
+      var hasListParams = !!(
+        mcGetQueryParamValue('categoryid') ||
+        mcGetQueryParamValue('category_id') ||
+        mcGetQueryParamValue('c')
+      );
+      var looksListing =
+        !!id ||
+        /-s\/\d+\.html?/i.test(path) ||
+        (hasListParams && /category\.asp/i.test(path));
+      if (!looksListing) return;
+      var ca = document.getElementById('content_area');
+      if (!ca || !ca.querySelector('.v-product, .v-product-grid, li.v-product')) return;
+      document.documentElement.classList.add('category');
+      b.classList.add('category');
+    } catch (eEcat) {}
+  }
+
+  function isBeanBagProductPage() {
+    try {
+      var pcInp = document.querySelector('input[name="ProductCode"], input[name="productcode"]');
+      var pc = String((pcInp && pcInp.value) || "").trim().toUpperCase();
+      if (/^SAR/.test(pc)) return false;
+      if (/^BB/.test(pc)) return true;
+      var p = (location.pathname || '').toLowerCase();
+      var catInp = document.querySelector(
+        'input[name="CategoryID"], input[name="categoryid"], input[name="Category_Id"]'
+      );
+      var catVal = catInp && String(catInp.value || '').trim();
+      if (catVal === '103') return true;
+      /* Fuzzy copy checks must NOT use document.body — global nav includes e.g. "Nest Bean Bags" (/nest/), which false-flagged every PDP as a bean bag and killed member pricing. */
+      var contentRoot =
+        document.getElementById('content_area') ||
+        document.getElementById('v65-product-parent') ||
+        document.body;
+      var bodyText = (contentRoot ? contentRoot.textContent : '').toLowerCase();
+      var titleText = (document.title || '').toLowerCase();
+
+      if (
+        /\/bean-bag-seating-s\//.test(p) ||
+        /product-p\/bb-/.test(p) ||
+        /cordaroys/.test(bodyText) ||
+        /cordaroys/.test(titleText) ||
+        /bean bag/.test(bodyText) ||
+        /bean bag/.test(titleText)
+      ) {
+        return true;
+      }
+
+      return false;
+    } catch (e) {
+      return false;
+    }
+  }
+  window.isBeanBagProductPage = isBeanBagProductPage;
+  function mcIsParagonOrTheaterPdpEarly() {
+    try {
+      if (document.body && document.body.classList.contains("mc-theater-seating-pdp")) return true;
+      if (document.documentElement.classList.contains("mc-paragon-pdp")) return true;
+      var path = String(location.pathname || "").toLowerCase();
+      if (/\bparagon\b/i.test(path)) return true;
+      if (/-s\/106(\b|\.|-|\/)/.test(path)) return true;
+      var pcInput = document.querySelector('input[name="ProductCode"]');
+      var pcVal = pcInput && String(pcInput.value || "").trim();
+      if (pcVal === "41417") return true;
+      if (/\bparagon\b|theater seating|theatre seating|theater chair|theatre chair/.test(
+        (
+          (document.querySelector("h1 [itemprop='name'], h1, .vp-product-title") || {}).textContent ||
+          document.title ||
+          ""
+        ).toLowerCase()
+      )) {
+        return true;
+      }
+    } catch (eEarly) {}
+    return false;
+  }
+
+  function mcShouldKeepOptionsOffscreen() {
+    if (mcIsParagonOrTheaterPdpEarly()) return true;
+    if (document.getElementById("mc-inline-config")) return true;
+    return mcPdpKeepsNativeOptionsOffscreen();
+  }
+
+  function mcPdpKeepsNativeOptionsOffscreen() {
+    if (!document.getElementById("mc-inline-config")) return false;
+    if (document.body && document.body.classList.contains("mc-theater-seating-pdp")) return true;
+    if (document.documentElement.classList.contains("mc-paragon-pdp")) return true;
+    if (document.querySelector(".mc-native-options-offscreen, [data-mc-hide-native-options='1']")) return true;
+    var title = (
+      (document.querySelector("h1 [itemprop='name'], h1, .vp-product-title") || {}).textContent ||
+      document.title ||
+      ""
+    ).toLowerCase();
+    return /\bparagon\b|theater seating|theatre seating|theater chair|theatre chair/.test(title);
+  }
+
+  function hideOptionsTable(scope){
+    if (typeof window.isBeanBagProductPage === "function" && window.isBeanBagProductPage()) return;
+    if (document.body && document.body.classList.contains("mc-saranoni-pdp")) return;
+    if (document.documentElement.classList.contains("has-sectional-config-cards")) return;
+    var root = scope || document;
+    var keepOffscreen = mcShouldKeepOptionsOffscreen();
+    var tables = qa('#options_table, table[id*="options_table"]', root);
+    tables.forEach(function(t){
+      if (keepOffscreen) {
+        if (t.dataset.mcHideNativeOptions === "1") return;
+        if (typeof window.mcApplyOffscreenNativeOptionsTable === "function") {
+          window.mcApplyOffscreenNativeOptionsTable(t);
+          return;
+        }
+        t.classList.add("mc-native-options-offscreen");
+        t.dataset.mcHideNativeOptions = "1";
+        try { t.style.setProperty("position", "absolute", "important"); } catch (e0) {}
+        try { t.style.setProperty("left", "-9999px", "important"); } catch (e1) {}
+        try { t.style.setProperty("opacity", "0", "important"); } catch (e2) {}
+        try { t.style.setProperty("pointer-events", "none", "important"); } catch (e3) {}
+        try { t.style.setProperty("height", "0", "important"); } catch (e4) {}
+        try { t.style.setProperty("overflow", "hidden", "important"); } catch (e5) {}
+        try { t.style.setProperty("display", "block", "important"); } catch (e6) {}
+        return;
+      }
+      if (document.body && document.body.classList.contains("mc-product-page")) return;
+      try { t.style.removeProperty('position'); } catch (e0) {}
+      try { t.style.removeProperty('left'); } catch (e1) {}
+      try { t.style.removeProperty('opacity'); } catch (e2) {}
+      try { t.style.removeProperty('pointer-events'); } catch (e3) {}
+      try { t.style.removeProperty('height'); } catch (e4) {}
+      try { t.style.removeProperty('overflow'); } catch (e5) {}
+    });
+  }
+
+  /** Theater PDP script may set display:none !important on "Choose configuration" rows; that beats CSS. Strip on sectionals. */
+  function unhideSectionalOptionRows(scope) {
+    if (typeof window.isSectionalProductPage !== "function" || !window.isSectionalProductPage()) return;
+    var root = scope || document;
+    if (!root.querySelectorAll) return;
+    var tables = root.querySelectorAll('#options_table, table[id*="options_table"]');
+    var ti;
+    for (ti = 0; ti < tables.length; ti++) {
+      var rows = tables[ti].querySelectorAll('tr');
+      var ri;
+      for (ri = 0; ri < rows.length; ri++) {
+        var tr = rows[ri];
+        try {
+          if (tr.classList && tr.classList.contains("mtl-native-config-row")) continue;
+          if (tr.querySelector && tr.querySelector('select.mc-native-leather')) continue;
+          if (tr.classList && tr.classList.contains('mc-leather-option-row')) continue;
+          var rowTxt = (tr.textContent || "").replace(/\s+/g, " ").trim().toLowerCase();
+          if (rowTxt === "choose cover" || rowTxt === "choose leather") continue;
+          var labelCell = tr.querySelector("td[align='right'], .productoptionname, label");
+          var labelTxt = ((labelCell && labelCell.textContent) || "").replace(/\s+/g, " ").trim().toLowerCase();
+          if (
+            /choose cover|choose leather|select leather|select a leather/.test(labelTxt) &&
+            tr.querySelector('select')
+          ) {
+            continue;
+          }
+          tr.classList.remove('mc-theater-hide-preleather');
+          tr.style.removeProperty('display');
+        } catch (eTr) {}
+      }
+    }
+  }
+
+  function rearrangePriceCaption(scope){ /* handled by renderMemberPricingCaption */ }
+
+  function ensureMemberCaptionMounted(caption) {
+    if (!caption || caption.parentNode) return;
+    var vp = document.getElementById('v65-product-parent') || document.querySelector('#v65-product-parent');
+    if (vp) vp.appendChild(caption);
+  }
+
+  /** Always search document — #v65-product-parent may not be inside #content_area. */
+  function findMemberCaptionAnchorEl() {
+    var el;
+    var selectors = [
+      '#priceWithOptionsNoTax',
+      '#priceWithOptions',
+      'font#priceWithOptions',
+      '#v65-product-parent .colors_pricebox [itemprop="price"]',
+      '#v65-product-parent .colors_pricebox font#priceWithOptions',
+      '#v65-product-parent .v65-product-price',
+      '#v65-product-parent .product_productprice',
+      '.colors_pricebox [itemprop="price"]',
+      '.colors_pricebox #priceWithOptions',
+      '.colors_pricebox'
+    ];
+    var i;
+    for (i = 0; i < selectors.length; i++) {
+      el = document.querySelector(selectors[i]);
+      if (el) return el;
+    }
+    return (
+      document.querySelector('#v65-product-parent .productnamecolorLARGE, #v65-product-parent .productnamecolor') ||
+      document.getElementById('v65-product-parent') ||
+      document.querySelector('#v65-product-parent') ||
+      null
+    );
+  }
+
+  function mcRemoveLowestPriceMapPromos(scope) {
+    try {
+      var doc = scope && scope.nodeType ? scope : document;
+      var hosts = [];
+      var vp = doc.getElementById && doc.getElementById('v65-product-parent');
+      if (vp) hosts.push({ root: vp, cartLinksOnly: true });
+      var extra = doc.querySelectorAll(
+        '#v65-product-related, #relateditems, #related-products, #content_area .v65-product-related'
+      );
+      var hi;
+      for (hi = 0; hi < extra.length; hi++) hosts.push({ root: extra[hi], cartLinksOnly: false });
+      if (!hosts.length) hosts.push({ root: doc, cartLinksOnly: true });
+      var LOW = /add to cart for our lowest price|our lowest price|lowest price!/i;
+      function stripLinksFrom(sub, cartLinksOnly) {
+        if (!sub || !sub.querySelectorAll) return;
+        var sel = cartLinksOnly
+          ? 'a[href*="ShoppingCart"], a[href*="shoppingcart"]'
+          : 'a';
+        var links = sub.querySelectorAll(sel);
+        var i;
+        for (i = links.length - 1; i >= 0; i--) {
+          var a = links[i];
+          var linkTxt = (a.textContent || '').replace(/\s+/g, ' ');
+          if (!LOW.test(linkTxt)) continue;
+          if (!cartLinksOnly && linkTxt.length > 160) continue;
+          try {
+            a.classList.add('mc-lowest-price-cta');
+          } catch (eCls) {}
+          var par = a.parentNode;
+          if (!par) continue;
+          try {
+            if (
+              par.parentNode &&
+              par.children &&
+              par.children.length === 1 &&
+              /^(div|p|font|span|td|li)$/i.test(par.tagName || '')
+            ) {
+              par.parentNode.removeChild(par);
+            } else {
+              par.removeChild(a);
+            }
+          } catch (eRm) {}
+        }
+      }
+      for (hi = 0; hi < hosts.length; hi++) {
+        stripLinksFrom(hosts[hi].root, hosts[hi].cartLinksOnly);
+      }
+    } catch (eAll) {}
+  }
+
+  function renderMemberPricingCaption(scope){
+    if (typeof window.mcPageType === 'function' && window.mcPageType() === 'pdp') return;
+    if (/\/product-p\//i.test(location.pathname || '')) return;
+    if (
+      document.body &&
+      (document.body.classList.contains('productdetails') || document.body.classList.contains('mc-product-page'))
+    )
+      return;
+    var root = scope || document;
+    if (document.body && document.body.classList.contains('mc-bean-bag-pdp')) return;
+    mcRemoveLowestPriceMapPromos(root);
+    var anchorEl = findMemberCaptionAnchorEl();
+    /* Do not append into empty #content_area — Volusion replaces innerHTML and would delete the caption. */
+    var fallbackHost =
+      document.querySelector('#v65-product-parent .colors_pricebox') ||
+      document.querySelector('#v65-product-parent') ||
+      null;
+    if (!anchorEl) {
+      anchorEl = fallbackHost;
+    }
+    if (!anchorEl) return;
+
+    // Remove legacy MAP / "Add to cart for our lowest price" siblings after anchor (Volusion reinjects)
+    var legacyDiv = null;
+    var sib = anchorEl.nextSibling;
+    while (sib) {
+      var nextSib = sib.nextSibling;
+      if (sib.nodeType === 1) {
+        var sibTxt = (sib.textContent || '').toLowerCase();
+        if (
+          /add to cart for our lowest price/i.test(sibTxt) &&
+          !sib.querySelector('#priceWithOptions') &&
+          !sib.querySelector('#priceWithOptionsNoTax')
+        ) {
+          try {
+            sib.classList.add('mc-lowest-price-cta');
+            sib.parentNode.removeChild(sib);
+            legacyDiv = null;
+          } catch (eLeg) {
+            legacyDiv = sib;
+          }
+        }
+      }
+      sib = nextSib;
+    }
+    if (legacyDiv && legacyDiv.parentNode) {
+      try {
+        legacyDiv.parentNode.removeChild(legacyDiv);
+      } catch (eL2) {}
+      legacyDiv = null;
+    }
+
+    // Single caption in the document; move it if Volusion re-injected the price block.
+    var caption = document.querySelector('.mc-member-price-caption');
+    if (!caption) {
+      caption = document.createElement('div');
+    }
+    var insertAfter = anchorEl;
+    try {
+      if (insertAfter && insertAfter.parentNode) {
+        insertAfter.parentNode.insertBefore(caption, insertAfter.nextSibling);
+      } else if (fallbackHost) {
+        fallbackHost.appendChild(caption);
+      }
+    } catch (insertErr) {
+      try {
+        var fh2 = document.querySelector('#v65-product-parent .colors_pricebox') || document.querySelector('#v65-product-parent');
+        if (fh2) fh2.appendChild(caption);
+      } catch (e3) {}
+    }
+
+    caption.className = 'mc-member-price-caption';
+    caption.style.setProperty('display','block','important');
+    caption.style.removeProperty('visibility');
+    caption.style.removeProperty('opacity');
+    caption.style.setProperty('pointer-events','auto','important');
+    caption.style.setProperty('position','relative','important');
+    caption.style.setProperty('z-index','12','important');
+
+    var state = window.__mcMemberPricing || {};
+    var fmt = typeof window.formatMcCurrency === 'function' ? window.formatMcCurrency : function(v){
+      return '$' + Number(v || 0).toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    };
+    var seatPrice = state.memberSeatPrice;
+    var memberDisplayPrice = seatPrice;
+
+    try {
+      if (state.unlocked && !(seatPrice > 0) && typeof window.getVolusionAddToCartSeatPrice === 'function') {
+        seatPrice = window.getVolusionAddToCartSeatPrice(document);
+        if (seatPrice > 0 && window.__mcMemberPricing) {
+          window.__mcMemberPricing.memberSeatPrice = seatPrice;
+        }
+      }
+      if (state.unlocked && !(seatPrice > 0) && typeof window.tryReadHowToGetSalePrice === 'function') {
+        var mapEl =
+          root.querySelector('#priceWithOptions') ||
+          root.querySelector('[itemprop="price"]') ||
+          root.querySelector('#priceWithOptionsNoTax') ||
+          document.querySelector('#priceWithOptions, [itemprop="price"], #priceWithOptionsNoTax');
+        var mapAmt = 0;
+        if (mapEl) {
+          mapAmt = mcParseCurrency(
+            (mapEl.getAttribute && (mapEl.getAttribute('content') || mapEl.getAttribute('value'))) ||
+              mapEl.textContent ||
+              ''
+          );
+        }
+        seatPrice = window.tryReadHowToGetSalePrice(mapAmt, true);
+        if (!(seatPrice > 0) && typeof window.extractHowToGetSalePriceFromScripts === 'function') {
+          seatPrice = window.extractHowToGetSalePriceFromScripts(
+            document.documentElement.innerHTML || '',
+            mapAmt,
+            true
+          );
+        }
+        if (seatPrice > 0 && window.__mcMemberPricing) {
+          window.__mcMemberPricing.memberSeatPrice = seatPrice;
+        }
+      }
+    } catch (err) {
+      try {
+        console.warn('[McCabe] member caption price resolution', err);
+      } catch (e2) {}
+    }
+
+    if (state.unlocked && window.__mcPlannerConfigApplied && window.__mcPlannerCounts) {
+      var visCap = typeof mcReadCurrentVisibleMemberUnitPrice === "function" ? mcReadCurrentVisibleMemberUnitPrice() : 0;
+      if (visCap > 0) memberDisplayPrice = visCap;
+    }
+    if (state.unlocked && memberDisplayPrice > 0) {
+      caption.innerHTML =
+        '<span class="mc-member-price-caption__option-label">Member price:</span>' +
+        '<span class="mc-member-price-caption__price-value">' + fmt(memberDisplayPrice) + '</span>';
+      caption.setAttribute('data-mc-member-state', 'unlocked');
+      ensureMemberCaptionMounted(caption);
+      return;
+    }
+
+    if (state.unlocked) {
+      caption.innerHTML =
+        '<span class="mc-member-price-caption__option-label">Member price:</span>';
+      caption.setAttribute('data-mc-member-state', 'unlocked-no-price');
+      ensureMemberCaptionMounted(caption);
+      return;
+    }
+
+    caption.innerHTML =
+      '<div class="mc-member-price-caption__headline">Member price:</div>' +
+      '<div class="mc-member-price-caption__sub">' +
+        '<a href="#" class="mc-member-price-caption__cta" data-mc-open-login>Log in</a> to see member pricing' +
+      '</div>' +
+      '<div class="mc-member-price-caption__actions">' +
+        '<a href="#" class="mc-member-price-caption__cta" data-mc-open-signup>Sign up</a>' +
+      '</div>';
+    caption.setAttribute('data-mc-member-state', 'locked');
+    try {
+      var loginCta = caption.querySelector('[data-mc-open-login]');
+      if (loginCta) {
+        loginCta.onclick = function(ev) {
+          ev.preventDefault();
+          ev.stopPropagation();
+          if (typeof window.mcOpenLoginModal === 'function') window.mcOpenLoginModal();
+          return false;
+        };
+      }
+      var signupCta = caption.querySelector('[data-mc-open-signup]');
+      if (signupCta) {
+        signupCta.onclick = function(ev) {
+          ev.preventDefault();
+          ev.stopPropagation();
+          if (typeof window.mcOpenSignupModal === 'function') window.mcOpenSignupModal();
+          return false;
+        };
+      }
+    } catch (eCapBind) {}
+    ensureMemberCaptionMounted(caption);
+  }
+
+  function leftAlignPricingBlock(scope){
+    var root = scope || document;
+    var sels = [
+      '#v65-product-parent td',
+      '.product_sale_price', '.v65-product-price', '#priceWithOptions',
+      '.product_productname', '.product_description',
+      '.option_pricing', '.product_list_price'
+    ];
+    qa(sels.join(','), root).forEach(function(el){
+      el.style.setProperty('text-align','left','important');
+    });
+  }
+
+  function hideNativePdpSalePricing(scope) {
+    if (!markProductPage()) return;
+    if (document.body && document.body.classList.contains('mc-bean-bag-pdp')) return;
+    if (
+      document.body &&
+      document.body.classList.contains('mc-palliser-pdp') &&
+      !document.body.classList.contains('mc-logged-in')
+    ) {
+      return;
+    }
+    var root =
+      (scope && scope.querySelector && scope.querySelector('#v65-product-parent')) ||
+      document.getElementById('v65-product-parent') ||
+      scope ||
+      document;
+    if (!root || !root.querySelectorAll) return;
+    var isPdp =
+      !!(document.body && (document.body.classList.contains('productdetails') || document.body.classList.contains('mc-product-page'))) ||
+      /\/product-p\//i.test(location.pathname || '');
+    var hasMcPricing =
+      !!(document.body && document.body.classList.contains('mc-pdp-price-stack')) ||
+      !!document.querySelector('.mc-pdp-member-pricing, .mc-pdp-retail-row');
+    var saleNodes = root.querySelectorAll(
+      'font.product_sale_price, .product_sale_price, .product_saleprice, [class*="product_sale_price"], [class*="product_saleprice"]'
+    );
+    var i;
+    for (i = 0; i < saleNodes.length; i++) {
+      var node = saleNodes[i];
+      if (node.closest && node.closest('.mc-member-price-caption')) continue;
+      if (node.closest && node.closest('.mc-pdp-sale-preview')) continue;
+      if (node.closest && node.closest('.mc-pdp-member-line--sale')) continue;
+      try {
+        if (isPdp || hasMcPricing) {
+          node.style.setProperty('display', 'none', 'important');
+          node.style.setProperty('visibility', 'hidden', 'important');
+          node.style.setProperty('height', '0', 'important');
+          node.style.setProperty('overflow', 'hidden', 'important');
+          node.style.setProperty('opacity', '0', 'important');
+        } else {
+          node.style.removeProperty('display');
+          node.style.removeProperty('visibility');
+          node.style.removeProperty('height');
+          node.style.removeProperty('overflow');
+          node.style.removeProperty('opacity');
+        }
+      } catch (eSaleHide) {}
+    }
+  }
+
+  function mcIsTheaterSeatingPdp(root){
+    if (typeof window.isSectionalProductPage === "function" && window.isSectionalProductPage()) {
+      return false;
+    }
+    var scope = root || document;
+    var theaterTitle = (
+      (document.querySelector("h1 [itemprop='name'], h1, .vp-product-title") || {}).textContent ||
+      document.title ||
+      ""
+    ).toLowerCase();
+    return (
+      !!(document.body && document.body.classList.contains('mc-theater-seating-pdp')) ||
+      !!document.querySelector('a[href*="customtheaterseating-s/106"], a[href*="palliser-theater-seating-s/100"]') ||
+      /theater seating|theatre seating|theater chair|theatre chair|\bparagon\b/i.test(theaterTitle) ||
+      !!scope.querySelector('select[title*="Number of Seats"], select[title*="Choose Configuration"], select[title*="Choose Cover"]')
+    );
+  }
+  function hideTheaterSeatPdpNativePricing(scope){
+    var root = scope || document;
+    if (typeof window.isSectionalProductPage === "function" && window.isSectionalProductPage()) return;
+    if (!mcIsTheaterSeatingPdp(root)) return;
+    try {
+      document.body.classList.add('mc-theater-seating-pdp');
+    } catch (eTheaterFlag) {}
+    try {
+      var rows = root.querySelectorAll('#options_table tr, table[id*="options_table"] tr');
+      var ri;
+      for (ri = 0; ri < rows.length; ri++) {
+        var row = rows[ri];
+        var select = row.querySelector('select');
+        if (!select) continue;
+        var meta = (((row.textContent || '') + ' ' + (select.getAttribute('title') || '') + ' ' + (select.name || '')).toLowerCase()).replace(/\s+/g, ' ');
+        if (/number of seats|choose configuration/.test(meta)) {
+          row.style.setProperty('display', 'none', 'important');
+        }
+      }
+    } catch (eHideTheaterRows) {}
+  }
+  function ensurePriceWithOptionsLabel(scope){
+    var root = scope || document;
+    if (mcIsTheaterSeatingPdp(root)) {
+      hideTheaterSeatPdpNativePricing(root);
+      return;
+    }
+    var priceNode = root.querySelector('#priceWithOptions');
+    if (!priceNode) return;
+    var prev = priceNode.previousElementSibling;
+    if (prev && /price with selected options/i.test(prev.textContent || '')) return;
+    var label = root.querySelector('.option_pricing');
+    if (label && /price with selected options/i.test(label.textContent || '')) {
+      priceNode.parentNode.insertBefore(label, priceNode);
+      return;
+    }
+    label = document.createElement('span');
+    label.className = 'text colors_text option_pricing';
+    label.textContent = 'Price with Selected Options: ';
+    priceNode.parentNode.insertBefore(label, priceNode);
+  }
+
+  function forceProductFixes() {
+    if (!markProductPage()) return;
+    var scope = document.querySelector('#content_area') || document.body;
+    var vp = document.getElementById('v65-product-parent');
+    var mediaScope = vp && scope && !scope.contains(vp) ? vp : scope;
+    try {
+      forceNoItalics(scope);
+      hideLegacyOptionQuestions(scope);
+      forceTabsInline(scope);
+      forceMediaLayout(mediaScope);
+      removeConfigurationDetails(scope);
+      hideOptionsTable(scope);
+      unhideSectionalOptionRows(document);
+      enforceMobileGutters(scope);
+      clampFloatingIcons();
+      clearAddToCartWrapperBackground(scope);
+      injectAddToCartIcon(scope);
+    } catch (e) {
+      if (typeof console !== 'undefined' && console.warn) console.warn('[McCabe] forceProductFixes (before caption)', e);
+    }
+    rearrangePriceCaption(scope);
+    try {
+      mcRemoveLowestPriceMapPromos(document);
+    } catch (eRm0) {}
+    try {
+      renderMemberPricingCaption(document);
+    } catch (e2) {
+      if (typeof console !== 'undefined' && console.warn) console.warn('[McCabe] renderMemberPricingCaption', e2);
+    }
+    try {
+      if (typeof mcCachePdpSaleAmountFromDom === 'function') mcCachePdpSaleAmountFromDom();
+      hideNativePdpSalePricing(scope);
+      if (typeof mcTidyMtlPriceBlock === 'function') mcTidyMtlPriceBlock();
+      if (typeof mcTidyPdpMemberPricing === 'function') mcTidyPdpMemberPricing();
+      if (typeof mcEnsurePdpPriceStack === 'function') mcEnsurePdpPriceStack();
+      hideTheaterSeatPdpNativePricing(scope);
+      ensurePriceWithOptionsLabel(scope);
+      leftAlignPricingBlock(scope);
+      if (document.getElementById("mcConfigurationBlock")) {
+        ensureTheaterPlannerOptionPriceResync();
+        if (typeof window.scheduleConfigurationFromDomRetries === "function") {
+          window.scheduleConfigurationFromDomRetries();
+        } else if (typeof window.mcSyncConfigurationFromDom === "function") {
+          window.mcSyncConfigurationFromDom();
+        }
+      }
+    } catch (e3) {}
+  }
+
+  function boot() {
+    forceProductFixes();
+    if (mcShouldKeepOptionsOffscreen()) {
+      setTimeout(forceProductFixes, 800);
+      return;
+    }
+    var tries = 0;
+    var t = setInterval(function () {
+      tries++;
+      forceProductFixes();
+      if (tries >= 25) clearInterval(t);
+    }, 400);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot);
+  } else {
+    boot();
+  }
+  window.addEventListener('load', function(){
+    setTimeout(forceProductFixes, 0);
+    setTimeout(forceProductFixes, 800);
+  });
+
+  (function observeContentAreaForPdp(){
+    var ca = document.getElementById('content_area');
+    if (!ca || ca.__mcPdpObserver) return;
+    ca.__mcPdpObserver = true;
+    var deb;
+    var mo = new MutationObserver(function(){
+      clearTimeout(deb);
+      deb = setTimeout(function(){
+        try {
+          var ca = document.getElementById('content_area');
+          var isSec = typeof window.isSectionalProductPage === "function" && window.isSectionalProductPage();
+          if (isSec) {
+            try {
+              document.documentElement.classList.add("is-sectional-product");
+              document.body.classList.remove("mc-hide-native-options-until-mc");
+            } catch (eRmH) {}
+          }
+          if (
+            ca &&
+            ca.querySelector('#options_table, table[id*="options_table"]') &&
+            !document.body.classList.contains('mc-product-page') &&
+            !document.body.classList.contains('mc-bean-bag-pdp') &&
+            !document.body.classList.contains('mc-saranoni-pdp') &&
+            !isSec
+          ) {
+            document.body.classList.add('mc-hide-native-options-until-mc');
+          }
+        } catch (eObs) {}
+        if (markProductPage()) forceProductFixes();
+      }, 50);
+    });
+    try {
+      mo.observe(ca, { childList: true, subtree: true });
+    } catch (e) {}
+  })();
+
+  /* #v65-product-parent may be injected outside #content_area; catch when it appears anywhere. */
+  (function observeBodyForPdp(){
+    if (!document.body || document.body.__mcPdpBodyObserver) return;
+    document.body.__mcPdpBodyObserver = true;
+    var deb2;
+    var mo2 = new MutationObserver(function(){
+      clearTimeout(deb2);
+      deb2 = setTimeout(function(){
+        if (!document.getElementById('v65-product-parent')) return;
+        var cap = document.querySelector('.mc-member-price-caption');
+        if (cap && (cap.textContent || '').replace(/\s/g, '').length > 0) return;
+        try {
+          if (markProductPage()) renderMemberPricingCaption(document);
+        } catch (e) {}
+      }, 200);
+    });
+    try {
+      mo2.observe(document.body, { childList: true, subtree: true });
+    } catch (e2) {}
+  })();
+
+  var _resizeTimer;
+  window.addEventListener('resize', function(){
+    if (!document.body.classList.contains('mc-product-page')) return;
+    clearTimeout(_resizeTimer);
+    _resizeTimer = setTimeout(forceProductFixes, 400);
+  });
+
+  window.addEventListener('orientationchange', function(){
+    if (document.body.classList.contains('mc-product-page')) setTimeout(forceProductFixes, 400);
+  });
+
+  window.addEventListener('mcMemberPricingReady', function(){
+    forceProductFixes();
+  });
+  window.forceProductFixes = forceProductFixes;
+  if (typeof window.detectMemberPricingState === 'function') {
+    window.detectMemberPricingState();
+  }
+  window.addEventListener('pageshow', function(ev){
+    if (!ev.persisted || !document.body.classList.contains('mc-product-page')) return;
+    if (typeof window.detectMemberPricingState !== 'function') return;
+    window.__mcMemberPricing.promise = null;
+    window.detectMemberPricingState();
+  });
+
+  try {
+    window.mcGetQueryParamValue = mcGetQueryParamValue;
+    window.mcListingCategoryIdFromPath = mcListingCategoryIdFromPath;
+    window.mcListingCategoryIdFromVolusion = mcListingCategoryIdFromVolusion;
+    window.mcEnsureCategoryListingClasses = mcEnsureCategoryListingClasses;
+  } catch (eMcListingWin) {}
+})();
+</script>
+
+<style id="mc-unified-pdp-critical-20260616">
+  body.mc-pdp-unified-ready #content_area tr.mc-unified-pdp-row,
+  body.mc-pdp-unified-ready #v65-product-parent tr.mc-unified-pdp-row {
+    vertical-align: top !important;
+  }
+  body.mc-pdp-unified-ready #content_area td.mc-unified-pdp-media,
+  body.mc-pdp-unified-ready #v65-product-parent td.mc-unified-pdp-media {
+    width: 58% !important;
+    max-width: 58% !important;
+    padding-right: 22px !important;
+    padding-left: 0 !important;
+    vertical-align: top !important;
+    text-align: center !important;
+    box-sizing: border-box !important;
+  }
+  body.mc-pdp-unified-ready #content_area td.mc-unified-pdp-info,
+  body.mc-pdp-unified-ready #v65-product-parent td.mc-unified-pdp-info {
+    width: 42% !important;
+    max-width: 42% !important;
+    padding-left: 22px !important;
+    padding-right: 0 !important;
+    vertical-align: top !important;
+    box-sizing: border-box !important;
+  }
+  body.mc-pdp-unified-ready .mc-unified-pdp-description {
+    max-width: 680px !important;
+    margin: 18px auto 0 !important;
+    text-align: center !important;
+    line-height: 1.55 !important;
+  }
+  body.mc-pdp-unified-ready .mc-unified-purchase-controls {
+    display: flex !important;
+    flex-direction: column !important;
+    align-items: center !important;
+    justify-content: center !important;
+    gap: 10px !important;
+    width: 100% !important;
+    margin: 18px auto 0 !important;
+    text-align: center !important;
+  }
+  body.mc-pdp-unified-ready input.mc-unified-atc-btn,
+  body.mc-pdp-unified-ready input[name="btnaddtocart"].mc-unified-atc-btn {
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    width: min(100%, 320px) !important;
+    min-height: 44px !important;
+    background: #000 !important;
+    background-color: #000 !important;
+    color: #fff !important;
+    border: 1px solid #000 !important;
+    border-radius: 0 !important;
+    transition: none !important;
+    animation: none !important;
+    text-align: center !important;
+  }
+  body.mc-pdp-unified-ready .mc-pdp-return-cell {
+    padding: 0 0 14px !important;
+    text-align: left !important;
+  }
+  body.mc-pdp-unified-ready .mc-pdp-return-link {
+    display: inline-block !important;
+    font-size: 12px !important;
+    letter-spacing: .12em !important;
+    text-transform: uppercase !important;
+    color: #444 !important;
+    text-decoration: none !important;
+  }
+  body.mc-pdp-unified-ready .mc-unified-altviews img,
+  body.mc-pdp-unified-ready #altviews img,
+  body.mc-pdp-unified-ready .altviews img {
+    max-width: 74px !important;
+    max-height: 74px !important;
+    width: auto !important;
+    height: auto !important;
+    object-fit: contain !important;
+  }
+  @media (max-width: 991px) {
+    body.mc-pdp-unified-ready #content_area td.mc-unified-pdp-media,
+    body.mc-pdp-unified-ready #v65-product-parent td.mc-unified-pdp-media,
+    body.mc-pdp-unified-ready #content_area td.mc-unified-pdp-info,
+    body.mc-pdp-unified-ready #v65-product-parent td.mc-unified-pdp-info {
+      display: block !important;
+      width: 100% !important;
+      max-width: 100% !important;
+      padding-left: 0 !important;
+      padding-right: 0 !important;
+    }
+    body.mc-pdp-unified-ready .mc-unified-pdp-description {
+      max-width: 92vw !important;
+    }
+  }
+</style>
+
+<!-- MC unified PDP normalizer: external mc-unified-pdp-layout.js (via mc-pdp-auth-cta-fix.js) -->
+
+
+<!-- MC removed legacy PDP accordion script: replaced by unified PDP normalizer 20260616unified12 -->
+
+<script>
+(function () {
+  /** Volusion PDP ProductCode → same thumbnail filenames category PLP uses (`/v/vspfiles/photos/{CODE}-1.jpg`). */
+  function mcVolusionProductCodeFromHref(href) {
+    var h = String(href || '');
+    var m =
+      h.match(/\/-p\/([^.\/?#]+)/i) ||
+      h.match(/\/product-p\/([^.\/?#]+)/i) ||
+      h.match(/[?&]ProductCode=([^&]+)/i) ||
+      h.match(/[?&]productcode=([^&]+)/i);
+    if (!m || !m[1]) return '';
+    var raw = String(m[1]);
+    try {
+      raw = decodeURIComponent(raw.replace(/\+/g, ' ')).trim();
+    } catch (eDec) {}
+    return raw.replace(/\.htm.*/i, '').toUpperCase();
+  }
+
+  function mcRelatedCurrentPdpProductCode() {
+    try {
+      var pc = document.querySelector('input[name="ProductCode"], input[name="productcode"]');
+      return pc ? String(pc.value || '').trim().toUpperCase() : '';
+    } catch (ePc) {
+      return '';
+    }
+  }
+
+  /** Volusion often renders two *top-level* related blocks — duplicates SKUs (e.g. 8 tiles). Keep one rail.
+      NOTE: `td#related_products_content` is normally NESTED inside `table#v65-product-related` (single rail).
+      Never hide that cell — both roots would match the same `table.v65-productDisplay` and the UI would vanish. */
+  function mcRelatedHideDuplicateVolusionRails() {
+    try {
+      var primary = document.getElementById('v65-product-related');
+      var dup = document.getElementById('related_products_content');
+      if (!primary || !dup) return;
+      if (primary.contains(dup)) return;
+      var tPrimary = primary.querySelector('table.v65-productDisplay');
+      var tDup = dup.querySelector('table.v65-productDisplay');
+      if (!tPrimary || !tDup) return;
+      dup.style.setProperty('display', 'none', 'important');
+    } catch (eHd) {}
+  }
+
+  function mcRelatedHideSelfSlots(root, selfCode) {
+    if (!root || !selfCode) return;
+    try {
+      root.querySelectorAll('a[href*="-p/"], a[href*="product-p/"], a[href*="ProductCode="], a[href*="productcode="]').forEach(function (a) {
+        var c = mcVolusionProductCodeFromHref(a.getAttribute('href') || a.href || '');
+        if (!c || c !== selfCode) return;
+        var cell =
+          (a.closest && a.closest('td')) ||
+          (a.closest && a.closest('li')) ||
+          (a.closest && a.closest('.v-product')) ||
+          (a.closest && a.closest('.v65-product-related-item'));
+        if (cell) cell.style.setProperty('display', 'none', 'important');
+      });
+    } catch (eS) {}
+  }
+
+  /** Volusion related grid: row 0 is P|D|P|D|… (divider cells); price/photo rows omit divider TDs (rowspan).
+      Capping by raw cell index breaks alignment (e.g. keeps only two products and orphans photo cells). */
+  function mcCapRelatedTableProductColumns(table, maxN) {
+    if (!table || !table.rows || maxN < 1) return;
+    try {
+      if (table.closest && table.closest('.mc-related-carousel__viewport')) return;
+      var r;
+      for (r = 0; r < table.rows.length; r++) {
+        var row = table.rows[r];
+        var cells = row.cells;
+        if (!cells || cells.length < 1) continue;
+        var hasDivider = false;
+        var di;
+        for (di = 0; di < cells.length; di++) {
+          if (cells[di].classList && cells[di].classList.contains('v65-productColumn-divider')) {
+            hasDivider = true;
+            break;
+          }
+        }
+        if (hasDivider) {
+          var slot = -1;
+          var c;
+          for (c = 0; c < cells.length; c++) {
+            var cell = cells[c];
+            if (cell.classList && cell.classList.contains('v65-productColumn-divider')) continue;
+            slot++;
+            if (slot >= maxN) cell.style.setProperty('display', 'none', 'important');
+          }
+          for (c = 0; c < cells.length; c++) {
+            var divCell = cells[c];
+            if (!divCell.classList || !divCell.classList.contains('v65-productColumn-divider')) continue;
+            var leftSlot = -1;
+            var j;
+            for (j = 0; j < c; j++) {
+              if (!(cells[j].classList && cells[j].classList.contains('v65-productColumn-divider'))) leftSlot++;
+            }
+            if (leftSlot + 1 >= maxN) divCell.style.setProperty('display', 'none', 'important');
+          }
+        } else {
+          if (cells.length <= maxN) continue;
+          for (c = maxN; c < cells.length; c++) {
+            cells[c].style.setProperty('display', 'none', 'important');
+          }
+        }
+      }
+    } catch (eT) {}
+  }
+
+  /** Volusion: name row is P|D|P|D|… with rowspan dividers; photo and price rows are one TD per product.
+      Reordering <tr> breaks rowspan. Rebuild as a PLP-style grid: image, title, price per card. */
+  function mcRelatedNthProductTd(row, n) {
+    if (!row || !row.cells) return null;
+    var cells = row.cells;
+    var slot = -1;
+    var i;
+    for (i = 0; i < cells.length; i++) {
+      var cell = cells[i];
+      if (cell.classList && cell.classList.contains('v65-productColumn-divider')) continue;
+      slot++;
+      if (slot === n) return cell;
+    }
+    return null;
+  }
+
+  function mcRelatedRowKind(tr) {
+    if (!tr || !tr.querySelectorAll) return '';
+    var tds = tr.querySelectorAll(':scope > td');
+    var ti;
+    for (ti = 0; ti < tds.length; ti++) {
+      var td = tds[ti];
+      if (td.classList.contains('v65-productColumn-divider')) continue;
+      if (td.classList.contains('v65-productPhoto')) return 'photo';
+      if (td.classList.contains('v65-productName')) return 'name';
+      if (td.classList.contains('v65-productDetailInfo')) return 'detail';
+      if (td.querySelector && td.querySelector('.product_price, .product_sale_price, .product_saleprice, .v65-product-related-price, font.pricecolorsmall, [itemprop="price"]'))
+        return 'detail';
+    }
+    return '';
+  }
+
+  function mcRelatedResolveTriplet(r0, r1, r2) {
+    if (!r0 || !r1 || !r2) return null;
+    var nameR = null;
+    var photoR = null;
+    var detailR = null;
+    var trip = [r0, r1, r2];
+    var z;
+    for (z = 0; z < 3; z++) {
+      var k = mcRelatedRowKind(trip[z]);
+      if (k === 'photo') photoR = trip[z];
+      else if (k === 'name') nameR = trip[z];
+      else if (k === 'detail') detailR = trip[z];
+    }
+    if (!nameR || !photoR || !detailR) return null;
+    return { nameR: nameR, photoR: photoR, detailR: detailR };
+  }
+
+  function mcCountRelatedNameRowProducts(nameR) {
+    if (!nameR || !nameR.cells) return 0;
+    var n = 0;
+    var i;
+    for (i = 0; i < nameR.cells.length; i++) {
+      if (nameR.cells[i].classList && nameR.cells[i].classList.contains('v65-productColumn-divider')) continue;
+      n++;
+    }
+    return n;
+  }
+
+  /** Volusion sometimes omits the photo in a related photo cell (e.g. Juno). Build PLP thumb from name link. */
+  function mcRelatedIsPlaceholderImgSrc(src) {
+    var s = String(src || '').trim();
+    if (!s || /^data:/i.test(s)) return true;
+    if (/clear1x1\.gif/i.test(s)) return true;
+    if (/nophoto/i.test(s)) return true;
+    if (/\/no[-_]?image|image[_-]?not[_-]?available|\/comingsoon|\/blank\.(gif|png|jpg)|^about:blank$/i.test(s))
+      return true;
+    return false;
+  }
+
+  function mcRelatedPlpMediaNeedsFallback(mediaEl) {
+    if (!mediaEl || !mediaEl.querySelector) return true;
+    var img = mediaEl.querySelector('img');
+    if (!img) return true;
+    return mcRelatedIsPlaceholderImgSrc(img.getAttribute('src') || '');
+  }
+
+  function mcRelatedEnsurePlpCardMedia(mediaEl, nameA, phTd) {
+    if (!mediaEl || !mcRelatedPlpMediaNeedsFallback(mediaEl)) return;
+    var href = '';
+    if (nameA) href = String(nameA.getAttribute('href') || nameA.href || '').trim();
+    if (!href && phTd && phTd.querySelector) {
+      var phL = phTd.querySelector('a[href]');
+      if (phL) href = String(phL.getAttribute('href') || phL.href || '').trim();
+    }
+    if (!href) return;
+    var code = mcVolusionProductCodeFromHref(href);
+    if (!code) return;
+    var link = document.createElement('a');
+    try {
+      link.setAttribute('href', href);
+      link.href = href;
+    } catch (eH) {}
+    var im = document.createElement('img');
+    im.setAttribute('alt', '');
+    im.setAttribute('src', '/v/vspfiles/photos/' + code + '-1.jpg');
+    try {
+      im.loading = 'eager';
+    } catch (eL) {}
+    im.onerror = function () {
+      var cur = im.getAttribute('src') || '';
+      if (/-1\.(jpg|jpeg|png|webp)(\?|$)/i.test(cur)) {
+        im.onerror = null;
+        im.setAttribute('src', '/v/vspfiles/photos/' + code + '-2T.jpg');
+        return;
+      }
+      if (/-2T\.(jpg|jpeg|png|webp)(\?|$)/i.test(cur)) {
+        im.onerror = null;
+        im.setAttribute('src', '/v/vspfiles/photos/' + code + '-1.jpg');
+      }
+    };
+    link.appendChild(im);
+    mediaEl.textContent = '';
+    mediaEl.appendChild(link);
+  }
+
+  function mcConvertRelatedV65TablesToPlpGrid(maxN) {
+    maxN = maxN || 4;
+    try {
+      var roots = document.querySelectorAll('#v65-product-related');
+      var ri;
+      for (ri = 0; ri < roots.length; ri++) {
+        var root = roots[ri];
+        if (!root) continue;
+        var killGrids = root.querySelectorAll('.mc-related-plp-grid');
+        var kg;
+        for (kg = 1; kg < killGrids.length; kg++) {
+          try {
+            killGrids[kg].parentNode.removeChild(killGrids[kg]);
+          } catch (eKg) {}
+        }
+        var tables = root.querySelectorAll('table.v65-productDisplay');
+        var convertedHere = false;
+        var ti;
+        for (ti = 0; ti < tables.length; ti++) {
+          var table = tables[ti];
+          if (!table || (table.closest && table.closest('.mc-related-carousel__viewport'))) continue;
+
+          if (convertedHere) {
+            if (!(table.getAttribute && table.getAttribute('data-mc-related-plp') === '1')) {
+              try {
+                table.style.setProperty('display', 'none', 'important');
+              } catch (eH0) {}
+            }
+            continue;
+          }
+
+          if (table.getAttribute && table.getAttribute('data-mc-related-plp') === '1') {
+            var existGrid = table.nextElementSibling;
+            if (existGrid && existGrid.classList && existGrid.classList.contains('mc-related-plp-grid')) {
+              convertedHere = true;
+              continue;
+            }
+            try {
+              table.removeAttribute('data-mc-related-plp');
+            } catch (eRa) {}
+            try {
+              table.style.removeProperty('display');
+            } catch (eRs) {}
+          }
+
+          var nextSib = table.nextElementSibling;
+          if (nextSib && nextSib.classList && nextSib.classList.contains('mc-related-plp-grid')) {
+            try {
+              nextSib.parentNode.removeChild(nextSib);
+            } catch (eRmG) {}
+          }
+
+          var tbody = table.tBodies[0] || table;
+          if (!tbody) continue;
+          var rows = [];
+          var ch;
+          for (ch = tbody.firstElementChild; ch; ch = ch.nextElementSibling) {
+            if (ch.tagName === 'TR' && ch.classList && ch.classList.contains('v65-productDisplay-row')) rows.push(ch);
+          }
+          if (rows.length < 3) continue;
+          /* Volusion often emits 6 rows: two blocks of (name | detail | photo) with 4 SKUs each. We only use the FIRST valid triplet and cap at maxN cards. */
+          var triple = null;
+          var si;
+          for (si = 0; si + 2 < rows.length; si++) {
+            triple = mcRelatedResolveTriplet(rows[si], rows[si + 1], rows[si + 2]);
+            if (triple) break;
+          }
+          if (!triple) continue;
+          var nameR = triple.nameR;
+          var photoR = triple.photoR;
+          var detailR = triple.detailR;
+
+          var nameCount = mcCountRelatedNameRowProducts(nameR);
+          var maxSlots = Math.min(photoR.cells.length, detailR.cells.length, nameCount);
+          var grid = document.createElement('div');
+          grid.className = 'mc-related-plp-grid';
+          var slot = 0;
+          var built = 0;
+          while (slot < maxSlots && built < maxN) {
+            var nameTd = mcRelatedNthProductTd(nameR, slot);
+            var detTd = detailR.cells[slot];
+            var phTd = photoR.cells[slot];
+            slot++;
+            if (!nameTd || !detTd || !phTd) continue;
+            if (typeof window.getComputedStyle === 'function') {
+              try {
+                if (getComputedStyle(nameTd).display === 'none') continue;
+              } catch (eCs) {}
+            }
+
+            var card = document.createElement('div');
+            card.className = 'mc-related-plp-card';
+
+            var media = document.createElement('div');
+            media.className = 'mc-related-plp-card__media';
+            var nameAForCard = nameTd.querySelector && nameTd.querySelector('a[href]');
+            var phA = phTd.querySelector && phTd.querySelector('a[href]');
+            if (phA) media.appendChild(phA.cloneNode(true));
+            else media.appendChild(phTd.cloneNode(true));
+            mcRelatedEnsurePlpCardMedia(media, nameAForCard, phTd);
+            card.appendChild(media);
+
+            /* Do not nest <td clone> inside <div> — invalid HTML breaks layout/order in browsers */
+            var titleEl = document.createElement('div');
+            titleEl.className = 'mc-related-plp-card__title';
+            if (nameAForCard) titleEl.appendChild(nameAForCard.cloneNode(true));
+            else titleEl.textContent = (nameTd.textContent || '').replace(/\s+/g, ' ').trim();
+            card.appendChild(titleEl);
+
+            var priceEl = document.createElement('div');
+            priceEl.className = 'mc-related-plp-card__price';
+            try {
+              priceEl.innerHTML = detTd.innerHTML || '';
+            } catch (eInner) {
+              priceEl.textContent = (detTd.textContent || '').replace(/\s+/g, ' ').trim();
+            }
+            card.appendChild(priceEl);
+
+            grid.appendChild(card);
+            built++;
+          }
+
+          if (!built) continue;
+          try {
+            table.setAttribute('data-mc-related-plp', '1');
+          } catch (eA) {}
+          table.style.setProperty('display', 'none', 'important');
+          if (table.nextSibling) table.parentNode.insertBefore(grid, table.nextSibling);
+          else table.parentNode.appendChild(grid);
+          convertedHere = true;
+        }
+      }
+    } catch (eConv) {}
+  }
+
+  /** When the main Volusion rail is converted to .mc-related-plp-grid, hide extra related blocks (duplicate second row). */
+  function mcRelatedHideSecondaryRailsIfPlpMain() {
+    try {
+      var main = document.getElementById('v65-product-related');
+      if (!main || !main.querySelector('.mc-related-plp-grid')) return;
+      var hideIds = ['relateditems', 'related-products'];
+      var hi;
+      for (hi = 0; hi < hideIds.length; hi++) {
+        var el = document.getElementById(hideIds[hi]);
+        if (!el || (main.contains && main.contains(el))) continue;
+        el.style.setProperty('display', 'none', 'important');
+      }
+      var tabs = document.querySelectorAll('table.relateditems');
+      var tj;
+      for (tj = 0; tj < tabs.length; tj++) {
+        var tb = tabs[tj];
+        if (main.contains(tb)) continue;
+        tb.style.setProperty('display', 'none', 'important');
+      }
+    } catch (eSec) {}
+  }
+
+  /** Hard cap related tiles/columns — McCabe PDP shows exactly four category-style picks (Volusion often emits 8). */
+  function mcCapRelatedProductSlots(maxN) {
+    maxN = maxN || 4;
+    var roots = document.querySelectorAll(
+      '#v65-product-related, #related_products_content, #relateditems, #related-products, table.relateditems'
+    );
+    var ri;
+    for (ri = 0; ri < roots.length; ri++) {
+      var root = roots[ri];
+      if (!root) continue;
+      try {
+        var flowItems = root.querySelectorAll(
+          '.v-product-grid > .v-product, .v-product-grid > div.v-product, ul.v-product-grid > li.v-product, .v-products-list > li'
+        );
+        if (flowItems.length > maxN) {
+          var j;
+          for (j = maxN; j < flowItems.length; j++) {
+            var node = flowItems[j];
+            var wrap = (node.closest && node.closest('td')) || node;
+            wrap.style.setProperty('display', 'none', 'important');
+          }
+          continue;
+        }
+        var tables = root.querySelectorAll('table.v65-productDisplay');
+        var ti;
+        for (ti = 0; ti < tables.length; ti++) {
+          if (tables[ti].getAttribute && tables[ti].getAttribute('data-mc-related-plp') === '1') continue;
+          mcCapRelatedTableProductColumns(tables[ti], maxN);
+        }
+        var rowsFlex = root.querySelectorAll('.mc-related-carousel__row');
+        var rf;
+        for (rf = 0; rf < rowsFlex.length; rf++) {
+          var carRow = rowsFlex[rf];
+          if (!carRow.cells || carRow.cells.length <= maxN) continue;
+          var cx;
+          for (cx = maxN; cx < carRow.cells.length; cx++) {
+            carRow.cells[cx].style.setProperty('display', 'none', 'important');
+          }
+        }
+      } catch (eR) {}
+    }
+  }
+
+  function mcRelatedImgExcluded(imgEl) {
+    if (!imgEl || (imgEl.closest && imgEl.closest('.mc-zoom-lens'))) return true;
+    if (imgEl.id === 'product_photo' || imgEl.id === 'main-image') return true;
+    if (imgEl.closest && imgEl.closest('#altviews, .altviews')) return true;
+    if (imgEl.closest && imgEl.closest('.mtl-sectional-configurations, #mtl-sectional-configurations')) return true;
+    if (imgEl.closest && imgEl.closest('#mcLeatherSwatchStrip, .wm-tile, .mc-leather-mini-swatch')) return true;
+    if (
+      imgEl.closest &&
+      imgEl.closest('#v65-product-parent') &&
+      !imgEl.closest(
+        '#relateditems, #related-products, #v65-product-related, #related_products_content, table.relateditems, .mc-related-carousel, .mc-related-carousel__viewport'
+      )
+    )
+      return true;
+    return false;
+  }
+
+  /** Category listing thumbnails for related SKUs (`-1.jpg`, flip `-2T` on error) — overrides PDP/detail-sized URLs. */
+  function mcForceRelatedItemCategoryThumbnails(scope) {
+    try {
+      var rootScope = scope || document;
+      function bindThumbErr(img, code) {
+        img.onerror = function () {
+          var cur = img.getAttribute('src') || '';
+          if (/-1\.(jpg|jpeg|png|webp)(\?|$)/i.test(cur)) {
+            img.onerror = null;
+            img.setAttribute('src', '/v/vspfiles/photos/' + code + '-2T.jpg');
+            return;
+          }
+          if (/-2T\.(jpg|jpeg|png|webp)(\?|$)/i.test(cur)) {
+            img.onerror = null;
+            img.setAttribute('src', '/v/vspfiles/photos/' + code + '-1.jpg');
+          }
+        };
+      }
+
+      rootScope
+        .querySelectorAll(
+          '#content_area #v65-product-related img, #v65-product-related img, ' +
+            '#content_area #related_products_content img, #related_products_content img, ' +
+            '#content_area #relateditems img, #relateditems img, ' +
+            '#content_area #related-products img, #related-products img, ' +
+            '#content_area table.relateditems img, table.relateditems img'
+        )
+        .forEach(function (imgEl) {
+          try {
+            if (mcRelatedImgExcluded(imgEl)) return;
+            var a =
+              (imgEl.closest &&
+                imgEl.closest(
+                  'a[href*="-p/"], a[href*="product-p/"], a[href*="ProductCode="], a[href*="productcode="]'
+                )) ||
+              null;
+            if (!a) return;
+            var code = mcVolusionProductCodeFromHref(a.getAttribute('href') || a.href || '');
+            if (!code) return;
+            imgEl.loading = 'eager';
+            imgEl.decoding = 'async';
+            try {
+              imgEl.removeAttribute('srcset');
+              imgEl.removeAttribute('data-src');
+              imgEl.removeAttribute('datasrc');
+              imgEl.removeAttribute('data-original');
+              imgEl.removeAttribute('data-lazy');
+            } catch (eRm) {}
+            imgEl.setAttribute('src', '/v/vspfiles/photos/' + code + '-1.jpg');
+            bindThumbErr(imgEl, code);
+          } catch (eF) {}
+        });
+    } catch (eAll) {}
+  }
+
+  function mcNormalizeRelatedItemImages(root) {
+    try {
+      var scope = root || document;
+
+      function normalizeOne(img, link) {
+        if (!img) return;
+
+        var src = img.getAttribute('src') || '';
+        var dataSrc =
+          img.getAttribute('data-src') ||
+          img.getAttribute('datasrc') ||
+          (img.dataset && (img.dataset.src || img.dataset.original || img.dataset.lazySrc || img.dataset.lazy)) ||
+          '';
+        var dataOriginal = img.getAttribute('data-original') || '';
+        var dataLazy = img.getAttribute('data-lazy') || '';
+        var chosen = String(dataSrc || dataOriginal || dataLazy || src || '').trim();
+
+        if (/^(data:image|about:blank)/i.test(chosen)) {
+          chosen = '';
+        }
+
+        if (!chosen) {
+          var linkFb =
+            link ||
+            (img.closest &&
+              img.closest('a[href*="-p/"], a[href*="product-p/"], a[href*="ProductCode="], a[href*="productcode="]'));
+          if (linkFb) {
+            var href0 = linkFb.getAttribute('href') || '';
+            var code0 = mcVolusionProductCodeFromHref(href0);
+            if (code0) chosen = '/v/vspfiles/photos/' + code0 + '-1.jpg';
+          }
+        }
+
+        if (!chosen) return;
+
+        chosen = chosen.replace(/^\s+|\s+$/g, '').replace(/^https?:\/\/[^/]+/i, '');
+        if (
+          mcRelatedIsPlaceholderImgSrc(chosen) ||
+          /-0\.(png|jpg|jpeg|webp)(\?|$)/i.test(chosen) ||
+          /(?:transparent|spacer|clear|pixel|blank)[^/]*\.(gif|png)(\?|$)/i.test(chosen)
+        ) {
+          var td = img.closest && img.closest('td');
+          var linkEl =
+            link ||
+            (img.closest && img.closest('a[href*="-p/"], a[href*="product-p/"], a[href*="ProductCode="], a[href*="productcode="]')) ||
+            (td && td.querySelector && td.querySelector(
+              'a[href*="-p/"], a[href*="product-p/"], a[href*="ProductCode="], a[href*="productcode="]'
+            )) ||
+            (img.parentElement && img.parentElement.tagName === 'A' ? img.parentElement : null);
+          if (linkEl) {
+            var href = linkEl.getAttribute('href') || '';
+            var code = mcVolusionProductCodeFromHref(href);
+            if (code) {
+              chosen = '/v/vspfiles/photos/' + code + '-1.jpg';
+            }
+          }
+        }
+
+        img.loading = 'eager';
+        img.decoding = 'async';
+        img.removeAttribute('srcset');
+        try {
+          img.removeAttribute('data-src');
+          img.removeAttribute('datasrc');
+          img.removeAttribute('data-original');
+          img.removeAttribute('data-lazy');
+        } catch (eRm) {}
+        img.setAttribute('src', chosen);
+
+        img.onerror = function(){
+          var current = img.getAttribute('src') || '';
+          if (/-1\.(jpg|jpeg|png|webp)$/i.test(current)) {
+            img.onerror = null;
+            img.src = current.replace(/-1\.(jpg|jpeg|png|webp)$/i, '-2T.jpg');
+            return;
+          }
+          if (/-2T\.(jpg|jpeg|png|webp)$/i.test(current)) {
+            img.onerror = null;
+            img.src = current.replace(/-2T\.(jpg|jpeg|png|webp)$/i, '-1.jpg');
+          }
+        };
+      }
+
+      var cards = scope.querySelectorAll(
+        '.mc-related-carousel__viewport .v-product, ' +
+        '.mc-related-carousel__viewport .v65-product-related-item, ' +
+        '#v65-product-related .v-product, ' +
+        '#v65-product-related .v65-product-related-item, ' +
+        '#related_products_content .v-product, ' +
+        '#related_products_content .v65-product-related-item, ' +
+        '#relateditems .v-product, ' +
+        '#relateditems .v65-product-related-item, ' +
+        '#related-products .v-product, ' +
+        '#related-products .v65-product-related-item, ' +
+        'table.relateditems .v-product, ' +
+        'table.relateditems .v65-product-related-item, ' +
+        '.v65-product-related .v-product, ' +
+        '.v65-product-related-item'
+      );
+
+      cards.forEach(function(card){
+        try {
+          if (card.getAttribute && card.getAttribute('data-mc-related-img-norm') === '1') return;
+          var img =
+            card.querySelector('img') ||
+            card.querySelector('.v-product__img img') ||
+            card.querySelector('.v-product__image img') ||
+            card.querySelector('.product_image img');
+          if (!img) return;
+          var link = card.querySelector(
+            'a[href*="-p/"], a[href*="product-p/"], a[href*="ProductCode="], a[href*="productcode="]'
+          );
+          normalizeOne(img, link);
+          try {
+            card.setAttribute('data-mc-related-img-norm', '1');
+          } catch (eNorm) {}
+        } catch (eCard) {}
+      });
+
+      scope
+        .querySelectorAll(
+          '#content_area #v65-product-related td.v65-productPhoto, #v65-product-related td.v65-productPhoto, ' +
+          '#content_area #related_products_content td.v65-productPhoto, #related_products_content td.v65-productPhoto, ' +
+          '#content_area #relateditems td.v65-productPhoto, #relateditems td.v65-productPhoto, ' +
+          '#content_area #related-products td.v65-productPhoto, #related-products td.v65-productPhoto, ' +
+          '#content_area table.relateditems td.v65-productPhoto, table.relateditems td.v65-productPhoto'
+        )
+        .forEach(function(td){
+        try {
+          var img = td.querySelector('img');
+          var link =
+            td.querySelector(
+              'a[href*="-p/"], a[href*="product-p/"], a[href*="ProductCode="], a[href*="productcode="]'
+            ) ||
+            (img && img.closest && img.closest(
+              'a[href*="-p/"], a[href*="product-p/"], a[href*="ProductCode="], a[href*="productcode="]'
+            ));
+          normalizeOne(img, link);
+        } catch (eTd) {}
+      });
+
+      scope
+        .querySelectorAll(
+          '#content_area #v65-product-related img, #v65-product-related img, ' +
+          '#content_area #related_products_content img, #related_products_content img, ' +
+          '#content_area #relateditems img, #relateditems img, ' +
+          '#content_area #related-products img, #related-products img, ' +
+          '#content_area table.relateditems img, table.relateditems img'
+        )
+        .forEach(function (imgEl) {
+        try {
+          if (!imgEl || (imgEl.closest && imgEl.closest('.mc-zoom-lens'))) return;
+          if (imgEl.id === 'product_photo' || imgEl.id === 'main-image') return;
+          if (imgEl.closest && imgEl.closest('#altviews, .altviews')) return;
+          if (imgEl.closest && imgEl.closest('.mtl-sectional-configurations, #mtl-sectional-configurations'))
+            return;
+          if (imgEl.closest && imgEl.closest('#mcLeatherSwatchStrip, .wm-tile, .mc-leather-mini-swatch'))
+            return;
+          if (
+            imgEl.closest &&
+            imgEl.closest('#v65-product-parent') &&
+            !imgEl.closest(
+              '#relateditems, #related-products, #v65-product-related, #related_products_content, table.relateditems, .mc-related-carousel, .mc-related-carousel__viewport'
+            )
+          )
+            return;
+          var lk =
+            (imgEl.closest &&
+              imgEl.closest(
+                'a[href*="-p/"], a[href*="product-p/"], a[href*="ProductCode="], a[href*="productcode="]'
+              )) ||
+            null;
+          normalizeOne(imgEl, lk);
+        } catch (eImg) {}
+      });
+    } catch (e) {}
+  }
+
+  function mcReorderV65RelatedProductRows() {
+    /* Disabled: rotating v65-productDisplay-row order (C,A,B) breaks Volusion's image/title/price row alignment and mismatches images to names. */
+    return;
+    try {
+      var root = document.querySelector('#content_area #v65-product-related, #content_area #related_products_content');
+      if (!root) return;
+      var table = root.querySelector('table.v65-productDisplay');
+      if (!table || (table.getAttribute && table.getAttribute('data-mc-related-rows-done') === '1')) return;
+      var tbody = table.tBodies[0] || table;
+      var rows = [];
+      var ch = tbody.children;
+      var ri;
+      for (ri = 0; ri < ch.length; ri++) {
+        var r = ch[ri];
+        if (r && r.tagName === 'TR' && r.classList && r.classList.contains('v65-productDisplay-row')) rows.push(r);
+      }
+      if (rows.length < 3) return;
+      var frag = document.createDocumentFragment();
+      for (ri = 0; ri < rows.length; ri += 3) {
+        var rowA = rows[ri];
+        var rowB = rows[ri + 1];
+        var rowC = rows[ri + 2];
+        if (rowC) frag.appendChild(rowC);
+        if (rowA) frag.appendChild(rowA);
+        if (rowB) frag.appendChild(rowB);
+      }
+      tbody.appendChild(frag);
+      try {
+        table.setAttribute('data-mc-related-rows-done', '1');
+      } catch (eAttr) {}
+    } catch (eR) {}
+  }
+
+  function mcForceBuildRelatedGrid(maxVisible) {
+    /* Disabled: pickBestCell/appendTitleContents could pair an image from one related row with a title link from another. Keep native Volusion table + CSS. */
+    return false;
+    try {
+      var root = document.querySelector('#content_area #v65-product-related, #content_area #related_products_content');
+      if (!root) return false;
+      var table = root.querySelector('table.v65-productDisplay');
+      if (!table) return false;
+
+      var tbody = table.tBodies[0] || table;
+      var rows = [];
+      var ch = tbody.children;
+      var i;
+      for (i = 0; i < ch.length; i++) {
+        if (ch[i] && ch[i].tagName === 'TR' && ch[i].classList && ch[i].classList.contains('v65-productDisplay-row')) {
+          rows.push(ch[i]);
+        }
+      }
+      if (rows.length < 3) return false;
+
+      var maxCols = 0;
+      for (i = 0; i < rows.length; i++) {
+        maxCols = Math.max(maxCols, rows[i] && rows[i].children ? rows[i].children.length : 0);
+      }
+      maxCols = Math.min(maxVisible, maxCols);
+      if (!maxCols) return false;
+
+      function cellText(cell) {
+        return ((cell && cell.textContent) || '').replace(/\s+/g, ' ').trim();
+      }
+
+      function hasUsefulCell(cell) {
+        if (!cell) return false;
+        if (cell.querySelector && cell.querySelector('img')) return true;
+        return cellText(cell).length > 0;
+      }
+
+      function looksLikePriceText(txt) {
+        return /\$[\d,]+(?:\.\d{2})?/.test(txt) || /member price|sale price|our price|list price/i.test(txt || '');
+      }
+
+      function cellImageScore(cell) {
+        if (!cell || !cell.querySelector) return 0;
+        var score = 0;
+        if (cell.querySelector('img')) score += 4;
+        if (cell.querySelector('a[href] > img, .v65-productPhoto img, .v-product__img img, .product_image img')) score += 8;
+        return score;
+      }
+
+      function cellPriceScore(cell) {
+        if (!cell) return 0;
+        var score = 0;
+        var txt = cellText(cell);
+        if (/\$[\d,]+(?:\.\d{2})?/.test(txt)) score += 5;
+        if (/member price|sale price|our price|list price/i.test(txt)) score += 4;
+        if (cell.querySelector && cell.querySelector('.product_price, .product_sale_price, .v65-product-related-price, .mc-member-grid-price')) score += 6;
+        return score;
+      }
+
+      function pickBestCell(cells, scorer) {
+        var best = null;
+        var bestScore = 0;
+        var ci;
+        for (ci = 0; ci < cells.length; ci++) {
+          var cell = cells[ci];
+          var score = scorer(cell);
+          if (score > bestScore) {
+            best = cell;
+            bestScore = score;
+          }
+        }
+        return best;
+      }
+
+      function appendCellContents(target, cell, kind) {
+        if (!target || !cell) return;
+        var clone = cell.cloneNode(true);
+        if (kind === 'price' && document.body && !document.body.classList.contains('mc-member-logged-in') && !document.body.classList.contains('mc-bean-bag-pdp')) {
+          var saleNodes = clone.querySelectorAll(
+            'font.product_sale_price, .product_sale_price, .product_saleprice, [class*="product_sale_price"], [class*="product_saleprice"]'
+          );
+          var si;
+          for (si = 0; si < saleNodes.length; si++) {
+            try {
+              if (saleNodes[si].parentNode) saleNodes[si].parentNode.removeChild(saleNodes[si]);
+            } catch (eRmSale) {}
+          }
+          var txt = cellText(clone);
+          if (/^sale\s*price\s*:?\s*$/i.test(txt)) clone.innerHTML = '';
+          if (/^sale\s*price\s*:?\s*\$[\d,]+(?:\.\d{2})?$/i.test(txt)) clone.innerHTML = '';
+        }
+        while (clone.firstChild) target.appendChild(clone.firstChild);
+      }
+
+      function appendTitleContents(target, cells) {
+        if (!target || !cells || !cells.length) return false;
+        var titleSelectors =
+          '.v-product__name, .productnamecolor, .v65-product-related-title, .productname, .ProductName, .vCSS_relatedProductName';
+        var ci;
+        for (ci = 0; ci < cells.length; ci++) {
+          var cell = cells[ci];
+          if (!cell || !cell.querySelector) continue;
+          var titleNode = cell.querySelector(titleSelectors);
+          if (titleNode && cellText(titleNode)) {
+            target.appendChild(titleNode.cloneNode(true));
+            return true;
+          }
+        }
+        for (ci = 0; ci < cells.length; ci++) {
+          var linkCell = cells[ci];
+          if (!linkCell || !linkCell.querySelectorAll) continue;
+          var links = linkCell.querySelectorAll('a[href]');
+          var li;
+          for (li = 0; li < links.length; li++) {
+            var link = links[li];
+            var linkTxt = cellText(link);
+            if (!linkTxt || link.querySelector('img') || looksLikePriceText(linkTxt) || /review/i.test(linkTxt)) continue;
+            target.appendChild(link.cloneNode(true));
+            return true;
+          }
+        }
+        for (ci = 0; ci < cells.length; ci++) {
+          var imgCell2 = cells[ci];
+          if (!imgCell2 || !imgCell2.querySelector) continue;
+          var img = imgCell2.querySelector('img[alt]');
+          var alt = ((img && img.getAttribute && img.getAttribute('alt')) || '').replace(/\s+/g, ' ').trim();
+          if (!alt || looksLikePriceText(alt) || /^image$/i.test(alt)) continue;
+          var hrefEl =
+            imgCell2.querySelector('a[href]') ||
+            (cells[0] && cells[0].querySelector && cells[0].querySelector('a[href]'));
+          if (hrefEl) {
+            var fallbackLink = document.createElement('a');
+            fallbackLink.href = hrefEl.getAttribute('href') || hrefEl.href || '#';
+            fallbackLink.textContent = alt;
+            target.appendChild(fallbackLink);
+          } else {
+            target.textContent = alt;
+          }
+          return true;
+        }
+        for (ci = 0; ci < cells.length; ci++) {
+          var txtCell = cells[ci];
+          var txt = cellText(txtCell);
+          if (!txt || looksLikePriceText(txt) || /review/i.test(txt) || txt.length > 140) continue;
+          target.textContent = txt;
+          return true;
+        }
+        return false;
+      }
+
+      var oldGrid = document.getElementById('mc-related-force-grid');
+      if (oldGrid && oldGrid.parentNode) oldGrid.parentNode.removeChild(oldGrid);
+
+      var grid = document.createElement('div');
+      grid.id = 'mc-related-force-grid';
+      grid.style.setProperty('display', 'grid', 'important');
+      grid.style.setProperty('grid-template-columns', 'repeat(' + maxCols + ', minmax(0, 1fr))', 'important');
+      grid.style.setProperty('gap', '24px 18px', 'important');
+      grid.style.setProperty('align-items', 'start', 'important');
+      grid.style.setProperty('justify-items', 'center', 'important');
+      grid.style.setProperty('width', '100%', 'important');
+      grid.style.setProperty('margin', '12px 0 0 0', 'important');
+
+      var cardsBuilt = 0;
+      for (i = 0; i < maxCols; i++) {
+        var columnCells = [];
+        var ri2;
+        for (ri2 = 0; ri2 < rows.length; ri2++) {
+          if (rows[ri2] && rows[ri2].children && rows[ri2].children[i]) columnCells.push(rows[ri2].children[i]);
+        }
+        var imgCell = pickBestCell(columnCells, cellImageScore);
+        var priceCell = pickBestCell(columnCells, cellPriceScore);
+        var hasTitleCandidate = false;
+        var ci3;
+        for (ci3 = 0; ci3 < columnCells.length; ci3++) {
+          if (cellText(columnCells[ci3])) {
+            hasTitleCandidate = true;
+            break;
+          }
+        }
+        if (!hasUsefulCell(imgCell) && !hasTitleCandidate && !hasUsefulCell(priceCell)) continue;
+
+        var card = document.createElement('div');
+        card.style.setProperty('display', 'flex', 'important');
+        card.style.setProperty('flex-direction', 'column', 'important');
+        card.style.setProperty('align-items', 'center', 'important');
+        card.style.setProperty('justify-content', 'flex-start', 'important');
+        card.style.setProperty('text-align', 'center', 'important');
+        card.style.setProperty('min-width', '0', 'important');
+        card.style.setProperty('width', '100%', 'important');
+
+        var media = document.createElement('div');
+        media.style.setProperty('display', 'flex', 'important');
+        media.style.setProperty('align-items', 'center', 'important');
+        media.style.setProperty('justify-content', 'center', 'important');
+        media.style.setProperty('width', '100%', 'important');
+        media.style.setProperty('min-height', '160px', 'important');
+        media.style.setProperty('margin', '0 0 12px 0', 'important');
+        appendCellContents(media, imgCell, 'image');
+        card.appendChild(media);
+
+        var title = document.createElement('div');
+        title.style.setProperty('display', 'block', 'important');
+        title.style.setProperty('width', '100%', 'important');
+        title.style.setProperty('margin', '0 auto 6px auto', 'important');
+        title.style.setProperty('text-align', 'center', 'important');
+        title.style.setProperty('line-height', '1.35', 'important');
+        appendTitleContents(title, columnCells);
+        if (cellText(title)) card.appendChild(title);
+
+        var price = document.createElement('div');
+        price.style.setProperty('display', 'block', 'important');
+        price.style.setProperty('width', '100%', 'important');
+        price.style.setProperty('text-align', 'center', 'important');
+        appendCellContents(price, priceCell, 'price');
+        if (cellText(price)) card.appendChild(price);
+
+        grid.appendChild(card);
+        cardsBuilt++;
+      }
+
+      if (!cardsBuilt) return false;
+      table.style.setProperty('display', 'none', 'important');
+      if (table.nextSibling) table.parentNode.insertBefore(grid, table.nextSibling);
+      else table.parentNode.appendChild(grid);
+      try {
+        mcNormalizeRelatedItemImages(grid);
+      } catch (eNormGrid) {}
+      return true;
+    } catch (eForce) {
+      return false;
+    }
+  }
+
+  function mcRunRelatedFix() {
+    try {
+      mcRelatedHideDuplicateVolusionRails();
+      var selfCode = mcRelatedCurrentPdpProductCode();
+      var railRoots = document.querySelectorAll(
+        '#v65-product-related, #related_products_content, #relateditems, #related-products, table.relateditems'
+      );
+      var ri2;
+      for (ri2 = 0; ri2 < railRoots.length; ri2++) {
+        mcRelatedHideSelfSlots(railRoots[ri2], selfCode);
+      }
+      mcConvertRelatedV65TablesToPlpGrid(4);
+      mcRelatedHideSecondaryRailsIfPlpMain();
+      mcCapRelatedProductSlots(4);
+      mcNormalizeRelatedItemImages(document);
+      mcForceRelatedItemCategoryThumbnails(document);
+    } catch (eRun) {}
+  }
+  function boot() {
+    if (
+      !document.body.classList.contains('productdetails') &&
+      !document.body.classList.contains('mc-product-page') &&
+      !document.body.classList.contains('mc-bean-bag-pdp')
+    )
+      return;
+    mcRunRelatedFix();
+  }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', boot);
+  else boot();
+  window.addEventListener('load', function () {
+    setTimeout(mcRunRelatedFix, 0);
+    setTimeout(mcRunRelatedFix, 400);
+    setTimeout(mcRunRelatedFix, 1200);
+    setTimeout(mcRunRelatedFix, 2600);
+    setTimeout(mcRunRelatedFix, 4800);
+  });
+  /* Related Items may render outside #content_area (Volusion) — observing only #content_area missed late inject + lazy img. */
+  var moRoot = typeof document.body !== 'undefined' && document.body ? document.body : null;
+  if (moRoot && typeof MutationObserver !== 'undefined') {
+    var t;
+    var mo = new MutationObserver(function () {
+      clearTimeout(t);
+      t = setTimeout(mcRunRelatedFix, 120);
+    });
+    try {
+      mo.observe(moRoot, { childList: true, subtree: true });
+    } catch (eMo) {}
+  }
+
+  window.mcNormalizeRelatedItemImages = mcNormalizeRelatedItemImages;
+  window.mcRunRelatedFix = mcRunRelatedFix;
+  document.addEventListener('DOMContentLoaded', function () {
+    mcRunRelatedFix();
+    setTimeout(mcRunRelatedFix, 300);
+    setTimeout(mcRunRelatedFix, 900);
+    window.addEventListener('load', mcRunRelatedFix);
+  });
+  if (document.readyState !== 'loading') {
+    mcRunRelatedFix();
+    setTimeout(mcRunRelatedFix, 300);
+    setTimeout(mcRunRelatedFix, 900);
+    window.addEventListener('load', mcRunRelatedFix);
+  }
+})();
+</script>
+
+<script>
+(function(){
+  function qsa(sel, root){ return Array.from((root || document).querySelectorAll(sel)); }
+
+  function cleanPriceNode(node){
+    if (!node) return;
+    var walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT, null);
+    var textNodes = [];
+    while (walker.nextNode()) textNodes.push(walker.currentNode);
+
+    textNodes.forEach(function(t){
+      var before = t.nodeValue || '';
+      var after = before
+        .replace(/^\s*:\s*(?=\$)/, '')
+        .replace(/^\s*:\s*(?=\d)/, '')
+        .replace(/^\s*:\s*$/, '');
+      if (after !== before) t.nodeValue = after;
+    });
+  }
+
+  function stripLeadingPriceColons(root){
+    var selectors = [
+      '.v65-product-price',
+      '.product_productprice',
+      '#priceWithOptions',
+      '.option_pricing',
+      '.v65-product-related-price',
+      '.price',
+      '[itemprop=\"offers\"]'
+    ];
+    qsa(selectors.join(','), root || document).forEach(cleanPriceNode);
+  }
+
+  function boot(){
+    stripLeadingPriceColons(document);
+    setTimeout(function(){ stripLeadingPriceColons(document); }, 500);
+    setTimeout(function(){ stripLeadingPriceColons(document); }, 1500);
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', boot);
+  else boot();
+  window.addEventListener('load', function(){ stripLeadingPriceColons(document); });
+
+  if (!window.__mcPriceColonObserver) {
+    var lastRun = 0;
+    var minInterval = 2500;
+    window.__mcPriceColonObserver = new MutationObserver(function(){
+      var now = Date.now();
+      if (now - lastRun < minInterval) return;
+      lastRun = now;
+      setTimeout(function(){ stripLeadingPriceColons(document); }, 200);
+    });
+    var contentArea = document.querySelector('#content_area');
+    window.__mcPriceColonObserver.observe(contentArea || document.body, { childList: true, subtree: true });
+  }
+})();
+</script>
+
+<!-- PDP: Volusion Product Info / Tech / Ext tabs stay hidden — see custom-safe.css vCSS_tab rules.
+     (Earlier “PATCH: Restore product tabs” JS/CSS reversed those hides — removed May 2026.) -->
+<script>
+(function(){
+  /* Fetch planner dims from Palliser spec-sheet PDFs */
+  var PALLISER_MODELS = window.__MC_PALLISER_SPEC_MODEL || {
+    flicks: "41416",
+    audio: "41422",
+    vivid: "41095",
+    ace: "41472",
+    paragon: "41417",
+    catalina: "41471",
+    vertex: "41470",
+    beckett: "41473",
+    titan: "44004"
+  };
+  var PX = 4;
+  var _fetchedDims = null;
+
+  function detectStyle(){
+    try {
+      if (typeof window.mcPalliserResolveModelAndStyle === "function") {
+        var r0 = window.mcPalliserResolveModelAndStyle();
+        if (r0 && r0.model && r0.style) {
+          return { style: String(r0.style).toLowerCase(), model: String(r0.model) };
+        }
+      }
+    } catch (eR0) {}
+    var name = (document.querySelector('h1.productnamecolor, .productnamecolor, #content_area h1')||{}).textContent||'';
+    var pc = String(((document.querySelector('input[name="ProductCode"]')||{}).value||'')).toLowerCase();
+    var hay = (name+' '+pc).toLowerCase();
+    var keys = Object.keys(PALLISER_MODELS).sort(function (a, b) { return b.length - a.length; });
+    var si;
+    for (si = 0; si < keys.length; si++){
+      var s = keys[si];
+      if (hay.indexOf(s) !== -1) return {style:s, model:PALLISER_MODELS[s]};
+    }
+    return null;
+  }
+
+  function loadPdfJs(){
+    if (window.pdfjsLib) return Promise.resolve(window.pdfjsLib);
+    return new Promise(function(ok,fail){
+      var s = document.createElement('script');
+      s.src = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js';
+      s.onload = function(){
+        pdfjsLib.GlobalWorkerOptions.workerSrc =
+          'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
+        ok(pdfjsLib);
+      };
+      s.onerror = fail;
+      document.head.appendChild(s);
+    });
+  }
+
+  function pdfToText(pdf){
+    var pages = [];
+    for (var p = 1; p <= pdf.numPages; p++) pages.push(p);
+    return pages.reduce(function(chain, pn){
+      return chain.then(function(acc){
+        return pdf.getPage(pn).then(function(pg){ return pg.getTextContent(); }).then(function(tc){
+          var yGroups = {};
+          tc.items.forEach(function(it){
+            var y = Math.round(it.transform[5]);
+            if (!yGroups[y]) yGroups[y] = [];
+            yGroups[y].push({x: it.transform[4], str: it.str});
+          });
+          var yKeys = Object.keys(yGroups).sort(function(a,b){ return parseFloat(b) - parseFloat(a); });
+          var lines = [];
+          yKeys.forEach(function(yk){
+            var items = yGroups[yk].sort(function(a,b){ return a.x - b.x; });
+            lines.push(items.map(function(it){ return it.str; }).join(' '));
+          });
+          acc.push(lines.join('\n'));
+          return acc;
+        });
+      });
+    }, Promise.resolve([])).then(function(all){ return all.join('\n'); });
+  }
+
+  function parsePieceDims(text){
+    var dims = {};
+    var lines = text.split('\n');
+    var inSide = false, inFront = false;
+    var sideData = {}, frontData = {};
+    for (var li = 0; li < lines.length; li++){
+      var line = lines[li].trim();
+      if (/^Side\b/i.test(line)){ inSide = true; inFront = false; continue; }
+      if (/^Front\b/i.test(line)){ inFront = true; inSide = false; continue; }
+      var rm = line.match(/\d+-(\d)[ERL]\b/);
+      if (!rm) continue;
+      var pid = rm[1] + 'L';
+      var afterId = line.substring(rm.index + rm[0].length);
+      var numMatches = afterId.match(/\d+\.?\d*/g);
+      if (!numMatches) continue;
+      var nums = numMatches.map(parseFloat).filter(function(n){ return !isNaN(n); });
+      if (inSide && nums.length >= 2 && !sideData[pid]){
+        sideData[pid] = { d: nums[0], h: nums[1] };
+      } else if (inFront && nums.length >= 1 && !frontData[pid]){
+        frontData[pid] = { w: nums[0] };
+      }
+    }
+    for (var k in frontData){
+      if (sideData[k]) dims[k] = { w: frontData[k].w, d: sideData[k].d, h: sideData[k].h };
+    }
+    if (Object.keys(dims).length === 0){
+      var pieceIds = [], seenIds = {}, m2;
+      var pidRe = /(\d)[ERL]\s+(?:LHF|RHF|Armless|Recliner|Wedge|Power)/gi;
+      while ((m2 = pidRe.exec(text)) !== null){
+        if (!seenIds[m2[1]]){ pieceIds.push(m2[1]); seenIds[m2[1]] = true; }
+      }
+      var dimsList = [];
+      var dimRe = /(\d+(?:\.\d+)?)\s*x\s*(\d+(?:\.\d+)?)\s*x\s*(\d+(?:\.\d+)?)\s*["\u2033]/g;
+      while ((m2 = dimRe.exec(text)) !== null){
+        var w = parseFloat(m2[1]);
+        if (w >= 15 && w <= 70) dimsList.push({ w:w, d:parseFloat(m2[2]), h:parseFloat(m2[3]) });
+      }
+      for (var j = 0; j < pieceIds.length && j < dimsList.length; j++){
+        dims[pieceIds[j]+'L'] = dimsList[j];
+      }
+    }
+    return dims;
+  }
+
+  function applyDims(dims){
+    if (!dims || !Object.keys(dims).length) return;
+    document.querySelectorAll('#roomPlannerApp .piece-row').forEach(function(row){
+      var ne = row.querySelector('.piece-name'), de = row.querySelector('.piece-dims');
+      if (!ne || !de) return;
+      var pid = (ne.textContent||'').trim().split(' ')[0];
+      if (dims[pid]) de.innerHTML = dims[pid].w+'\u2033 \u00d7 '+dims[pid].d+'\u2033 \u00d7 '+dims[pid].h+'\u2033';
+    });
+    document.querySelectorAll('#roomPlannerApp .seat').forEach(function(seat){
+      var pid = seat.dataset.pieceId;
+      if (dims[pid]){
+        seat.style.width  = (dims[pid].w * PX)+'px';
+        seat.style.height = (dims[pid].d * PX)+'px';
+      }
+    });
+  }
+
+  var _dimObsSet = false;
+  function setupDimObserver(dims){
+    if (_dimObsSet || !dims) return;
+    var app = document.getElementById('roomPlannerApp');
+    if (!app) return;
+    _dimObsSet = true;
+    new MutationObserver(function(muts){
+      muts.forEach(function(m){
+        for (var i=0;i<m.addedNodes.length;i++){
+          var n = m.addedNodes[i];
+          if (n.nodeType===1 && n.classList && n.classList.contains('seat')){
+            var pid = n.dataset.pieceId;
+            if (dims[pid]){
+              n.style.width  = (dims[pid].w * PX)+'px';
+              n.style.height = (dims[pid].d * PX)+'px';
+            }
+          }
+        }
+      });
+    }).observe(app, {childList:true, subtree:true});
+  }
+
+  function fetchPlannerDimensions(){
+    if (_fetchedDims){ applyDims(_fetchedDims); setupDimObserver(_fetchedDims); return; }
+    var pdfUrl =
+      typeof window.mcBuildPalliserSpecSheetUrl === "function" ? window.mcBuildPalliserSpecSheetUrl() : "";
+    var info = null;
+    try {
+      if (pdfUrl && typeof window.mcPalliserResolveModelAndStyle === "function") {
+        var r1 = window.mcPalliserResolveModelAndStyle();
+        if (r1 && r1.model && r1.style) {
+          info = { model: String(r1.model), style: String(r1.style).toLowerCase() };
+        }
+      }
+    } catch (eInf) {}
+    if (!info) info = detectStyle();
+    if (!info) return;
+    if (!pdfUrl) {
+      var base =
+        (typeof window.MC_PALLISER_SPEC_SHEET_BASE === "string" && window.MC_PALLISER_SPEC_SHEET_BASE) ||
+        "https://images.palliser.com/specsheet/en/";
+      base = String(base).replace(/\/?$/, "/");
+      pdfUrl =
+        base +
+        encodeURIComponent(info.model + " " + String(info.style || "").toUpperCase()) +
+        ".pdf";
+    }
+    var cacheKey = 'mc_dims_v2_' + info.style;
+    try {
+      var cached = sessionStorage.getItem(cacheKey);
+      if (cached){
+        _fetchedDims = JSON.parse(cached);
+        applyDims(_fetchedDims); setupDimObserver(_fetchedDims);
+        return;
+      }
+    } catch(e){}
+    function fetchAB(url){ return fetch(url).then(function(r){ if (!r.ok) throw new Error('HTTP '+r.status); return r.arrayBuffer(); }); }
+    var proxy1 = 'https://corsproxy.io/?'+encodeURIComponent(pdfUrl);
+    var proxy2 = 'https://api.allorigins.win/raw?url='+encodeURIComponent(pdfUrl);
+    loadPdfJs().then(function(lib){
+      return fetchAB(pdfUrl).catch(function(){
+        console.log('[MC Planner] Direct PDF fetch failed, trying proxy 1');
+        return fetchAB(proxy1);
+      }).catch(function(){
+        console.log('[MC Planner] Proxy 1 failed, trying proxy 2');
+        return fetchAB(proxy2);
+      }).then(function(data){
+        return lib.getDocument({data: new Uint8Array(data)}).promise;
+      });
+    }).then(function(pdf){
+      return pdfToText(pdf);
+    }).then(function(text){
+      console.log('[MC Planner] PDF text extracted, length:', text.length);
+      var dims = parsePieceDims(text);
+      console.log('[MC Planner] Parsed dims:', JSON.stringify(dims));
+      if (Object.keys(dims).length){
+        _fetchedDims = dims;
+        try { sessionStorage.setItem(cacheKey, JSON.stringify(dims)); } catch(e){}
+        applyDims(dims); setupDimObserver(dims);
+      } else {
+        console.warn('[MC Planner] No dimensions parsed from PDF');
+      }
+    }).catch(function(err){
+      console.warn('[MC Planner] Spec-sheet fetch failed:', err);
+    });
+  }
+
+  function runPatches(){
+    fetchPlannerDimensions();
+  }
+
+  if (document.readyState==='loading') document.addEventListener('DOMContentLoaded', runPatches);
+  else runPatches();
+  window.addEventListener('load', runPatches);
+  var _patchDelays = [500, 1500, 3500, 8000];
+  _patchDelays.forEach(function(ms, i){ setTimeout(runPatches, ms); });
+})();
+</script>
+
+<!-- Cart page: configuration image modal + remove X per line -->
+<script>
+(function(){
+  function mcSeatSlug(s){
+    return String(s || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  }
+  function mcParseSeatMoney(s){
+    var n = parseFloat(String(s || "").replace(/[^0-9.]/g, ""));
+    return isNaN(n) ? 0 : n;
+  }
+  function mcFmtCartMoney(v){
+    return "$" + Number(v || 0).toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  }
+  function mcCacheSeatPrice(pc, name, price){
+    if (!(price > 0)) return;
+    try {
+      if (pc) localStorage.setItem("mc_member_seat_" + pc, String(price));
+      var slug = mcSeatSlug(name);
+      if (slug) localStorage.setItem("mc_member_seat_name_" + slug, String(price));
+    } catch (_) {}
+  }
+  function mcCartLooksLoggedIn(){
+    var raw = document.documentElement ? document.documentElement.innerHTML : "";
+    var h = String(raw)
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<!--[\s\S]*?-->/g, ' ');
+    var lc = h.toLowerCase();
+    if (/<input[^>]+type\s*=\s*["']password["']/i.test(h) && /returning customer|login password|sign in/i.test(lc)) return false;
+    if (/href\s*=\s*["'][^"']*logout\.asp[^"']*["']/i.test(h)) return true;
+    if (/href\s*=\s*["'][^"']*logoff\.asp[^"']*["']/i.test(h)) return true;
+    if (/>\s*sign\s*out\s*</i.test(h) || />\s*log\s*out\s*</i.test(h)) return true;
+    if (/welcome to your account|order history|account settings/i.test(lc) && !/returning customer/i.test(lc)) return true;
+    return false;
+  }
+  function mcReadPlannerCookieTarget(){
+    try {
+      var c = document.cookie || "";
+      var m = c.match(/(?:^|;\s*)mc_planner_ct=([^;]+)/);
+      if (!m) return null;
+      var t = parseFloat(decodeURIComponent(m[1]));
+      if (!(t > 0)) return null;
+      var pc = "";
+      var m2 = c.match(/(?:^|;\s*)mc_planner_pc=([^;]+)/);
+      if (m2) pc = decodeURIComponent(m2[1]).trim();
+      return { retailTotal: t, memberTotal: t, ts: Date.now(), pc: pc, name: "" };
+    } catch (_) {
+      return null;
+    }
+  }
+  function mcReadCartTarget(){
+    try {
+      var raw = localStorage.getItem("mc_cart_target_last");
+      if (!raw) return null;
+      var obj = JSON.parse(raw);
+      if (!obj || !obj.ts) return null;
+      if ((Date.now() - Number(obj.ts)) > 1000 * 60 * 60 * 6) return null;
+      return obj;
+    } catch (_) {
+      return null;
+    }
+  }
+  function mcReadSessionPlannerCartTarget(pc, allowAnyProduct){
+    try {
+      var t = parseFloat(sessionStorage.getItem("mc_planner_config_total") || "");
+      var ts = parseInt(sessionStorage.getItem("mc_planner_config_ts") || "0", 10);
+      var spc = (sessionStorage.getItem("mc_planner_config_pc") || "").trim();
+      if (!(t > 0) || !ts || (Date.now() - ts) > 1000 * 60 * 60 * 6) return null;
+      var p = String(pc || "").trim();
+      if (!allowAnyProduct) {
+        if (spc && p && p.toLowerCase() !== spc.toLowerCase()) return null;
+        if (spc && !p) return null;
+      }
+      return { retailTotal: t, memberTotal: t, ts: ts, pc: spc || p, name: "" };
+    } catch (_) {
+      return null;
+    }
+  }
+  function mcReadCartTargetPreferPc(pc, allowSessionAnyProduct){
+    try {
+      var p = String(pc || "").trim();
+      if (p) {
+        var raw = localStorage.getItem("mc_cart_target_" + p);
+        if (raw) {
+          var obj = JSON.parse(raw);
+          if (obj && obj.ts && (Date.now() - Number(obj.ts)) <= 1000 * 60 * 60 * 6) return obj;
+        }
+      }
+    } catch (_) {}
+    var sess = mcReadSessionPlannerCartTarget(pc, !!allowSessionAnyProduct);
+    if (sess) return sess;
+    var ck = mcReadPlannerCookieTarget();
+    if (ck) {
+      if (!pc || !ck.pc || String(pc).toLowerCase() === String(ck.pc).toLowerCase() || allowSessionAnyProduct) return ck;
+    }
+    return mcReadCartTarget();
+  }
+  function mcApplyCartTargetPrice(row, targetTotal){
+    if (!(targetTotal > 0)) return 0;
+    var cells = row.querySelectorAll("td");
+    var nCells = cells.length;
+    var pickCell = null;
+    var pickVal = 0;
+    for (var i = nCells - 1; i >= 0; i--) {
+      var tx = cells[i].textContent || "";
+      var mm = tx.match(/\$[\d,]+(?:\.\d+)?/);
+      if (!mm) continue;
+      var n = mcParseSeatMoney(mm[0]);
+      if (!(n > 0)) continue;
+      pickCell = cells[i];
+      pickVal = n;
+      break;
+    }
+    if (!pickCell) return 0;
+    var newTxt = mcFmtCartMoney(targetTotal);
+    pickCell.textContent = (pickCell.textContent || "").replace(/\$[\d,]+(?:\.\d+)?/g, newTxt);
+    try { row.dataset.mcPlannerCartTarget = "1"; } catch (ePc) {}
+    return targetTotal - pickVal;
+  }
+  function mcGetCached4LDiscount(pc, name){
+    try {
+      var p = 0;
+      if (pc) p = mcParseSeatMoney(localStorage.getItem("mc_4l_discount_" + pc) || "");
+      if (!(p > 0)) {
+        var slug = mcSeatSlug(name);
+        if (slug) p = mcParseSeatMoney(localStorage.getItem("mc_4l_discount_name_" + slug) || "");
+      }
+      return p > 0 ? p : 0;
+    } catch (_) {
+      return 0;
+    }
+  }
+  function mcClearCached4LDiscount(pc, name){
+    try {
+      if (pc) localStorage.removeItem("mc_4l_discount_" + pc);
+      var slug = mcSeatSlug(name);
+      if (slug) localStorage.removeItem("mc_4l_discount_name_" + slug);
+    } catch (_) {}
+  }
+  function mcGuessProductCodeFromRow(tr, removeHref){
+    var v = "";
+    var inp = tr.querySelector('input[name*="ProductCode" i], input[id*="ProductCode" i], input[name*="pcode" i], input[id*="pcode" i]');
+    if (inp) v = (inp.value || inp.getAttribute("value") || "").trim();
+    if (!v) {
+      var rowText = (tr.textContent || "");
+      var m = rowText.match(/\b([A-Z0-9][A-Z0-9\-]{3,})\b/);
+      if (m) v = m[1];
+    }
+    if (!v && removeHref) {
+      var m2 = removeHref.match(/(?:ProductCode|Product_Code|productcode|pcode)=([^&]+)/i);
+      if (m2) {
+        try { v = decodeURIComponent(m2[1]); } catch (e) { v = m2[1]; }
+      }
+    }
+    return String(v || "").trim();
+  }
+  function mcGuessProductNameFromRow(tr){
+    var el = tr.querySelector('a[href*="-p/"], a[href*="/p/"], a[href*="product"], .productnamecolor, .productnamecolorLARGE');
+    if (el) return (el.textContent || "").replace(/\s+/g, " ").trim();
+    var tds = tr.querySelectorAll("td");
+    for (var i = 0; i < tds.length; i++) {
+      var t = (tds[i].textContent || "").replace(/\s+/g, " ").trim();
+      if (!t) continue;
+      if (/\$[\d,]/.test(t)) continue;
+      if (/remove|delete|qty|quantity|total|price|each/i.test(t)) continue;
+      if (t.length < 4) continue;
+      return t;
+    }
+    return "";
+  }
+  function mcExtractRowSeatPrice(tr){
+    var prices = ((tr.textContent || "").match(/\$[\d,]+(?:\.\d+)?/g) || []);
+    var best = 0;
+    for (var i = 0; i < prices.length; i++) {
+      var n = mcParseSeatMoney(prices[i]);
+      // Prefer larger row price to avoid accessory add-ons like $79.
+      if (n > 0 && (!best || n > best)) best = n;
+    }
+    return best;
+  }
+  function isCartPage(){
+    var p = (window.location.pathname || "").toLowerCase();
+    var h = (window.location.href || "").toLowerCase();
+    var title = (document.title || "").toLowerCase();
+    return (
+      p.indexOf("shoppingcart") !== -1 ||
+      p.indexOf("shopcart") !== -1 ||
+      p.indexOf("/cart") !== -1 ||
+      p.indexOf("basket") !== -1 ||
+      p.indexOf("orderform") !== -1 ||
+      h.indexOf("shoppingcart") !== -1 ||
+      h.indexOf("shopcart.asp") !== -1 ||
+      h.indexOf("basket.asp") !== -1 ||
+      h.indexOf("/cart") !== -1 ||
+      h.indexOf("basket") !== -1 ||
+      h.indexOf("shoppingcart.asp") !== -1 ||
+      title.indexOf("shopping cart") !== -1 ||
+      title.indexOf("cart") !== -1 ||
+      title.indexOf("basket") !== -1
+    );
+  }
+  function mcClosest(el, sel) {
+    if (!el || !sel) return null;
+    if (el.nodeType !== 1) el = el.parentElement;
+    if (!el) return null;
+    if (el.closest) return el.closest(sel);
+    while (el && el.nodeType === 1) {
+      try { if (el.matches && el.matches(sel)) return el; } catch (e) {}
+      try { if (el.webkitMatchesSelector && el.webkitMatchesSelector(sel)) return el; } catch (e) {}
+      el = el.parentElement;
+    }
+    return null;
+  }
+  function extractLayoutFromText(text){
+    if (typeof text !== "string") return null;
+    var start = text.indexOf("[MC_LAYOUT]");
+    var end = text.indexOf("[/MC_LAYOUT]");
+    if (start === -1 || end === -1 || end <= start) return null;
+    try {
+      return JSON.parse(text.slice(start + "[MC_LAYOUT]".length, end));
+    } catch (e) { return null; }
+  }
+  function drawLayoutInCanvas(canvas, data){
+    var PX_PER_INCH = 4;
+    var room = (data && data.r) ? data.r : { widthTotalIn: 192, depthTotalIn: 144 };
+    var layout = (data && data.l) ? data.l : [];
+    var wIn = (room.widthTotalIn != null) ? room.widthTotalIn : 192;
+    var dIn = (room.depthTotalIn != null) ? room.depthTotalIn : 144;
+    var roomWpx = wIn * PX_PER_INCH, roomHpx = dIn * PX_PER_INCH;
+    var pad = 56;
+    var scale = Math.min((canvas.width - pad) / roomWpx, (canvas.height - pad) / roomHpx) || 0.5;
+    var roomW = roomWpx * scale, roomH = roomHpx * scale;
+    var ox = (canvas.width - roomW) / 2, oy = (canvas.height - roomH) / 2;
+    var ctx = canvas.getContext("2d");
+    ctx.fillStyle = "#fff";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.strokeStyle = "#999";
+    ctx.lineWidth = 2;
+    ctx.strokeRect(ox, oy, roomW, roomH);
+    var gridSize = 12 * PX_PER_INCH * scale;
+    ctx.strokeStyle = "rgba(0,0,0,0.10)";
+    ctx.lineWidth = 1;
+    for (var gx = ox; gx < ox + roomW + 0.5; gx += gridSize) { ctx.beginPath(); ctx.moveTo(gx, oy); ctx.lineTo(gx, oy + roomH); ctx.stroke(); }
+    for (var gy = oy; gy < oy + roomH + 0.5; gy += gridSize) { ctx.beginPath(); ctx.moveTo(ox, gy); ctx.lineTo(ox + roomW, gy); ctx.stroke(); }
+    var wFt = Math.floor(wIn / 12), wInRem = wIn % 12, dFt = Math.floor(dIn / 12), dInRem = dIn % 12;
+    var dimTopText = (wFt ? wFt + " ft " : "") + (wInRem ? wInRem + " in" : (wFt ? "" : "0 in"));
+    var dimLeftText = (dFt ? dFt + " ft " : "") + (dInRem ? dInRem + " in" : (dFt ? "" : "0 in"));
+    ctx.font = "600 12px Helvetica, Arial, sans-serif";
+    ctx.fillStyle = "#333";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    var dimH = 22, dimPad = 6;
+    ctx.fillStyle = "#fff";
+    ctx.strokeStyle = "#ccc";
+    ctx.lineWidth = 1;
+    var topW = ctx.measureText(dimTopText).width + dimPad * 2;
+    ctx.fillRect(ox + roomW / 2 - topW / 2, oy - dimH - 4, topW, dimH);
+    ctx.strokeRect(ox + roomW / 2 - topW / 2, oy - dimH - 4, topW, dimH);
+    ctx.fillStyle = "#333";
+    ctx.fillText(dimTopText, ox + roomW / 2, oy - dimH / 2 - 4);
+    ctx.save();
+    ctx.translate(ox - dimH / 2 - 4, oy + roomH / 2);
+    ctx.rotate(-Math.PI / 2);
+    var leftW = ctx.measureText(dimLeftText).width + dimPad * 2;
+    ctx.fillStyle = "#fff";
+    ctx.fillRect(-leftW / 2, -dimH / 2, leftW, dimH);
+    ctx.strokeRect(-leftW / 2, -dimH / 2, leftW, dimH);
+    ctx.fillStyle = "#333";
+    ctx.fillText(dimLeftText, 0, 0);
+    ctx.restore();
+    layout.forEach(function(item){
+      var x = (item.x != null ? item.x : 40) * scale + ox;
+      var y = (item.y != null ? item.y : 40) * scale + oy;
+      var w = (item.w != null ? item.w : 160) * scale;
+      var h = (item.h != null ? item.h : 96) * scale;
+      ctx.save();
+      ctx.translate(x + w/2, y + h/2);
+      ctx.rotate(((item.rot != null ? item.rot : 0) * Math.PI) / 180);
+      ctx.translate(-(x + w/2), -(y + h/2));
+      ctx.fillStyle = "#fff";
+      ctx.strokeStyle = "#999";
+      ctx.lineWidth = 1;
+      ctx.fillRect(x, y, w, h);
+      ctx.strokeRect(x, y, w, h);
+      ctx.fillStyle = "rgba(100,100,100,0.85)";
+      ctx.font = "10px Helvetica, Arial, sans-serif";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "bottom";
+      ctx.fillText(item.id || "", x + w/2, y + h - 2);
+      ctx.restore();
+    });
+  }
+  var MC_PIECE_IMG_BASE = "/v/vspfiles/MRP/";
+  function drawConfigModalWithImages(canvas, data, doneCallback){
+    var PX_PER_INCH = 4;
+    var room = (data && data.r) ? data.r : { widthTotalIn: 192, depthTotalIn: 144 };
+    var layout = (data && data.l) ? data.l : [];
+    var wIn = (room.widthTotalIn != null) ? room.widthTotalIn : 192;
+    var dIn = (room.depthTotalIn != null) ? room.depthTotalIn : 144;
+    var roomWpx = wIn * PX_PER_INCH, roomHpx = dIn * PX_PER_INCH;
+    var pad = 48;
+    var scale = Math.min((canvas.width - pad) / roomWpx, (canvas.height - pad) / roomHpx) || 0.5;
+    var roomW = roomWpx * scale, roomH = roomHpx * scale;
+    var ox = (canvas.width - roomW) / 2, oy = (canvas.height - roomH) / 2;
+    var ctx = canvas.getContext("2d");
+    ctx.fillStyle = "#fff";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.strokeStyle = "#999";
+    ctx.lineWidth = 2;
+    ctx.strokeRect(ox, oy, roomW, roomH);
+    var gridSize = 12 * PX_PER_INCH * scale;
+    ctx.strokeStyle = "rgba(0,0,0,0.10)";
+    ctx.lineWidth = 1;
+    for (var gx = ox; gx < ox + roomW + 0.5; gx += gridSize) { ctx.beginPath(); ctx.moveTo(gx, oy); ctx.lineTo(gx, oy + roomH); ctx.stroke(); }
+    for (var gy = oy; gy < oy + roomH + 0.5; gy += gridSize) { ctx.beginPath(); ctx.moveTo(ox, gy); ctx.lineTo(ox + roomW, gy); ctx.stroke(); }
+    var wFt = Math.floor(wIn / 12), wInRem = wIn % 12, dFt = Math.floor(dIn / 12), dInRem = dIn % 12;
+    var dimTopText = (wFt ? wFt + " ft " : "") + (wInRem ? wInRem + " in" : (wFt ? "" : "0 in"));
+    var dimLeftText = (dFt ? dFt + " ft " : "") + (dInRem ? dInRem + " in" : (dFt ? "" : "0 in"));
+    ctx.font = "600 12px Helvetica, Arial, sans-serif";
+    ctx.fillStyle = "#333";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    var dimH = 22, dimPad = 6;
+    ctx.fillStyle = "#fff";
+    ctx.strokeStyle = "#ccc";
+    ctx.lineWidth = 1;
+    var topW = ctx.measureText(dimTopText).width + dimPad * 2;
+    ctx.fillRect(ox + roomW / 2 - topW / 2, oy - dimH - 4, topW, dimH);
+    ctx.strokeRect(ox + roomW / 2 - topW / 2, oy - dimH - 4, topW, dimH);
+    ctx.fillStyle = "#333";
+    ctx.fillText(dimTopText, ox + roomW / 2, oy - dimH / 2 - 4);
+    ctx.save();
+    ctx.translate(ox - dimH / 2 - 4, oy + roomH / 2);
+    ctx.rotate(-Math.PI / 2);
+    var leftW = ctx.measureText(dimLeftText).width + dimPad * 2;
+    ctx.fillStyle = "#fff";
+    ctx.fillRect(-leftW / 2, -dimH / 2, leftW, dimH);
+    ctx.strokeRect(-leftW / 2, -dimH / 2, leftW, dimH);
+    ctx.fillStyle = "#333";
+    ctx.fillText(dimLeftText, 0, 0);
+    ctx.restore();
+    var images = [];
+    var pending = layout.length;
+    function tryDrawAll() {
+      if (pending > 0) return;
+      ctx.fillStyle = "#fff";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.strokeStyle = "#999";
+      ctx.lineWidth = 2;
+      ctx.strokeRect(ox, oy, roomW, roomH);
+      ctx.strokeStyle = "rgba(0,0,0,0.10)";
+      ctx.lineWidth = 1;
+      for (var gx = ox; gx < ox + roomW + 0.5; gx += gridSize) { ctx.beginPath(); ctx.moveTo(gx, oy); ctx.lineTo(gx, oy + roomH); ctx.stroke(); }
+      for (var gy = oy; gy < oy + roomH + 0.5; gy += gridSize) { ctx.beginPath(); ctx.moveTo(ox, gy); ctx.lineTo(ox + roomW, gy); ctx.stroke(); }
+      ctx.font = "600 12px Helvetica, Arial, sans-serif";
+      ctx.fillStyle = "#333";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillStyle = "#fff";
+      ctx.strokeStyle = "#ccc";
+      ctx.fillRect(ox + roomW / 2 - topW / 2, oy - dimH - 4, topW, dimH);
+      ctx.strokeRect(ox + roomW / 2 - topW / 2, oy - dimH - 4, topW, dimH);
+      ctx.fillStyle = "#333";
+      ctx.fillText(dimTopText, ox + roomW / 2, oy - dimH / 2 - 4);
+      ctx.save();
+      ctx.translate(ox - dimH / 2 - 4, oy + roomH / 2);
+      ctx.rotate(-Math.PI / 2);
+      ctx.fillStyle = "#fff";
+      ctx.fillRect(-leftW / 2, -dimH / 2, leftW, dimH);
+      ctx.strokeRect(-leftW / 2, -dimH / 2, leftW, dimH);
+      ctx.fillStyle = "#333";
+      ctx.fillText(dimLeftText, 0, 0);
+      ctx.restore();
+      for (var i = 0; i < layout.length; i++) {
+        var item = layout[i];
+        var img = images[i];
+        var x = (item.x != null ? item.x : 40) * scale + ox;
+        var y = (item.y != null ? item.y : 40) * scale + oy;
+        var w = (item.w != null ? item.w : 160) * scale;
+        var h = (item.h != null ? item.h : 96) * scale;
+        var rot = (item.rot != null ? item.rot : 0) * Math.PI / 180;
+        if (img && img.width) {
+          ctx.save();
+          ctx.translate(x + w / 2, y + h / 2);
+          ctx.rotate(rot);
+          ctx.translate(-w / 2, -h / 2);
+          ctx.drawImage(img, 0, 0, w, h);
+          ctx.restore();
+        } else {
+          ctx.fillStyle = "#f0f0f0";
+          ctx.strokeStyle = "#999";
+          ctx.fillRect(x, y, w, h);
+          ctx.strokeRect(x, y, w, h);
+        }
+        ctx.fillStyle = "rgba(100,100,100,0.85)";
+        ctx.font = "10px Helvetica, Arial, sans-serif";
+        ctx.textAlign = "center";
+        ctx.textBaseline = "bottom";
+        ctx.fillText(item.id || "", x + w / 2, y + h - 2);
+      }
+      if (doneCallback) doneCallback();
+    }
+    if (layout.length === 0) { if (doneCallback) doneCallback(); return; }
+    layout.forEach(function(item, idx){
+      var img = new Image();
+      images[idx] = img;
+      var src = (item.img && item.img.indexOf("/") !== -1) ? item.img : (MC_PIECE_IMG_BASE + (item.id || "1L") + ".png");
+      img.onload = function(){ pending--; tryDrawAll(); };
+      img.onerror = function(){ pending--; tryDrawAll(); };
+      img.src = src;
+    });
+  }
+  function showConfigModal(data){
+    try {
+      if (!data || !data.r) data = { r: { widthTotalIn: 192, depthTotalIn: 144 }, l: (data && data.l) ? data.l : [] };
+    } catch (e) {}
+    var overlay = document.createElement("div");
+    overlay.className = "mc-cart-config-overlay";
+    overlay.style.cssText = "position:fixed;inset:0;background:rgba(0,0,0,.5);z-index:99999;display:flex;align-items:center;justify-content:center;padding:20px;box-sizing:border-box;";
+    var dialog = document.createElement("div");
+    dialog.className = "mc-cart-config-dialog";
+    dialog.style.cssText = "background:#fff;border-radius:12px;padding:20px;max-width:95vw;max-height:90vh;overflow:auto;box-shadow:0 10px 40px rgba(0,0,0,.3);";
+    var title = document.createElement("div");
+    title.style.cssText = "font-size:16px;font-weight:600;margin-bottom:12px;";
+    title.textContent = "Room configuration";
+    var canvas = document.createElement("canvas");
+    canvas.width = 640;
+    canvas.height = 440;
+    canvas.style.cssText = "display:block;max-width:100%;height:auto;border:2px solid #999;background:#fff;";
+    var closeBtn = document.createElement("button");
+    closeBtn.type = "button";
+    closeBtn.textContent = "Close";
+    closeBtn.style.cssText = "margin-top:14px;padding:8px 16px;cursor:pointer;border:1px solid #333;background:#fff;border-radius:0;";
+    closeBtn.onclick = function(){ overlay.remove(); };
+    overlay.onclick = function(e){ if (e.target === overlay) overlay.remove(); };
+    dialog.appendChild(title);
+    dialog.appendChild(canvas);
+    dialog.appendChild(closeBtn);
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+    drawConfigModalWithImages(canvas, data);
+  }
+  window.__mcCartShowConfig = function(idx) {
+    idx = parseInt(idx, 10);
+    if (isNaN(idx)) idx = 0;
+    var list = window.__mcCartConfigList || [];
+    if (list[idx]) return showConfigModal(list[idx]);
+    if (list.length) return showConfigModal(list[0]);
+  };
+  function runCartEnhancements(){
+    if (!isCartPage()) return;
+    var content = document.getElementById("content_area") || document.body;
+    if (!content || !content.querySelectorAll) return;
+    var configDataList = [];
+    var mcTotal4LDiscount = 0;
+    var mcCartDelta = 0;
+    var mcCartTarget =
+      mcReadCartTarget() || mcReadSessionPlannerCartTarget("", true) || mcReadPlannerCookieTarget();
+    var mcSuppressCart4L = true;
+    var mcIsMember = mcCartLooksLoggedIn();
+    var mcPending4LDiscount = 0;
+    var mcPending4LPayload = null;
+    var mcFallbackRow = null;
+    function mcFmtMoney(v){ return "$" + Number(v || 0).toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ","); }
+    function mcPatchLastMoneyCell(tr, delta){
+      if (!(delta != 0) || !tr) return false;
+      var cells = tr.querySelectorAll("td, th");
+      for (var j = cells.length - 1; j >= 0; j--) {
+        var tx = (cells[j].textContent || "").trim();
+        var ms = tx.match(/\$[\d,]+(?:\.\d+)?/);
+        if (!ms) continue;
+        var nsum = mcParseSeatMoney(ms[0]);
+        if (!(nsum > 0)) continue;
+        cells[j].textContent = tx.replace(/\$[\d,]+(?:\.\d+)?/, mcFmtMoney(Math.max(0, nsum + delta)));
+        return true;
+      }
+      return false;
+    }
+    function mcApplyCartSummaryDelta(delta){
+      if (!(delta != 0)) return;
+      var trs = content.querySelectorAll("tr");
+      var i, rt, patchedGrand = false, patchedSub = false;
+      function mcRowLooksLikeLineItem(tr){ return !!(tr && tr.querySelector && tr.querySelector("img")); }
+      for (i = 0; i < trs.length; i++) {
+        if (mcRowLooksLikeLineItem(trs[i])) continue;
+        rt = (trs[i].textContent || "").replace(/\s+/g, " ").trim().toLowerCase();
+        if (/\bgrand total\b/.test(rt) || /\border total\b/.test(rt)) {
+          if (mcPatchLastMoneyCell(trs[i], delta)) { patchedGrand = true; break; }
+        }
+      }
+      for (i = 0; i < trs.length; i++) {
+        if (mcRowLooksLikeLineItem(trs[i])) continue;
+        rt = (trs[i].textContent || "").replace(/\s+/g, " ").trim().toLowerCase();
+        if (!/\bsubtotal\b/.test(rt) && !/\bmerchandise total\b/.test(rt)) continue;
+        if (/\bgrand total\b/.test(rt) || /\border total\b/.test(rt)) continue;
+        if (mcPatchLastMoneyCell(trs[i], delta)) {
+          patchedSub = true;
+          break;
+        }
+      }
+      if (!patchedGrand && !patchedSub) {
+        for (i = 0; i < trs.length; i++) {
+          if (mcRowLooksLikeLineItem(trs[i])) continue;
+          rt = (trs[i].textContent || "").replace(/\s+/g, " ").trim().toLowerCase();
+          if (/\b(estimat|expected)\s+total\b/.test(rt)) continue;
+          if (/\bamount\s+due\b/.test(rt) || /^\s*total\s*:/.test(rt)) {
+            if (mcPatchLastMoneyCell(trs[i], delta)) return;
+          }
+        }
+      }
+    }
+    function mcMergeArmlessLoveHtsSatelliteLine(tbl) {
+      try {
+        var armRaw = String(window.MC_ARMLESS_LOVE_HTS_PRODUCT_CODE || "armless-love-hts").trim();
+        var armCode = armRaw.toLowerCase().replace(/\s+/g, "");
+        if (!tbl || !armCode) return;
+        var low = (tbl.innerHTML || "").toLowerCase();
+        if (low.indexOf(armRaw.toLowerCase()) === -1 && low.indexOf(armCode) === -1) return;
+
+        var rows0 = tbl.querySelectorAll("tbody tr, tr");
+        var armTr = null;
+        var mainTr = null;
+        var wantPc = String((mcCartTarget || {}).pc || "")
+          .toLowerCase()
+          .replace(/\s+/g, "");
+
+        for (var mi = 0; mi < rows0.length; mi++) {
+          var trm = rows0[mi];
+          if (trm.querySelector("th")) continue;
+          if (trm.querySelectorAll("td").length < 4) continue;
+          if (!trm.querySelector("img")) continue;
+          var rlm = trm.querySelector('a[href*="Remove"], a[href*="remove"], a[href*="Delete"], a[href*="delete"]');
+          var hrefm = rlm ? (rlm.getAttribute("href") || rlm.href || "").trim() : "";
+          var pcm = String(mcGuessProductCodeFromRow(trm, hrefm) || "")
+            .toLowerCase()
+            .replace(/\s+/g, "");
+          if (pcm && pcm === armCode) armTr = trm;
+          else if (wantPc && pcm === wantPc) mainTr = trm;
+        }
+        if (!armTr) return;
+        if (!mainTr) {
+          for (var mj = 0; mj < rows0.length; mj++) {
+            var trj = rows0[mj];
+            if (trj === armTr) continue;
+            if (trj.querySelector("th")) continue;
+            if (trj.querySelectorAll("td").length < 4) continue;
+            if (!trj.querySelector("img")) continue;
+            var rlj = trj.querySelector('a[href*="Remove"], a[href*="remove"]');
+            var hrefj = rlj ? (rlj.getAttribute("href") || rlj.href || "").trim() : "";
+            var pcj = String(mcGuessProductCodeFromRow(trj, hrefj) || "")
+              .toLowerCase()
+              .replace(/\s+/g, "");
+            if (pcj && pcj !== armCode) {
+              mainTr = trj;
+              break;
+            }
+          }
+        }
+        if (!mainTr || mainTr === armTr) return;
+
+        function rowLargestMoney(tr) {
+          var cells = tr.querySelectorAll("td");
+          var best = 0;
+          var bestCell = null;
+          for (var c = 0; c < cells.length; c++) {
+            var tx = (cells[c].textContent || "").trim();
+            var m = tx.match(/\$[\d,]+(?:\.\d{2})?/);
+            if (!m) continue;
+            var n = parseFloat(m[0].replace(/[$,]/g, ""));
+            if (n > best) {
+              best = n;
+              bestCell = cells[c];
+            }
+          }
+          return { n: best, cell: bestCell };
+        }
+
+        var armD = rowLargestMoney(armTr);
+        var mainD = rowLargestMoney(mainTr);
+        if (!(armD.n > 0) || !mainD.cell) return;
+
+        var sum = mainD.n + armD.n;
+        var txMain = (mainD.cell.textContent || "").trim();
+        mainD.cell.textContent = txMain.replace(/\$[\d,]+(?:\.\d{2})?/, mcFmtMoney(sum));
+
+        var pn = mainTr.querySelector(".product-name a, td a[href*='ProductDetails' i]");
+        if (pn && (pn.textContent || "").toLowerCase().indexOf("loveseat") === -1) {
+          var par = pn.parentNode;
+          if (par && !par.querySelector(".mc-cart-merged-armless-note")) {
+            var note = document.createElement("div");
+            note.className = "mc-cart-merged-armless-note";
+            note.style.cssText = "font-size:12px;font-weight:400;color:#555;margin-top:4px;";
+            note.textContent = "Includes armless loveseat (room planner 4L).";
+            par.appendChild(note);
+          }
+        }
+
+        armTr.style.display = "none";
+        armTr.setAttribute("aria-hidden", "true");
+        armTr.classList.add("mc-cart-merged-armless-love");
+      } catch (eMrg) {}
+    }
+    function mcFinalEnforcePlannerLinePrice(root, total, cartTable){
+      if (!(total > 0) || !root || !root.querySelectorAll) return;
+      var wantPc = String((mcCartTarget || {}).pc || "").trim().toLowerCase();
+      var tblf = cartTable;
+      if (!tblf || !tblf.querySelector) {
+        var fall = root.querySelectorAll("table");
+        for (var fi = 0; fi < fall.length; fi++) {
+          var ft = fall[fi];
+          if ((ft.textContent || "").toLowerCase().indexOf("related products") !== -1) continue;
+          if (!ft.querySelector("img")) continue;
+          tblf = ft;
+          break;
+        }
+      }
+      if (!tblf || !tblf.querySelector) return;
+      var rowsf = tblf.querySelectorAll("tbody tr, tr");
+      var need = [];
+      for (var rf = 0; rf < rowsf.length; rf++) {
+        var trf = rowsf[rf];
+        if (trf.querySelector("th")) continue;
+        if (trf.querySelectorAll("td").length < 4) continue;
+        if (!trf.querySelector("img")) continue;
+        var rtf = (trf.textContent || "").toLowerCase();
+        if (rtf.indexOf("tax:") !== -1 || /total:\s*\$/.test(rtf)) continue;
+        need.push(trf);
+      }
+      if (need.length === 1) {
+        mcApplyCartTargetPrice(need[0], total);
+      } else {
+        for (var nf = 0; nf < need.length; nf++) {
+          var trn = need[nf];
+          if (trn.dataset && trn.dataset.mcPlannerCartTarget === "1") {
+            mcApplyCartTargetPrice(trn, total);
+          } else if (wantPc) {
+            var rln = trn.querySelector('a[href*="Remove"], a[href*="remove"], a[href*="Delete"], a[href*="delete"]');
+            var rhn = rln ? ((rln.href || rln.getAttribute("href") || "").trim()) : "";
+            var pcn = String(mcGuessProductCodeFromRow(trn, rhn) || "").toLowerCase();
+            if (pcn && pcn === wantPc) mcApplyCartTargetPrice(trn, total);
+          }
+        }
+      }
+    }
+    function mcAlignSubtotalForSingleLinePlanner(root, total, cartTable){
+      if (!(total > 0) || !root || !root.querySelectorAll) return;
+      var tb = cartTable;
+      if (!tb || !tb.querySelector) {
+        var fall2 = root.querySelectorAll("table");
+        for (var gi = 0; gi < fall2.length; gi++) {
+          var g = fall2[gi];
+          if ((g.textContent || "").toLowerCase().indexOf("related products") !== -1) continue;
+          if (!g.querySelector("img")) continue;
+          tb = g;
+          break;
+        }
+      }
+      if (!tb || !tb.querySelector) return;
+      var rows = tb.querySelectorAll("tbody tr, tr");
+      var imgRows = 0;
+      for (var r = 0; r < rows.length; r++) {
+        if (rows[r].querySelector("th")) continue;
+        if (rows[r].querySelectorAll("td").length < 4) continue;
+        if (rows[r].querySelector("img")) imgRows++;
+      }
+      if (imgRows !== 1) return;
+      var trsAll = root.querySelectorAll("tr");
+      for (var si = 0; si < trsAll.length; si++) {
+        var trs = trsAll[si];
+        if (trs.querySelector("img")) continue;
+        var st = (trs.textContent || "").toLowerCase();
+        if (!/\bsubtotal\b/.test(st) && !/\bmerchandise total\b/.test(st)) continue;
+        if (/\bgrand total\b/.test(st) || /\border total\b/.test(st)) continue;
+        var tdc = trs.querySelectorAll("td, th");
+        for (var jk = tdc.length - 1; jk >= 0; jk--) {
+          var tx2 = (tdc[jk].textContent || "").trim();
+          if (!/\$[\d,]+/.test(tx2)) continue;
+          tdc[jk].textContent = tx2.replace(/\$[\d,]+(?:\.\d+)?/, mcFmtMoney(total));
+          return;
+        }
+      }
+    }
+    function mcGuessQtyFromRow(tr){
+      var qEl = tr.querySelector('input[name*="qty" i], input[name*="quantity" i], select[name*="qty" i], select[name*="quantity" i]');
+      if (qEl) {
+        var qv = parseFloat((qEl.value || qEl.getAttribute("value") || "").replace(/[^0-9.]/g, ""));
+        if (qv > 0) return qv;
+      }
+      return 1;
+    }
+    function mcCount4LInRow(tr){
+      var txt = ((tr && tr.textContent) || "").toLowerCase();
+      var matches = txt.match(/\b4l\b/g);
+      var count = matches ? matches.length : 0;
+      if (!count && /armless\s+loveseat/.test(txt)) count = 1;
+      return count;
+    }
+    function mcApplyRow4LDiscount(tr, fallbackDiscount){
+      /* Planner configuration total already includes 4L bundle math — do not subtract again on this line. */
+      if (tr && tr.dataset && tr.dataset.mcPlannerCartTarget === "1") return;
+      var txt = tr.innerHTML || "";
+      var m = txt.match(/\[MC_4L_DISCOUNT\](\d+(?:\.\d+)?)\[\/MC_4L_DISCOUNT\]/i);
+      var discount = 0;
+      if (m) {
+        discount = parseFloat(m[1]);
+      } else {
+        var cnt = mcCount4LInRow(tr);
+        var qty = mcGuessQtyFromRow(tr);
+        discount = 0;
+      }
+      if (!(discount > 0) && fallbackDiscount > 0) discount = fallbackDiscount;
+      if (!(discount > 0)) return;
+      var cells = tr.querySelectorAll("td");
+      var bestCell = null, bestVal = 0;
+      for (var i = 0; i < cells.length; i++) {
+        var ct = (cells[i].textContent || "").trim();
+        var mm = ct.match(/\$[\d,]+(?:\.\d+)?/);
+        if (!mm) continue;
+        var n = parseFloat(mm[0].replace(/[$,]/g, ""));
+        if (n > bestVal) { bestVal = n; bestCell = cells[i]; }
+      }
+      if (!bestCell || !(bestVal > 0)) return;
+      if (!bestCell.dataset.mcOrigPrice) bestCell.dataset.mcOrigPrice = String(bestVal);
+      var base = parseFloat(bestCell.dataset.mcOrigPrice || "0");
+      if (!(base > 0)) base = bestVal;
+      var applied = Math.min(discount, base);
+      var newVal = Math.max(0, base - applied);
+      bestCell.textContent = mcFmtMoney(newVal);
+      tr.dataset.mc4lApplied = String(applied);
+      mcTotal4LDiscount += applied;
+      return applied;
+    }
+    function mcReadPending4L(){
+      try {
+        var raw = localStorage.getItem("mc_4l_discount_pending");
+        if (!raw) return null;
+        var obj = JSON.parse(raw);
+        if (!obj || !(obj.amount > 0)) return null;
+        if (obj.ts && (Date.now() - Number(obj.ts)) > 1000 * 60 * 60 * 6) {
+          localStorage.removeItem("mc_4l_discount_pending");
+          return null;
+        }
+        return obj;
+      } catch (_) {
+        return null;
+      }
+    }
+    function mcClearPending4L(){
+      try { localStorage.removeItem("mc_4l_discount_pending"); } catch (_) {}
+    }
+    if (!mcSuppressCart4L) {
+      mcPending4LPayload = mcReadPending4L();
+      mcPending4LDiscount = mcPending4LPayload && mcPending4LPayload.amount ? Number(mcPending4LPayload.amount) : 0;
+    }
+    function processElement(el) {
+      if (el.id === "content_area" || el.classList.contains("mc-config-view-done")) return;
+      var html = el.innerHTML || "";
+      if (html.indexOf("[MC_LAYOUT]") === -1) return;
+      var descendants = el.querySelectorAll("*");
+      for (var d = 0; d < descendants.length; d++) {
+        if ((descendants[d].innerHTML || "").indexOf("[MC_LAYOUT]") !== -1) return;
+      }
+      var match = html.match(/\[MC_LAYOUT\]([\s\S]*?)\[\/MC_LAYOUT\]/);
+      if (!match) return;
+      var data = null;
+      try { data = JSON.parse(match[1]); } catch (e) { return; }
+      if (!data) return;
+      el.classList.add("mc-config-view-done");
+      var idx = configDataList.length;
+      configDataList.push(data);
+      var newHtml = html.replace(/\s*\[MC_LAYOUT\][\s\S]*?\[\/MC_LAYOUT\]\s*/g, " <span data-mc-config-idx=\"" + idx + "\"></span>");
+      el.innerHTML = newHtml;
+      el.querySelectorAll("[data-mc-config-idx]").forEach(function(sp) {
+        var iid = parseInt(sp.getAttribute("data-mc-config-idx"), 10);
+        var d = configDataList[iid];
+        if (!d) return;
+        var link = document.createElement("a");
+        link.href = "#";
+        link.setAttribute("data-mc-config-idx", String(iid));
+        link.className = "mc-view-config-link";
+        link.setAttribute("onclick", "window.__mcCartShowConfig(this.getAttribute('data-mc-config-idx')); return false;");
+        link.textContent = "View configuration";
+        link.style.cssText = "margin-left:6px;font-size:12px;text-decoration:underline;cursor:pointer;";
+        link.addEventListener("click", function(ev) {
+          ev.preventDefault();
+          ev.stopPropagation();
+          var idx = parseInt(this.getAttribute("data-mc-config-idx"), 10);
+          if (isNaN(idx)) idx = 0;
+          var list = window.__mcCartConfigList;
+          if (list && list[idx]) showConfigModal(list[idx]);
+          else if (list && list[0]) showConfigModal(list[0]);
+        }, false);
+        sp.parentNode.replaceChild(link, sp);
+      });
+    }
+    var tagList = "td, div, span, li, p, label, font, a";
+    var candidates = content.querySelectorAll(tagList);
+    for (var i = 0; i < candidates.length; i++) processElement(candidates[i]);
+    if ((content.textContent || "").indexOf("[MC_LAYOUT]") !== -1) {
+      var walker = document.createTreeWalker(content, NodeFilter.SHOW_ELEMENT, null, false);
+      var node;
+      while ((node = walker.nextNode())) {
+        if (node.id === "content_area") continue;
+        if (node.classList && node.classList.contains("mc-config-view-done")) continue;
+        if ((node.innerHTML || "").indexOf("[MC_LAYOUT]") === -1) continue;
+        var kids = node.querySelectorAll("*");
+        var childHas = false;
+        for (var k = 0; k < kids.length; k++) {
+          if ((kids[k].innerHTML || "").indexOf("[MC_LAYOUT]") !== -1) { childHas = true; break; }
+        }
+        if (!childHas) processElement(node);
+      }
+    }
+    if (configDataList.length) window.__mcCartConfigList = configDataList;
+    content.querySelectorAll("td.mc-cart-remove-x").forEach(function(td){ td.remove(); });
+    content.querySelectorAll("tr.mc-remove-x-done").forEach(function(tr){ tr.classList.remove("mc-remove-x-done"); });
+    var tables = content.querySelectorAll("table");
+    var mcSelectedCartTable = null;
+    var bestTblScore = 0;
+    for (var tbI = 0; tbI < tables.length; tbI++) {
+      var tbc = tables[tbI];
+      var tbcText = (tbc.textContent || "").toLowerCase();
+      if (tbcText.indexOf("related products") !== -1) continue;
+      if (!tbc.querySelector("img")) continue;
+      var rowsScore = tbc.querySelectorAll("tbody tr, tr");
+      var score = 0;
+      for (var rc = 0; rc < rowsScore.length; rc++) {
+        var rw = rowsScore[rc];
+        if (rw.querySelector("th")) continue;
+        if (rw.querySelectorAll("td").length < 4) continue;
+        if (rw.querySelector("img")) score++;
+      }
+      if (score > bestTblScore) {
+        bestTblScore = score;
+        mcSelectedCartTable = tbc;
+      }
+    }
+    if (mcSelectedCartTable && bestTblScore > 0) {
+      var tbl = mcSelectedCartTable;
+      var tblText = (tbl.textContent || "").toLowerCase();
+      var rows = tbl.querySelectorAll("tbody tr, tr");
+      var lineItemRows = 0;
+      for (var r = 0; r < rows.length; r++) {
+        var row = rows[r];
+        if (row.querySelector("th")) continue;
+        if (row.querySelectorAll("td").length < 4) continue;
+        if (row.querySelector("img")) lineItemRows++;
+      }
+      if (lineItemRows === 0) {
+        /* keep mcSelectedCartTable */
+      } else {
+      var rowIndex = 0;
+      for (var ri = 0; ri < rows.length; ri++) {
+        var tr = rows[ri];
+        rowIndex++;
+        if (tr.classList.contains("mc-remove-x-done")) continue;
+        if (tr.querySelector("th")) continue;
+        var cells = tr.querySelectorAll("td");
+        if (cells.length < 4) continue;
+        var rowText = (tr.textContent || "").toLowerCase();
+        if (rowIndex === 1 && (rowText.indexOf("item") !== -1 || rowText.indexOf("description") !== -1 || (rowText.indexOf("each") !== -1 && rowText.indexOf("qty") !== -1))) continue;
+        if (rowText.indexOf("calculate shipping") !== -1 || rowText.indexOf("zip") !== -1 || rowText.indexOf("postal") !== -1 || rowText.indexOf("select stat") !== -1 || rowText.indexOf("residential") !== -1 || rowText.indexOf("business") !== -1) break;
+        if (rowText.indexOf("tax:") !== -1 || /total:\s*\$/.test(rowText)) break;
+        if (!tr.querySelector("img")) continue;
+        var removeLink = tr.querySelector('a[href*="Remove"], a[href*="remove"], a[href*="Delete"], a[href*="delete"]') || (function(){
+          var links = tr.querySelectorAll("a[href]");
+          for (var L = 0; L < links.length; L++) {
+            var lt = (links[L].textContent || "").toLowerCase();
+            var lh = (links[L].getAttribute("href") || "").toLowerCase();
+            if (lt.indexOf("remove") !== -1 || lt.indexOf("delete") !== -1 || lh.indexOf("remove") !== -1 || lh.indexOf("delete") !== -1) return links[L];
+          }
+          return null;
+        })();
+        var removeHref = removeLink ? ((removeLink.href || removeLink.getAttribute("href") || "").trim()) : "";
+        var pcRowGuess = "";
+        var nmRowGuess = "";
+        var rowCached4LDiscount = 0;
+        try {
+          pcRowGuess = mcGuessProductCodeFromRow(tr, removeHref);
+          nmRowGuess = mcGuessProductNameFromRow(tr);
+          rowCached4LDiscount = mcGetCached4LDiscount(pcRowGuess, nmRowGuess);
+        } catch (eGuess) {}
+        var applied4L = 0;
+        if (!mcSuppressCart4L) {
+          applied4L = mcApplyRow4LDiscount(tr, rowCached4LDiscount);
+          if (applied4L > 0 && rowCached4LDiscount > 0) {
+            mcClearCached4LDiscount(pcRowGuess, nmRowGuess);
+          }
+        }
+        var removeInput = tr.querySelector('input[value*="Remove"], input[value*="Delete"], input[type="image"][alt*="emove"], input[type="submit"][value*="emove"]');
+        if (!removeLink && !removeInput) continue;
+        var lastTd = cells[cells.length - 1];
+        if (!lastTd) continue;
+        var totalCell = lastTd;
+        for (var c = 0; c < cells.length; c++) {
+          var ct = (cells[c].textContent || "").trim();
+          if (/^\$[\d.,]+$/.test(ct) || (/\d+\.?\d*/.test(ct) && ct.length < 15)) totalCell = cells[c];
+        }
+        var rowVal = 0;
+        var mmRow = ((totalCell && totalCell.textContent) || "").match(/\$[\d,]+(?:\.\d+)?/);
+        if (mmRow) rowVal = parseFloat(mmRow[0].replace(/[$,]/g, "")) || 0;
+        if (!mcFallbackRow || rowVal > mcFallbackRow.val) {
+          mcFallbackRow = { tr: tr, totalCell: totalCell, val: rowVal };
+        }
+        tr.classList.add("mc-remove-x-done");
+        var xWrap = document.createElement("td");
+        xWrap.className = "mc-cart-remove-x";
+        xWrap.style.cssText = "vertical-align:middle;padding-left:8px;white-space:nowrap;";
+        if (removeHref && removeHref !== "#" && removeHref.indexOf("javascript:") !== 0) {
+          var xLink = document.createElement("a");
+          xLink.href = removeHref;
+          xLink.setAttribute("aria-label", "Remove");
+          xLink.textContent = "\u00D7";
+          xLink.style.cssText = "display:inline-block;width:28px;height:28px;padding:0;border:1px solid #999;background:#fff;cursor:pointer;font-size:20px;line-height:26px;border-radius:4px;color:#333;text-align:center;text-decoration:none;";
+          xWrap.appendChild(xLink);
+        } else {
+          var xBtn = document.createElement("button");
+          xBtn.type = "button";
+          xBtn.setAttribute("aria-label", "Remove");
+          xBtn.textContent = "\u00D7";
+          xBtn.style.cssText = "width:28px;height:28px;padding:0;border:1px solid #999;background:#fff;cursor:pointer;font-size:20px;line-height:1;border-radius:4px;color:#333;";
+          xBtn.onclick = (function(rl, ri, row){
+            return function(e){
+              e.preventDefault();
+              e.stopPropagation();
+              if (rl) {
+                try { rl.click(); return; } catch (err) {}
+              }
+              if (ri) {
+                try { ri.click(); return; } catch (err2) {}
+              }
+              var form = mcClosest(row, "form");
+              if (form) {
+                var inp = row.querySelector('input[name*="Remove"], input[value*="Remove"], input[name*="Delete"], input[value*="Delete"]');
+                if (inp) inp.click();
+              }
+            };
+          })(removeLink, removeInput, tr);
+          xWrap.appendChild(xBtn);
+        }
+        // Cache per-seat member price from cart row for PDP caption fallback.
+        try {
+          var seatRow = mcExtractRowSeatPrice(tr);
+          var pcRow = mcGuessProductCodeFromRow(tr, removeHref);
+          var nmRow = mcGuessProductNameFromRow(tr);
+          if (seatRow > 0) mcCacheSeatPrice(pcRow, nmRow, seatRow);
+        } catch (cacheErr) {}
+        totalCell.parentNode.insertBefore(xWrap, totalCell.nextSibling);
+      }
+      if (!mcSuppressCart4L && mcTotal4LDiscount <= 0 && mcPending4LDiscount > 0 && mcFallbackRow && mcFallbackRow.totalCell) {
+        var frTr = mcFallbackRow.tr;
+        if (!(frTr && frTr.dataset && frTr.dataset.mcPlannerCartTarget === "1")) {
+          var tc = mcFallbackRow.totalCell;
+          var baseTxt = (tc.textContent || "").match(/\$[\d,]+(?:\.\d+)?/);
+          var base = baseTxt ? parseFloat(baseTxt[0].replace(/[$,]/g, "")) : 0;
+          if (!(base > 0) && mcFallbackRow.val > 0) base = mcFallbackRow.val;
+          if (base > 0) {
+            var appliedPending = Math.min(base, mcPending4LDiscount);
+            tc.textContent = (tc.textContent || "").replace(/\$[\d,]+(?:\.\d+)?/, mcFmtMoney(base - appliedPending));
+            mcTotal4LDiscount += appliedPending;
+            mcClearPending4L();
+          }
+        }
+      }
+      }
+    }
+    if (!mcSuppressCart4L && mcTotal4LDiscount > 0) {
+      var moneyNodes = content.querySelectorAll("td, span, strong, b, font");
+      for (var mn = 0; mn < moneyNodes.length; mn++) {
+        var tx = (moneyNodes[mn].textContent || "").trim();
+        if (!/\$[\d,]/.test(tx)) continue;
+        var line = (moneyNodes[mn].parentElement && moneyNodes[mn].parentElement.textContent || "").toLowerCase();
+        if (!/total|subtotal|grand total|order total/.test(line)) continue;
+        var mm2 = tx.match(/\$[\d,]+(?:\.\d+)?/);
+        if (!mm2) continue;
+        if (!moneyNodes[mn].dataset.mcOrigMoney) moneyNodes[mn].dataset.mcOrigMoney = mm2[0];
+        var n2 = parseFloat((moneyNodes[mn].dataset.mcOrigMoney || mm2[0]).replace(/[$,]/g, ""));
+        if (!(n2 > 0)) continue;
+        var adj = Math.max(0, n2 - mcTotal4LDiscount);
+        moneyNodes[mn].textContent = tx.replace(/\$[\d,]+(?:\.\d+)?/, mcFmtMoney(adj));
+      }
+    }
+    if (!mcSuppressCart4L && mcCartDelta !== 0) {
+      mcApplyCartSummaryDelta(mcCartDelta);
+    }
+    // Hard fallback: if no row-level application happened, apply pending discount to summary totals.
+    if (!mcSuppressCart4L && mcTotal4LDiscount <= 0 && mcPending4LDiscount > 0) {
+      var appliedAny = false;
+      var summaryNodes = content.querySelectorAll("td, span, div, strong, b, font");
+      for (var sn = 0; sn < summaryNodes.length; sn++) {
+        var node = summaryNodes[sn];
+        var lineTxt = ((node.parentElement && node.parentElement.textContent) || node.textContent || "").toLowerCase();
+        if (!/subtotal|total|order total|grand total/.test(lineTxt)) continue;
+        var curr = (node.textContent || "").match(/\$[\d,]+(?:\.\d+)?/);
+        if (!curr) continue;
+        var baseVal = parseFloat(curr[0].replace(/[$,]/g, ""));
+        if (!(baseVal > 0)) continue;
+        var newVal = Math.max(0, baseVal - mcPending4LDiscount);
+        node.textContent = (node.textContent || "").replace(/\$[\d,]+(?:\.\d+)?/, mcFmtMoney(newVal));
+        appliedAny = true;
+      }
+      if (appliedAny) {
+        mcTotal4LDiscount = mcPending4LDiscount;
+        mcClearPending4L();
+      }
+    }
+    // Show an explicit discount line so users can verify it.
+    if (!mcSuppressCart4L && mcTotal4LDiscount > 0 && !content.querySelector(".mc-4l-discount-note")) {
+      var note = document.createElement("div");
+      note.className = "mc-4l-discount-note";
+      note.style.cssText = "margin:10px 0;padding:8px 10px;border:1px solid #ddd;background:#fafafa;font-size:13px;";
+      note.innerHTML = "<strong>4L Discount Applied:</strong> -" + mcFmtMoney(mcTotal4LDiscount).replace("$", "$");
+      var anchor = content.querySelector("table") || content.firstElementChild || content;
+      if (anchor && anchor.parentNode) anchor.parentNode.insertBefore(note, anchor);
+      else content.appendChild(note);
+    }
+    /* Split cart: show native Volusion line totals per SKU; do not merge armless row or enforce planner configuration total on a line. */
+  }
+  function runWhenCartReady() {
+    if (!isCartPage()) return;
+    runCartEnhancements();
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", runWhenCartReady);
+  } else {
+    runWhenCartReady();
+  }
+  window.addEventListener("load", runWhenCartReady);
+  setTimeout(runWhenCartReady, 500);
+  setTimeout(runWhenCartReady, 1500);
+  setTimeout(runWhenCartReady, 3000);
+  setTimeout(runWhenCartReady, 5000);
+  function mcInstallCartPriceObserver(){
+    if (!isCartPage() || typeof MutationObserver === "undefined") return;
+    var ca = document.getElementById("content_area");
+    if (!ca || ca.dataset.mcCartPriceObserver) return;
+    ca.dataset.mcCartPriceObserver = "1";
+    var deb = null;
+    var mo = new MutationObserver(function(){
+      if (!isCartPage()) return;
+      if (deb) clearTimeout(deb);
+      deb = setTimeout(function(){ runWhenCartReady(); }, 400);
+    });
+    try {
+      mo.observe(ca, { childList: true, subtree: true, characterData: true });
+    } catch (eMo) {}
+  }
+  setTimeout(mcInstallCartPriceObserver, 600);
+  setTimeout(mcInstallCartPriceObserver, 2800);
+})();
+</script>
+
+<script>
+function mcStartDetectMemberPricing() {
+  if (typeof window.detectMemberPricingState !== 'function') return;
+  try {
+    window.detectMemberPricingState();
+  } catch (e2) {}
+}
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', function () {
+    mcStartDetectMemberPricing();
+  });
+} else {
+  mcStartDetectMemberPricing();
+}
+window.addEventListener('load', function () {
+  mcStartDetectMemberPricing();
+});
+</script>
+<style id="mc-member-grid-inline-fallback">
+/* Fallback if vspfiles/css/custom-safe.css is not deployed — keeps MAP swap + modal usable */
+.mc-member-grid-price__regular{font-size:15px;color:#333;margin-bottom:6px}
+.mc-member-grid-price__amount{font-size:15px;margin-top:2px;color:#111}
+.mc-member-grid-price__label{font-size:13px;font-weight:600;letter-spacing:.02em;text-transform:none;color:#333}
+.mc-member-grid-price__hint{font-size:12px;margin-top:4px;color:#555}
+.mc-member-grid-price__hint .mc-member-grid-price__login{margin:0;font-size:inherit;display:inline;text-decoration:underline;color:#333;letter-spacing:.04em;cursor:pointer;background:none;border:0;padding:0}
+.mc-login-modal{position:fixed;inset:0;z-index:100000;display:none;align-items:center;justify-content:center;padding:16px;box-sizing:border-box}
+.mc-login-modal.mc-login-modal--open{display:flex}
+.mc-login-modal__backdrop{position:absolute;inset:0;background:rgba(0,0,0,.45);cursor:pointer}
+.mc-login-modal__panel{position:relative;z-index:1;width:min(440px,100%);max-height:min(90vh,720px);background:#fff;border-radius:8px;box-shadow:0 20px 60px rgba(0,0,0,.25);padding:20px;display:flex;flex-direction:column;overflow:hidden}
+.mc-login-modal__close{position:absolute;top:8px;right:10px;border:none;background:transparent;font-size:28px;line-height:1;cursor:pointer;color:#333}
+.mc-login-modal__title{margin:0 0 8px;font-size:18px;font-weight:600;letter-spacing:.06em;text-transform:uppercase}
+.mc-login-modal__hint{margin:0 0 12px;font-size:13px;line-height:1.45;color:#454545}
+.mc-login-modal__frame{width:100%;min-height:320px;border:1px solid #ddd;border-radius:4px;background:#fafafa}
+.mc-login-modal__tabs{display:flex;gap:8px;margin:0 0 14px 0}
+.mc-login-modal__tab{flex:1;padding:10px 12px;border:1px solid #ccc;background:#f5f5f5;font-size:13px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;cursor:pointer;border-radius:4px}
+.mc-login-modal__tab.is-active{background:#111;color:#fff;border-color:#111}
+.mc-login-modal__panel-body{display:none;flex-direction:column;flex:1;min-height:0}
+.mc-login-modal__panel-body.is-active{display:flex}
+.mc-login-modal__form{display:flex;flex-direction:column;gap:10px}
+.mc-login-modal__field label{display:block;font-size:12px;font-weight:600;margin-bottom:4px;color:#333}
+.mc-login-modal__field input{width:100%;padding:10px 12px;border:1px solid #ccc;border-radius:4px;font-size:14px;box-sizing:border-box}
+.mc-login-modal__submit{margin-top:6px;padding:12px 16px;background:#111;color:#fff;border:0;border-radius:4px;font-size:13px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;cursor:pointer}
+.mc-login-modal__switch{margin-top:12px;font-size:13px;text-align:center}
+.mc-login-modal__switch a{color:#333;text-decoration:underline;cursor:pointer}
+.mc-login-modal__signup{margin:12px 0 0;font-size:13px;text-align:center}
+.mc-login-modal__signup-note{display:block;font-size:11px;opacity:.75;margin-top:4px}
+.mc-login-modal__status{min-height:1.2em;font-size:13px;line-height:1.4;margin:0 0 10px}
+.mc-login-modal__status.is-error{color:#a11;font-weight:600}
+.mc-login-modal__status.is-success{color:#2d6a4f}
+
+/* Global member-price typography — 13px stack (match product title / options) */
+body .mc-member-grid-price__label,
+body .mc-member-price-caption__option-label,
+body .mc-member-price-caption__headline,
+body .mc-member-price-caption__sub,
+body .mc-member-price-caption__cta {
+  display:block !important;
+  font-size:13px !important;
+  font-weight:400 !important;
+  letter-spacing:0.16em !important;
+  text-transform:uppercase !important;
+  color:#777 !important;
+  line-height:1.2 !important;
+}
+body .mc-member-grid-price__amount,
+body .mc-member-price-caption__price-value,
+body .mc-pdp-sale-preview,
+body .mc-pdp-member-line__amount,
+body .mc-pdp-member-line__amount a,
+body .mc-pdp-retail-row .product_list_price,
+body .mc-pdp-retail-row .product_productprice,
+body .mc-pdp-retail-row .v65-product-price {
+  text-transform:none !important;
+  color:#444 !important;
+  letter-spacing:0.02em !important;
+  white-space:normal !important;
+}
+body .mc-pdp-sale-preview,
+body .mc-pdp-member-line__amount,
+body .mc-pdp-member-line__amount a {
+  display:block !important;
+  font-size:13px !important;
+  font-weight:400 !important;
+  line-height:1.2 !important;
+  margin-top:4px !important;
+}
+body .mc-member-grid-price__amount,
+body .mc-member-price-caption__price-value {
+  display:block !important;
+  font-size:13px !important;
+  font-weight:400 !important;
+  letter-spacing:0.16em !important;
+  line-height:1.2 !important;
+  margin-top:4px !important;
+}
+/* Do not show Volusion sale rows when member price is present. */
+body #content_area .v-product:has(.mc-member-grid-price) .product_sale_price,
+body #content_area .v-product:has(.mc-member-grid-price) font.product_sale_price,
+body #content_area .v-product:has(.mc-member-grid-price) .product_saleprice,
+body #content_area td:has(.mc-member-grid-price) .product_sale_price,
+body #content_area td:has(.mc-member-grid-price) font.product_sale_price,
+body #content_area td:has(.mc-member-grid-price) .product_saleprice {
+  display:none !important;
+}
+/* Category grid: image then title then price; constrain images (template fallback) */
+:is(html.category, body.category) .v-product-grid .v-product{display:flex;flex-direction:column;align-items:stretch;box-sizing:border-box;min-width:100%!important}
+:is(html.category, body.category) .v-product-grid .v-product .v-product__img,:is(html.category, body.category) .v-product-grid .v-product .v-product__image,:is(html.category, body.category) .v-product-grid .v-product .v-product__image-wrap,:is(html.category, body.category) .v-product-grid .v-product .product_image,:is(html.category, body.category) .v-product-grid .v-product .vcss_img,:is(html.category, body.category) .v-product-grid .v-product a.v-product__img{order:1;flex:0 0 auto;width:100%;height:280px;min-height:280px;max-height:280px;overflow:hidden;margin:0!important;padding:14px!important;display:flex!important;align-items:flex-end!important;justify-content:center!important;position:relative;background:#ffffff!important;box-sizing:border-box!important}
+:is(html.category, body.category) .v-product-grid .v-product .v-product__img a,:is(html.category, body.category) .v-product-grid .v-product .v-product__image a,:is(html.category, body.category) .v-product-grid .v-product .v-product__image-wrap a,:is(html.category, body.category) .v-product-grid .v-product .product_image a,:is(html.category, body.category) .v-product-grid .v-product .vcss_img a{display:flex!important;align-items:flex-end!important;justify-content:center!important;width:100%!important;height:100%!important;margin:0!important;padding:0!important;background:transparent!important}
+:is(html.category, body.category) .v-product-grid .v-product .v-product__img img,:is(html.category, body.category) .v-product-grid .v-product .v-product__image img,:is(html.category, body.category) .v-product-grid .v-product .v-product__image-wrap img,:is(html.category, body.category) .v-product-grid .v-product .product_image img,:is(html.category, body.category) .v-product-grid .v-product .vcss_img img,:is(html.category, body.category) .v-product-grid .v-product a.v-product__img>img{width:100%!important;height:220px!important;max-width:100%!important;max-height:220px!important;object-fit:contain!important;object-position:center bottom!important;display:block!important;margin:0 auto!important;border:0!important}
+:is(html.category, body.category) .v-product-grid .v-product .v-product__name,:is(html.category, body.category) .v-product-grid .v-product .productnamecolor,:is(html.category, body.category) .v-product-grid .v-product h2,:is(html.category, body.category) .v-product-grid .v-product h3,:is(html.category, body.category) .v-product-grid .v-product h4{order:2;flex:0 1 auto;line-height:1.25;display:flex;align-items:flex-start;justify-content:flex-start;text-align:left;min-height:0!important;box-sizing:border-box;width:100%;margin-top:4px!important}
+:is(html.category, body.category) .v-product-grid .v-product .productnamecolor a,:is(html.category, body.category) .v-product-grid .v-product .v-product__name a{width:100%;text-align:center!important}
+:is(html.category, body.category) .v-product-grid .v-product .mc-member-grid-price{order:4;min-height:0!important;box-sizing:border-box;display:flex;flex-direction:column;justify-content:flex-start;align-items:center;width:100%;text-align:center!important}
+:is(html.category, body.category) .v-product-grid .v-product .v-product__price,:is(html.category, body.category) .v-product-grid .v-product .product_price{order:5;min-height:0!important;box-sizing:border-box;display:flex;flex-direction:column;justify-content:flex-start;align-items:center;width:100%;text-align:center!important}
+:is(html.category, body.category) #content_area .mc-plp-bean-subline{order:3;width:100%;box-sizing:border-box;margin:2px 0 0;font-size:12px;letter-spacing:.06em;color:#555;text-align:center;line-height:1.35;align-self:center}
+:is(html.category, body.category) .sidebar-wrapper .sidebar,:is(html.category, body.category) .sidebar-wrapper [id^="display_menu_"]{text-align:left!important}
+:is(html.category, body.category) .sidebar-wrapper [id^="display_menu_"] ul,:is(html.category, body.category) .sidebar-wrapper [id^="display_menu_"] li{text-align:left!important}
+:is(html.category, body.category) .sidebar-wrapper [id^="display_menu_"] a,:is(html.category, body.category) .sidebar-wrapper [id^="display_menu_"] .vnav__link,:is(html.category, body.category) .sidebar-wrapper [id^="display_menu_"] .vnav__label,:is(html.category, body.category) .sidebar-wrapper .menu a{font-weight:400!important;letter-spacing:.08em!important;text-transform:uppercase!important;font-size:11px!important;color:#1a1a1a!important}
+:is(html.category, body.category) #content_area .vnav--level2,:is(html.category, body.category) #content_area .vnav--level3,:is(html.category, body.category) #content_area .vnav--level2>li,:is(html.category, body.category) #content_area .vnav--level3>li{text-align:left!important}
+:is(html.category, body.category) #content_area .vnav--level2 a,:is(html.category, body.category) #content_area .vnav--level3 a{font-weight:400!important;letter-spacing:.06em!important;text-transform:uppercase!important;font-size:11px!important}
+@media (max-width:991px){:is(html.category, body.category) .v-product-grid .v-product .v-product__img,:is(html.category, body.category) .v-product-grid .v-product .v-product__image,:is(html.category, body.category) .v-product-grid .v-product .v-product__image-wrap,:is(html.category, body.category) .v-product-grid .v-product .product_image,:is(html.category, body.category) .v-product-grid .v-product .vcss_img,:is(html.category, body.category) ul.v-product-grid>li.v-product .v-product__img,:is(html.category, body.category) .v-product-grid .v-product a.v-product__img{height:220px!important;min-height:220px!important;max-height:220px!important;overflow:hidden!important;margin:0!important;padding:12px!important;display:flex!important;align-items:flex-end!important;justify-content:center!important;background:#ffffff!important}:is(html.category, body.category) .v-product-grid .v-product .v-product__img img,:is(html.category, body.category) .v-product-grid .v-product .v-product__image img,:is(html.category, body.category) .v-product-grid .v-product .v-product__image-wrap img,:is(html.category, body.category) .v-product-grid .v-product .product_image img,:is(html.category, body.category) .v-product-grid .v-product .vcss_img img,:is(html.category, body.category) ul.v-product-grid>li.v-product .v-product__img img,:is(html.category, body.category) .v-product-grid .v-product a.v-product__img>img{width:100%!important;height:172px!important;max-width:100%!important;max-height:172px!important;object-fit:contain!important;object-position:center bottom!important;margin:0 auto!important;border:0!important}:is(html.category, body.category) .v-product-grid .v-product .v-product__name,:is(html.category, body.category) .v-product-grid .v-product .productnamecolor,:is(html.category, body.category) .v-product-grid .v-product h2,:is(html.category, body.category) .v-product-grid .v-product h3,:is(html.category, body.category) .v-product-grid .v-product h4{min-height:0!important;align-items:center!important;justify-content:center!important;text-align:center!important;margin-top:3px!important;margin-bottom:0!important;padding-top:0!important}:is(html.category, body.category) .v-product-grid .v-product{gap:0!important;row-gap:0!important}}
+
+.mc-pdp-retail-member {
+  display: block !important;
+  width: 100% !important;
+  margin: 0 0 10px 0 !important;
+  font-family: Inter, system-ui, -apple-system, sans-serif !important;
+}
+
+.mc-pdp-retail-member .mc-pdp-retail-line,
+.mc-pdp-retail-member .mc-pdp-member-line {
+  display: block !important;
+  width: 100% !important;
+  font-size: 13px !important;
+  line-height: 1.45 !important;
+  letter-spacing: 0.06em !important;
+  text-transform: none !important;
+  color: #444 !important;
+  font-weight: 400 !important;
+  margin: 0 0 3px 0 !important;
+}
+
+.mc-pdp-retail-member .mc-pdp-member-line {
+  color: #2f2f2f !important;
+  font-weight: 500 !important;
+}
+
+.mc-price-stack,
+.mc-retail-price,
+.mc-member-grid-price,
+.mc-pdp-member-pricing,
+.mc-pdp-retail-line,
+.mc-pdp-member-line {
+  display: block !important;
+  width: 100% !important;
+}
+
+.mc-member-grid-price__login,
+.mc-pdp-member-line--locked a {
+  text-decoration: underline !important;
+  color: inherit !important;
+}
+
+body.mc-theater-seating-pdp #v65-product-parent .option_pricing,
+body.mc-theater-seating-pdp #content_area .option_pricing,
+body.mc-theater-seating-pdp #v65-product-parent #priceWithOptions,
+body.mc-theater-seating-pdp #content_area #priceWithOptions,
+body.mc-theater-seating-pdp #v65-product-parent #priceWithOptionsNoTax,
+body.mc-theater-seating-pdp #content_area #priceWithOptionsNoTax,
+body.mc-theater-seating-pdp #v65-product-parent tr.mc-theater-hide-preleather,
+body.mc-theater-seating-pdp #content_area tr.mc-theater-hide-preleather {
+  display: none !important;
+  visibility: hidden !important;
+  opacity: 0 !important;
+}
+
+.mc-pdp-retail-row {
+  display: flex !important;
+  flex-direction: column !important;
+  align-items: flex-start !important;
+  gap: 2px !important;
+  width: 100% !important;
+  margin: 60px 0 8px 0 !important;
+  font-family: Inter, system-ui, -apple-system, sans-serif !important;
+  font-size: inherit !important;
+  line-height: normal !important;
+  letter-spacing: normal !important;
+  color: inherit !important;
+}
+
+.mc-pdp-retail-row .mc-pdp-retail-label {
+  display: block !important;
+  width: auto !important;
+  margin: 0 !important;
+  flex: 0 0 auto !important;
+  font-size: 13px !important;
+  font-weight: 400 !important;
+  line-height: 1.2 !important;
+  letter-spacing: 0.16em !important;
+  text-transform: uppercase !important;
+  color: #777 !important;
+}
+/* Native Volusion sale row must not stack on list price in retail block (sale → .mc-pdp-sale-preview). */
+.mc-pdp-retail-row .product_sale_price,
+.mc-pdp-retail-row .product_saleprice,
+.mc-pdp-retail-row font.product_sale_price,
+.mtl-product-price-block > .product_sale_price,
+.mtl-product-price-block > .product_saleprice,
+.mtl-product-price-block > font.product_sale_price {
+  display: none !important;
+  visibility: hidden !important;
+  height: 0 !important;
+  overflow: hidden !important;
+}
+.mc-pdp-retail-row > .product_list_price,
+.mc-pdp-retail-row > .product_productprice,
+.mc-pdp-retail-row > .v65-product-price,
+.mc-pdp-retail-row > font.product_list_price {
+  display: block !important;
+  position: static !important;
+  width: 100% !important;
+}
+.mc-pdp-member-pricing .mc-pdp-sale-preview {
+  display: block !important;
+  width: 100% !important;
+  margin: 4px 0 0 0 !important;
+  clear: both !important;
+}
+
+.mc-pdp-member-pricing {
+  display: flex !important;
+  flex-direction: column !important;
+  align-items: flex-start !important;
+  gap: 2px !important;
+  width: 100% !important;
+  margin: 0 0 10px 0 !important;
+  font-family: Inter, system-ui, -apple-system, sans-serif !important;
+  font-size: inherit !important;
+}
+
+.mc-pdp-member-pricing .mc-pdp-retail-line,
+.mc-pdp-member-pricing .mc-pdp-member-line {
+  display: flex !important;
+  flex-direction: column !important;
+  align-items: flex-start !important;
+  gap: 2px !important;
+  width: 100% !important;
+  margin: 0 0 4px 0 !important;
+  font-size: inherit !important;
+  line-height: normal !important;
+  letter-spacing: normal !important;
+  text-transform: none !important;
+  color: inherit !important;
+  font-weight: 400 !important;
+}
+
+.mc-pdp-member-pricing .mc-pdp-member-line__label,
+.mc-pdp-member-line__label {
+  display: block !important;
+  font-size: 13px !important;
+  font-weight: 400 !important;
+  line-height: 1.2 !important;
+  letter-spacing: 0.16em !important;
+  text-transform: uppercase !important;
+  color: #777 !important;
+}
+
+.mc-pdp-member-pricing .mc-pdp-member-line__amount,
+.mc-pdp-member-line__amount {
+  display: block !important;
+  font-size: 13px !important;
+  line-height: 1.2 !important;
+  letter-spacing: 0.02em !important;
+  color: #444 !important;
+  font-weight: 400 !important;
+  white-space: normal !important;
+  position: static !important;
+  width: 100% !important;
+}
+.mc-pdp-member-pricing .mc-pdp-member-line--sale {
+  margin-top: 4px !important;
+}
+.mc-pdp-member-pricing > .product_sale_price,
+.mc-pdp-member-pricing > .product_saleprice,
+.mc-pdp-member-pricing > font.product_sale_price {
+  display: none !important;
+  visibility: hidden !important;
+}
+
+.mc-pdp-member-pricing .mc-pdp-member-line {
+  color: inherit !important;
+  font-weight: 400 !important;
+}
+
+.mc-pdp-retail-label {
+  display: block !important;
+  width: auto !important;
+  margin: 0 !important;
+  font-size: 13px !important;
+  font-weight: 400 !important;
+  line-height: 1.2 !important;
+  letter-spacing: 0.16em !important;
+  text-transform: uppercase !important;
+  color: #777 !important;
+}
+
+body.productdetails:not(.mc-bean-bag-pdp):not(.mc-saranoni-pdp) #content_area #options_table,
+body.productdetails:not(.mc-bean-bag-pdp):not(.mc-saranoni-pdp) #content_area table[id*="options_table"],
+body.productdetails:not(.mc-bean-bag-pdp):not(.mc-saranoni-pdp) #v65-product-parent #options_table,
+body.productdetails:not(.mc-bean-bag-pdp):not(.mc-saranoni-pdp) #v65-product-parent table[id*="options_table"],
+body.mc-product-page:not(.mc-bean-bag-pdp):not(.mc-saranoni-pdp) #content_area #options_table,
+body.mc-product-page:not(.mc-bean-bag-pdp):not(.mc-saranoni-pdp) #content_area table[id*="options_table"],
+body.mc-product-page:not(.mc-bean-bag-pdp):not(.mc-saranoni-pdp) #v65-product-parent #options_table,
+body.mc-product-page:not(.mc-bean-bag-pdp):not(.mc-saranoni-pdp) #v65-product-parent table[id*="options_table"] {
+  position: static !important;
+  left: auto !important;
+  opacity: 1 !important;
+  pointer-events: auto !important;
+  height: auto !important;
+  overflow: visible !important;
+}
+
+body.productdetails #v65-product-parent #priceWithOptions,
+body.productdetails #v65-product-parent #priceWithOptionsNoTax,
+body.productdetails #content_area #priceWithOptions,
+body.productdetails #content_area #priceWithOptionsNoTax,
+body.mc-product-page #v65-product-parent #priceWithOptions,
+body.mc-product-page #v65-product-parent #priceWithOptionsNoTax,
+body.mc-product-page #content_area #priceWithOptions,
+body.mc-product-page #content_area #priceWithOptionsNoTax {
+  display: block !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+}
+
+body.productdetails #v65-product-parent .product_list_price,
+body.productdetails #content_area .product_list_price,
+body.productdetails #v65-product-parent .product_productprice,
+body.productdetails #content_area .product_productprice,
+body.productdetails #v65-product-parent .v65-product-price,
+body.productdetails #content_area .v65-product-price,
+body.productdetails #v65-product-parent .product_price,
+body.productdetails #content_area .product_price,
+body.mc-product-page #v65-product-parent .product_list_price,
+body.mc-product-page #content_area .product_list_price,
+body.mc-product-page #v65-product-parent .product_productprice,
+body.mc-product-page #content_area .product_productprice,
+body.mc-product-page #v65-product-parent .v65-product-price,
+body.mc-product-page #content_area .v65-product-price,
+body.mc-product-page #v65-product-parent .product_price,
+body.mc-product-page #content_area .product_price {
+  display: block !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+}
+
+body.productdetails #v65-product-parent .mc-pdp-retail-row .product_list_price,
+body.productdetails #content_area .mc-pdp-retail-row .product_list_price,
+body.productdetails #v65-product-parent .mc-pdp-retail-row font.product_list_price,
+body.productdetails #content_area .mc-pdp-retail-row font.product_list_price,
+body.productdetails #v65-product-parent .mc-pdp-retail-row .product_productprice,
+body.productdetails #content_area .mc-pdp-retail-row .product_productprice,
+body.productdetails #v65-product-parent .mc-pdp-retail-row .v65-product-price,
+body.productdetails #content_area .mc-pdp-retail-row .v65-product-price,
+body.productdetails #v65-product-parent .mc-pdp-retail-row .product_price,
+body.productdetails #content_area .mc-pdp-retail-row .product_price,
+body.productdetails #v65-product-parent .mc-pdp-retail-row .price,
+body.productdetails #content_area .mc-pdp-retail-row .price,
+body.productdetails #v65-product-parent .mc-pdp-retail-row #priceWithOptions,
+body.productdetails #content_area .mc-pdp-retail-row #priceWithOptions,
+body.productdetails #v65-product-parent .mc-pdp-retail-row #priceWithOptionsNoTax,
+body.productdetails #content_area .mc-pdp-retail-row #priceWithOptionsNoTax,
+body.mc-product-page #v65-product-parent .mc-pdp-retail-row .product_list_price,
+body.mc-product-page #content_area .mc-pdp-retail-row .product_list_price,
+body.mc-product-page #v65-product-parent .mc-pdp-retail-row font.product_list_price,
+body.mc-product-page #content_area .mc-pdp-retail-row font.product_list_price,
+body.mc-product-page #v65-product-parent .mc-pdp-retail-row .product_productprice,
+body.mc-product-page #content_area .mc-pdp-retail-row .product_productprice,
+body.mc-product-page #v65-product-parent .mc-pdp-retail-row .v65-product-price,
+body.mc-product-page #content_area .mc-pdp-retail-row .v65-product-price,
+body.mc-product-page #v65-product-parent .mc-pdp-retail-row .product_price,
+body.mc-product-page #content_area .mc-pdp-retail-row .product_price,
+body.mc-product-page #v65-product-parent .mc-pdp-retail-row .price,
+body.mc-product-page #content_area .mc-pdp-retail-row .price,
+body.mc-product-page #v65-product-parent .mc-pdp-retail-row #priceWithOptions,
+body.mc-product-page #content_area .mc-pdp-retail-row #priceWithOptions,
+body.mc-product-page #v65-product-parent .mc-pdp-retail-row #priceWithOptionsNoTax,
+body.mc-product-page #content_area .mc-pdp-retail-row #priceWithOptionsNoTax {
+  display: block !important;
+  width: auto !important;
+  margin: 0 !important;
+  font-size: 13px !important;
+  line-height: 1.2 !important;
+  font-weight: 400 !important;
+  letter-spacing: 0.16em !important;
+  color: #444 !important;
+  vertical-align: baseline !important;
+}
+
+body.productdetails #v65-product-parent .product_sale_price,
+body.productdetails #v65-product-parent .product_saleprice,
+body.productdetails #v65-product-parent font.product_sale_price,
+body.productdetails #content_area .product_sale_price,
+body.productdetails #content_area .product_saleprice,
+body.productdetails #content_area font.product_sale_price,
+body.mc-product-page #v65-product-parent .product_sale_price,
+body.mc-product-page #v65-product-parent .product_saleprice,
+body.mc-product-page #v65-product-parent font.product_sale_price,
+body.mc-product-page #content_area .product_sale_price,
+body.mc-product-page #content_area .product_saleprice,
+body.mc-product-page #content_area font.product_sale_price {
+  display: none !important;
+  visibility: hidden !important;
+  opacity: 0 !important;
+}
+</style>
+<div id="mc-login-modal" class="mc-login-modal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="mc-login-modal-title">
+  <div class="mc-login-modal__backdrop" data-mc-close-login tabindex="-1"></div>
+  <div class="mc-login-modal__panel" role="document">
+    <button type="button" class="mc-login-modal__close" data-mc-close-login aria-label="Close">&times;</button>
+    <h2 id="mc-login-modal-title" class="mc-login-modal__title">Member login</h2>
+    <div class="mc-login-modal__tabs" role="tablist">
+      <button type="button" class="mc-login-modal__tab is-active" data-mc-login-tab="login" role="tab" aria-selected="true">Log in</button>
+      <button type="button" class="mc-login-modal__tab" data-mc-login-tab="signup" role="tab" aria-selected="false">Sign up</button>
+    </div>
+    <div id="mc-login-modal-panel-login" class="mc-login-modal__panel-body is-active">
+      <p class="mc-login-modal__hint">Sign in below. Member pricing updates on this page when login succeeds — you stay on the product.</p>
+      <div id="mc-login-modal-login-status" class="mc-login-modal__status" aria-live="polite"></div>
+      <form id="mc-member-login-form" class="mc-login-modal__form" method="post" action="/login.asp" autocomplete="on">
+        <input type="hidden" name="CustomerNewOld" value="old" />
+        <input type="hidden" name="imageField2.x" value="1" />
+        <input type="hidden" name="imageField2.y" value="1" />
+        <div class="mc-login-modal__field">
+          <label for="mc-login-email">Email (username)</label>
+          <input type="email" id="mc-login-email" name="email" required autocomplete="username" maxlength="75" />
+        </div>
+        <div class="mc-login-modal__field">
+          <label for="mc-login-password">Password</label>
+          <input type="password" id="mc-login-password" name="password" required autocomplete="current-password" maxlength="80" />
+        </div>
+        <button type="submit" class="mc-login-modal__submit">Log in</button>
+      </form>
+      <p class="mc-login-modal__signup-note">Need the full login page? <a href="/login.asp" target="_blank" rel="noopener">Open in a new tab</a></p>
+      <p class="mc-login-modal__signup">New here? <a href="#" id="mc-login-modal-switch-signup">Create an account</a></p>
+    </div>
+    <div id="mc-login-modal-panel-signup" class="mc-login-modal__panel-body">
+      <p class="mc-login-modal__hint">Create your account with your name, email, and password.</p>
+      <div id="mc-login-modal-signup-status" class="mc-login-modal__status" aria-live="polite"></div>
+      <form id="mc-member-signup-form" class="mc-login-modal__form" method="post" action="/AccountSettings.asp" autocomplete="on">
+        <input type="hidden" name="AddNewCustomer" value="Y" />
+        <input type="hidden" name="FirstName" id="mc-signup-firstname" value="" />
+        <input type="hidden" name="LastName" id="mc-signup-lastname" value="" />
+        <input type="hidden" name="EmailAddress2" id="mc-signup-email2" value="" />
+        <input type="hidden" name="Password2" id="mc-signup-password2" value="" />
+        <div class="mc-login-modal__field">
+          <label for="mc-signup-display-name">Name</label>
+          <input type="text" id="mc-signup-display-name" required autocomplete="name" maxlength="120" />
+        </div>
+        <div class="mc-login-modal__field">
+          <label for="mc-signup-email">Email</label>
+          <input type="email" id="mc-signup-email" name="EmailAddress" required autocomplete="email" maxlength="120" />
+        </div>
+        <div class="mc-login-modal__field">
+          <label for="mc-signup-password">Password</label>
+          <input type="password" id="mc-signup-password" name="Password" required autocomplete="new-password" minlength="6" maxlength="64" />
+        </div>
+        <button type="submit" class="mc-login-modal__submit">Create account</button>
+      </form>
+      <p class="mc-login-modal__switch">Already have an account? <a href="#" id="mc-login-modal-switch-login">Log in</a></p>
+    </div>
+  </div>
+</div>
+<script>
+(function () {
+  'use strict';
+  function mcLoginModalClearRecentAuth() {
+    try {
+      if (typeof window.mcClearRecentMemberAuth === "function") window.mcClearRecentMemberAuth();
+      else try { sessionStorage.removeItem("mc_recent_member_auth_ts"); } catch (eR0) {}
+    } catch (eR) {}
+  }
+  function mcLoginModalRememberRecentAuth() {
+    try {
+      if (typeof window.mcRememberRecentMemberAuth === "function") window.mcRememberRecentMemberAuth();
+      else try { sessionStorage.setItem("mc_recent_member_auth_ts", String(Date.now())); } catch (eM0) {}
+    } catch (eM) {}
+  }
+  function mcLoginReturnTo() {
+    return encodeURIComponent((location.pathname || '/') + (location.search || ''));
+  }
+  function mcSetSignupFormAction() {
+    var form = document.getElementById('mc-member-signup-form');
+    if (!form) return;
+    form.setAttribute(
+      'action',
+      '/AccountSettings.asp?AddNewCustomer=Y&ReturnTo=' + mcLoginReturnTo()
+    );
+  }
+  function mcSetLoginFormAction() {
+    var form = document.getElementById('mc-member-login-form');
+    if (!form) return;
+    form.setAttribute('action', '/login.asp?ReturnTo=' + mcLoginReturnTo());
+  }
+  function mcGetLogoutUrl() {
+    var link = document.querySelector('a[href*="logout"], a[href*="logoff"]');
+    if (link && link.href) return link.href;
+    return '/logout.asp?ReturnTo=' + mcLoginReturnTo();
+  }
+  function mcSplitDisplayName(full) {
+    var s = String(full || '').trim().replace(/\s+/g, ' ');
+    if (!s) return { first: '', last: 'Customer' };
+    var i = s.indexOf(' ');
+    if (i === -1) return { first: s, last: 'Customer' };
+    return { first: s.slice(0, i), last: s.slice(i + 1) };
+  }
+ function mcSetModalTab(mode) {
+  var loginPanel = document.getElementById('mc-login-modal-panel-login');
+  var signupPanel = document.getElementById('mc-login-modal-panel-signup');
+  var tabs = document.querySelectorAll('[data-mc-login-tab]');
+  var title = document.getElementById('mc-login-modal-title');
+
+  mcSetAuthStatus('login', '', '');
+  mcSetAuthStatus('signup', '', '');
+
+  var i;
+  for (i = 0; i < tabs.length; i++) {
+    var tab = tabs[i];
+    var isSel = tab.getAttribute('data-mc-login-tab') === mode;
+    tab.classList.toggle('is-active', isSel);
+    tab.setAttribute('aria-selected', isSel ? 'true' : 'false');
+  }
+
+  if (loginPanel) loginPanel.classList.toggle('is-active', mode === 'login');
+  if (signupPanel) signupPanel.classList.toggle('is-active', mode === 'signup');
+  if (title) title.textContent = mode === 'signup' ? 'Create account' : 'Member login';
+
+  if (mode === 'login') {
+    mcSetLoginFormAction();
+    try {
+      mcToggleAuthPending(document.getElementById('mc-member-login-form'), false);
+    } catch (eLogReset) {}
+  }
+
+  if (mode === 'signup') {
+    mcSetSignupFormAction();
+  }
+}
+  function mcPrepareLoginModal() {
+    var m = document.getElementById('mc-login-modal');
+    if (!m) return null;
+    try {
+      if (document.body && m.parentNode !== document.body) {
+        document.body.appendChild(m);
+      } else if (document.body) {
+        document.body.appendChild(m);
+      }
+    } catch (eMove) {}
+    try {
+      m.style.setProperty('position', 'fixed', 'important');
+      m.style.setProperty('inset', '0', 'important');
+      m.style.setProperty('display', 'flex', 'important');
+      m.style.setProperty('visibility', 'visible', 'important');
+      m.style.setProperty('opacity', '1', 'important');
+      m.style.setProperty('pointer-events', 'auto', 'important');
+      m.style.setProperty('z-index', '2147483647', 'important');
+    } catch (eStyle) {}
+    return m;
+  }
+  function mcOpenLoginModal() {
+    var m = mcPrepareLoginModal();
+    if (!m) return false;
+    mcEnsureAuthFormBound();
+    mcSetModalTab('login');
+    m.classList.add('mc-login-modal--open');
+    m.setAttribute('aria-hidden', 'false');
+    try {
+      document.body.style.overflow = 'hidden';
+    } catch (e) {}
+    try {
+      var cs = window.getComputedStyle ? window.getComputedStyle(m) : null;
+      var rect = m.getBoundingClientRect ? m.getBoundingClientRect() : null;
+      var visible = !!(
+        cs &&
+        cs.display !== 'none' &&
+        cs.visibility !== 'hidden' &&
+        cs.opacity !== '0' &&
+        rect &&
+        rect.width > 0 &&
+        rect.height > 0
+      );
+      if (!visible) return false;
+    } catch (eVis) {}
+    return true;
+  }
+  function mcOpenSignupModal() {
+    var m = mcPrepareLoginModal();
+    if (!m) return false;
+    mcEnsureAuthFormBound();
+    mcSetModalTab('signup');
+    m.classList.add('mc-login-modal--open');
+    m.setAttribute('aria-hidden', 'false');
+    try {
+      document.body.style.overflow = 'hidden';
+    } catch (e2) {}
+    try {
+      var cs = window.getComputedStyle ? window.getComputedStyle(m) : null;
+      var rect = m.getBoundingClientRect ? m.getBoundingClientRect() : null;
+      var visible = !!(
+        cs &&
+        cs.display !== 'none' &&
+        cs.visibility !== 'hidden' &&
+        cs.opacity !== '0' &&
+        rect &&
+        rect.width > 0 &&
+        rect.height > 0
+      );
+      if (!visible) return false;
+    } catch (eVis2) {}
+    return true;
+  }
+  function mcCloseLoginModalOnly() {
+    var m = document.getElementById('mc-login-modal');
+    if (!m) return;
+    m.classList.remove('mc-login-modal--open');
+    m.setAttribute('aria-hidden', 'true');
+    try {
+      m.style.removeProperty('display');
+      m.style.removeProperty('visibility');
+      m.style.removeProperty('opacity');
+      m.style.removeProperty('pointer-events');
+      m.style.removeProperty('z-index');
+      document.body.style.overflow = '';
+    } catch (e2) {}
+  }
+
+  async function mcRefreshMemberPricingAfterAuth() {
+    try {
+      if (typeof window.mcRememberRecentMemberAuth === "function") window.mcRememberRecentMemberAuth();
+    } catch (eRem) {}
+    try {
+      window.__mcMemberPricing.promise = null;
+    } catch (ePr) {}
+    try {
+      document.body.classList.add("mc-member-logged-in");
+      if (typeof window.mcSyncPalliserPdpBodyClasses === "function") {
+        window.mcSyncPalliserPdpBodyClasses(true);
+      }
+    } catch (eCls) {}
+    var state = null;
+    try {
+      if (typeof window.detectMemberPricingState === "function") {
+        state = await window.detectMemberPricingState();
+      }
+    } catch (eDet) {}
+    try {
+      if (typeof window.refreshPlannerPriceForMemberState === "function") {
+        window.refreshPlannerPriceForMemberState();
+      } else if (typeof refreshPlannerPriceForMemberState === "function") {
+        refreshPlannerPriceForMemberState();
+      }
+    } catch (eRpf) {}
+    try {
+      if (typeof window.renderMemberPricingCaption === "function") {
+        window.renderMemberPricingCaption(document);
+      } else if (typeof renderMemberPricingCaption === "function") {
+        renderMemberPricingCaption(document);
+      }
+    } catch (eCap) {}
+    try {
+      if (typeof window.forceProductFixes === "function") window.forceProductFixes();
+    } catch (eFx) {}
+    try {
+      if (typeof window.mcRenderRetailMemberOnPdp === "function") {
+        await window.mcRenderRetailMemberOnPdp();
+      }
+    } catch (ePdp) {}
+    try {
+      if (window.__mcPlannerConfigApplied) {
+        if (typeof window.mcSyncPlannerConfigurationPriceDisplay === "function") {
+          window.mcSyncPlannerConfigurationPriceDisplay();
+        }
+        if (window.__mcLastPlannerPayload && typeof window.applyPlannerToPage === "function") {
+          window.applyPlannerToPage(window.__mcLastPlannerPayload);
+        }
+      }
+    } catch (ePl) {}
+    try {
+      if (typeof window.recalcRoomPlannerPrice === "function") window.recalcRoomPlannerPrice();
+    } catch (eRec) {}
+    try {
+      window.dispatchEvent(new CustomEvent("mcMemberPricingReady", { detail: window.__mcMemberPricing }));
+    } catch (eEv) {}
+    try {
+      if (typeof mcRunParagonPriceSourceDebug === "function") mcRunParagonPriceSourceDebug();
+    } catch (eDbg) {}
+    return state;
+  }
+
+  function mcFinishLoginModalAndRefreshPdp() {
+    mcCloseLoginModalOnly();
+    try {
+      document.body.style.overflow = "";
+    } catch (eOv) {}
+    window.setTimeout(function () {
+      mcRefreshMemberPricingAfterAuth().catch(function () {
+        try {
+          if (typeof window.detectMemberPricingState === "function") {
+            window.__mcMemberPricing.promise = null;
+            window.detectMemberPricingState();
+          }
+        } catch (eRetry) {}
+      });
+    }, 0);
+  }
+
+  function mcCloseLoginModal(skipPricingRefresh) {
+    mcCloseLoginModalOnly();
+    if (skipPricingRefresh) return;
+    try {
+      window.__mcMemberPricing.promise = null;
+    } catch (e3) {}
+    try {
+      if (typeof window.mcResolveVolusionSession === 'function') window.mcResolveVolusionSession();
+    } catch (eRvs) {}
+    if (typeof window.detectMemberPricingState === 'function') {
+      window.detectMemberPricingState().then(function () {
+        try {
+          if (typeof window.mcPaintCategoryGridMemberPricing === 'function') {
+            window.mcPaintCategoryGridMemberPricing();
+          }
+        } catch (e5) {}
+        try {
+          if (typeof window.mcRenderRetailMemberOnPdp === 'function') {
+            window.mcRenderRetailMemberOnPdp();
+          }
+        } catch (e6) {}
+      });
+    }
+  }
+  window.mcOpenLoginModal = mcOpenLoginModal;
+  window.mcCloseLoginModal = mcCloseLoginModal;
+  window.mcCloseLoginModalOnly = mcCloseLoginModalOnly;
+  window.mcRefreshMemberPricingAfterAuth = mcRefreshMemberPricingAfterAuth;
+  window.mcFinishLoginModalAndRefreshPdp = mcFinishLoginModalAndRefreshPdp;
+  window.mcOpenSignupModal = mcOpenSignupModal;
+
+  function mcEnsureAuthFormBound() {
+    var loginForm = document.getElementById('mc-member-login-form');
+    if (loginForm && loginForm.getAttribute('data-mc-auth-bound') !== '1') {
+      loginForm.setAttribute('data-mc-auth-bound', '1');
+      loginForm.setAttribute('action', '/login.asp');
+      loginForm.setAttribute('target', '_self');
+      loginForm.addEventListener(
+        'submit',
+        function (ev) {
+          ev.preventDefault();
+          ev.stopPropagation();
+          try {
+            ev.stopImmediatePropagation();
+          } catch (eStop) {}
+          mcSubmitAuthForm(loginForm, 'login');
+          return false;
+        },
+        true
+      );
+      loginForm.onsubmit = function () {
+        return false;
+      };
+    }
+    var signupForm = document.getElementById('mc-member-signup-form');
+    if (signupForm && signupForm.getAttribute('data-mc-auth-bound') !== '1') {
+      signupForm.setAttribute('data-mc-auth-bound', '1');
+      signupForm.setAttribute('target', '_self');
+      signupForm.addEventListener(
+        'submit',
+        function (ev) {
+          ev.preventDefault();
+          ev.stopPropagation();
+          try {
+            ev.stopImmediatePropagation();
+          } catch (eStop2) {}
+          var nameEl = document.getElementById('mc-signup-display-name');
+          var emailEl = document.getElementById('mc-signup-email');
+          var pwEl = document.getElementById('mc-signup-password');
+          var fn = document.getElementById('mc-signup-firstname');
+          var ln = document.getElementById('mc-signup-lastname');
+          var e2 = document.getElementById('mc-signup-email2');
+          var p2 = document.getElementById('mc-signup-password2');
+          if (!nameEl || !emailEl || !pwEl || !fn || !ln || !e2 || !p2) return false;
+          var parts = mcSplitDisplayName(nameEl.value);
+          fn.value = parts.first;
+          ln.value = parts.last;
+          e2.value = emailEl.value;
+          p2.value = pwEl.value;
+          mcSetSignupFormAction();
+          mcSubmitAuthForm(signupForm, 'signup');
+          return false;
+        },
+        true
+      );
+      signupForm.onsubmit = function () {
+        return false;
+      };
+    }
+  }
+  window.mcEnsureAuthFormBound = mcEnsureAuthFormBound;
+
+  var mcIdleLogoutTimer = null;
+  function mcClearIdleLogoutTimer() {
+    if (mcIdleLogoutTimer) {
+      window.clearTimeout(mcIdleLogoutTimer);
+      mcIdleLogoutTimer = null;
+    }
+  }
+  function mcRecordMemberActivity() {
+    try {
+      sessionStorage.setItem('mc_last_member_activity_ts', String(Date.now()));
+    } catch (eAct) {}
+  }
+  function mcScheduleIdleLogout() {
+    mcClearIdleLogoutTimer();
+    if (!(document.body && document.body.classList.contains('mc-member-logged-in'))) return;
+    mcIdleLogoutTimer = window.setTimeout(function () {
+      if (!(document.body && document.body.classList.contains('mc-member-logged-in'))) return;
+      window.location.href = mcGetLogoutUrl();
+    }, 60 * 60 * 1000);
+  }
+  function mcRefreshIdleLogout() {
+    if (document.body && document.body.classList.contains('mc-member-logged-in')) {
+      mcRecordMemberActivity();
+      mcScheduleIdleLogout();
+    } else {
+      mcClearIdleLogoutTimer();
+    }
+  }
+  (function mcBindIdleLogout() {
+    var lastRecorded = 0;
+    ['mousedown', 'keydown', 'touchstart', 'scroll', 'click'].forEach(function (evtName) {
+      window.addEventListener(evtName, function () {
+        if (!(document.body && document.body.classList.contains('mc-member-logged-in'))) return;
+        var now = Date.now();
+        if (now - lastRecorded < 15000) return;
+        lastRecorded = now;
+        mcRefreshIdleLogout();
+      }, { passive: true });
+    });
+    window.addEventListener('mcMemberPricingReady', function () {
+      mcRefreshIdleLogout();
+    });
+    window.setTimeout(mcRefreshIdleLogout, 0);
+  })();
+
+  function mcSetAuthStatus(mode, message, kind) {
+    var id = mode === 'signup' ? 'mc-login-modal-signup-status' : 'mc-login-modal-login-status';
+    var box = document.getElementById(id);
+    if (!box) return;
+    box.className = 'mc-login-modal__status' + (kind ? ' is-' + kind : '');
+    box.textContent = message || '';
+  }
+
+  function mcToggleAuthPending(form, pending) {
+    if (!form) return;
+    try {
+      if (pending) {
+        form.setAttribute('data-mc-auth-pending', '1');
+        form.setAttribute('aria-busy', 'true');
+      } else {
+        form.removeAttribute('data-mc-auth-pending');
+        form.removeAttribute('aria-busy');
+      }
+    } catch (eState) {}
+    var submitBtn = form.querySelector('button[type="submit"], input[type="submit"], input[type="image"]');
+    if (!submitBtn) return;
+    try {
+      if (!submitBtn.getAttribute('data-mc-label-default')) {
+        var baseLabel =
+          submitBtn.tagName === 'INPUT'
+            ? (submitBtn.getAttribute('value') || submitBtn.getAttribute('alt') || '')
+            : (submitBtn.textContent || '');
+        submitBtn.setAttribute('data-mc-label-default', baseLabel);
+      }
+      var defaultLabel = submitBtn.getAttribute('data-mc-label-default') || '';
+      var pendingLabel = form.id === 'mc-member-signup-form' ? 'Creating account...' : 'Signing in...';
+      if (submitBtn.tagName === 'INPUT') {
+        if (pending) {
+          submitBtn.setAttribute('value', pendingLabel);
+          submitBtn.setAttribute('alt', pendingLabel);
+        } else {
+          if (defaultLabel) {
+            submitBtn.setAttribute('value', defaultLabel);
+            submitBtn.setAttribute('alt', defaultLabel);
+          }
+        }
+      } else {
+        submitBtn.textContent = pending ? pendingLabel : defaultLabel;
+      }
+    } catch (eLabel) {}
+  }
+
+  function mcAuthFormBody(form) {
+    var fd = new FormData(form);
+    var params = new URLSearchParams();
+    fd.forEach(function (value, key) {
+      params.append(key, value == null ? '' : String(value));
+    });
+    return params.toString();
+  }
+  function mcGetAuthFrame() {
+    var frame = document.getElementById('mc-member-auth-frame');
+    if (frame) return frame;
+    frame = document.createElement('iframe');
+    frame.id = 'mc-member-auth-frame';
+    frame.name = 'mc-member-auth-frame';
+    frame.setAttribute('aria-hidden', 'true');
+    frame.setAttribute('tabindex', '-1');
+    frame.style.position = 'absolute';
+    frame.style.left = '-9999px';
+    frame.style.width = '1px';
+    frame.style.height = '1px';
+    frame.style.border = '0';
+    try {
+      document.body.appendChild(frame);
+    } catch (e) {}
+    return frame;
+  }
+
+  function mcDomIndicatesLoggedIn() {
+    try {
+      if (document.body && document.body.classList.contains("mc-member-logged-in")) return true;
+      if (document.querySelector('a[href*="logout.asp"], a[href*="logoff.asp"]')) return true;
+    } catch (eDom) {}
+    return false;
+  }
+
+  function mcReadAuthFrameSnapshot() {
+    var frame = document.getElementById("mc-member-auth-frame");
+    if (!frame) return { html: "", url: "" };
+    try {
+      var win = frame.contentWindow;
+      var doc = frame.contentDocument || (win && win.document);
+      var url = win && win.location ? String(win.location.href || "") : "";
+      var html = doc && doc.documentElement ? doc.documentElement.innerHTML : "";
+      return { html: html, url: url };
+    } catch (eFrame) {
+      return { html: "", url: "" };
+    }
+  }
+
+  function mcVolusionAuthIndicatesSuccess(html, url) {
+    var check = window.volusionMyAccountHtmlIndicatesLoggedIn || volusionMyAccountHtmlIndicatesLoggedIn;
+    if (typeof check === "function" && check(html)) return true;
+    var u = String(url || "").toLowerCase();
+    if (/productdetails\.asp/i.test(u)) return true;
+    if (/\/\w+-p\//.test(u) && u.indexOf("login.asp") === -1 && u.indexOf("customer_login") === -1) {
+      return true;
+    }
+    if (mcDomIndicatesLoggedIn()) return true;
+    return false;
+  }
+
+  async function mcAuthSucceeded() {
+    if (mcDomIndicatesLoggedIn()) return true;
+    var ctrl = null;
+    var timer = null;
+    try {
+      if (typeof AbortController !== "undefined") {
+        ctrl = new AbortController();
+        timer = window.setTimeout(function () {
+          try {
+            ctrl.abort();
+          } catch (eA) {}
+        }, 4500);
+      }
+      var resp = await fetch("/myaccount.asp?mcAuthCheck=" + Date.now(), {
+        credentials: "same-origin",
+        cache: "no-store",
+        signal: ctrl ? ctrl.signal : undefined,
+      });
+      var html = await resp.text();
+      if (timer) {
+        window.clearTimeout(timer);
+        timer = null;
+      }
+      var check = window.volusionMyAccountHtmlIndicatesLoggedIn || volusionMyAccountHtmlIndicatesLoggedIn;
+      if (typeof check === "function") return !!check(html);
+      return false;
+    } catch (e2) {
+      if (timer) {
+        try {
+          window.clearTimeout(timer);
+        } catch (eC) {}
+      }
+    }
+    return mcDomIndicatesLoggedIn();
+  }
+  function mcAuthDelayMs(ms) {
+    return new Promise(function (resolve) {
+      setTimeout(resolve, Math.max(0, Number(ms) || 0));
+    });
+  }
+
+  async function mcWaitForAuthSuccess(maxMs, intervalMs) {
+    var timeoutMs = Math.max(1000, Number(maxMs) || 0);
+    var stepMs = Math.max(200, Number(intervalMs) || 0);
+    var started = Date.now();
+    while (Date.now() - started < timeoutMs) {
+      try {
+        if (await mcAuthSucceeded()) return true;
+      } catch (eAuthPoll) {}
+      var delayFn = typeof mcDelay === "function" ? mcDelay : mcAuthDelayMs;
+      await delayFn(stepMs);
+    }
+    return false;
+  }
+
+  function mcPostHiddenVolusionForm(actionUrl, fields) {
+    return new Promise(function (resolve, reject) {
+      var frame = mcGetAuthFrame();
+      var settled = false;
+      var timer = window.setTimeout(function () {
+        if (settled) return;
+        settled = true;
+        try {
+          frame.onload = null;
+        } catch (eT) {}
+        reject(new Error("timeout"));
+      }, 22000);
+      frame.onload = function () {
+        if (settled) return;
+        settled = true;
+        window.clearTimeout(timer);
+        try {
+          frame.onload = null;
+        } catch (eL) {}
+        window.setTimeout(function () {
+          resolve(mcReadAuthFrameSnapshot());
+        }, 280);
+      };
+      var f = document.createElement("form");
+      f.method = "POST";
+      f.action = actionUrl;
+      f.target = frame.name;
+      f.style.cssText = "position:absolute;left:-9999px;visibility:hidden";
+      Object.keys(fields || {}).forEach(function (key) {
+        var inp = document.createElement("input");
+        inp.type = "hidden";
+        inp.name = key;
+        inp.value = fields[key] == null ? "" : String(fields[key]);
+        f.appendChild(inp);
+      });
+      document.body.appendChild(f);
+      try {
+        f.submit();
+      } catch (eSub) {
+        settled = true;
+        window.clearTimeout(timer);
+        reject(eSub);
+        return;
+      }
+      window.setTimeout(function () {
+        try {
+          f.remove();
+        } catch (eRm) {}
+      }, 600);
+    });
+  }
+  function mcNormalizeLoginFormFields(form) {
+    if (!form) return;
+    var emailEl = document.getElementById('mc-login-email');
+    if (emailEl) emailEl.setAttribute('name', 'email');
+    var passwordEl = document.getElementById('mc-login-password');
+    if (passwordEl) passwordEl.setAttribute('name', 'password');
+  }
+
+  function mcVolusionLoginUrls() {
+    var returnTo = mcLoginReturnTo();
+    return {
+      step1: '/login.asp?ReturnTo=' + returnTo,
+      step2: '/login.asp?ReturnTo=' + returnTo,
+    };
+  }
+
+  function mcVolusionLoginStep1Body(email) {
+    var body = new URLSearchParams();
+    body.append('CustomerNewOld', 'old');
+    body.append('email', String(email || '').trim());
+    body.append('imageField2.x', '1');
+    body.append('imageField2.y', '1');
+    return body.toString();
+  }
+
+  function mcVolusionLoginStep2Body(email, password) {
+    var body = new URLSearchParams();
+    body.append('CustomerNewOld', 'old');
+    body.append('email', String(email || '').trim());
+    body.append('password', String(password || ''));
+    body.append('imageField2.x', '1');
+    body.append('imageField2.y', '1');
+    return body.toString();
+  }
+
+  async function mcFetchVolusionAuth(url, body) {
+    return fetch(url, {
+      method: 'POST',
+      credentials: 'same-origin',
+      cache: 'no-store',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'text/html,application/xhtml+xml',
+      },
+      body: body,
+      redirect: 'follow',
+    });
+  }
+
+  async function mcPostVolusionLoginTwoStep(form) {
+    mcNormalizeLoginFormFields(form);
+    var emailEl = document.getElementById("mc-login-email");
+    var passwordEl = document.getElementById("mc-login-password");
+    var email = emailEl ? String(emailEl.value || "").trim() : "";
+    var password = passwordEl ? String(passwordEl.value || "") : "";
+    if (!email || !password) return false;
+
+    var urls = mcVolusionLoginUrls();
+    try {
+      await mcPostHiddenVolusionForm(urls.step1, {
+        CustomerNewOld: "old",
+        email: email,
+        "imageField2.x": "1",
+        "imageField2.y": "1",
+      });
+      await mcAuthDelayMs(400);
+      var afterStep2 = await mcPostHiddenVolusionForm(urls.step2, {
+        CustomerNewOld: "old",
+        email: email,
+        password: password,
+        "imageField2.x": "1",
+        "imageField2.y": "1",
+      });
+      if (mcVolusionAuthIndicatesSuccess(afterStep2 && afterStep2.html, afterStep2 && afterStep2.url)) {
+        mcLoginModalRememberRecentAuth();
+        return true;
+      }
+      if (mcLoginResponseLooksFailed(afterStep2 && afterStep2.html, afterStep2 && afterStep2.url)) {
+        return false;
+      }
+    } catch (eLoginSteps) {
+      try {
+        await mcFetchVolusionAuth(urls.step1, mcVolusionLoginStep1Body(email));
+        await mcAuthDelayMs(300);
+        var r2 = await mcFetchVolusionAuth(urls.step2, mcVolusionLoginStep2Body(email, password));
+        var html2 = await r2.text();
+        if (mcVolusionAuthIndicatesSuccess(html2, r2.url)) {
+          mcLoginModalRememberRecentAuth();
+          return true;
+        }
+        if (mcLoginResponseLooksFailed(html2, r2.url)) return false;
+      } catch (eFetchFallback) {
+        return false;
+      }
+    }
+    try {
+      var retryHtml = await mcConfirmRecentMemberAuth(6, 450);
+      if (retryHtml && volusionMyAccountHtmlIndicatesLoggedIn(retryHtml)) {
+        mcLoginModalRememberRecentAuth();
+        return true;
+      }
+    } catch (eConfirm) {}
+    if (await mcAuthSucceeded()) {
+      mcLoginModalRememberRecentAuth();
+      return true;
+    }
+    return await mcWaitForAuthSuccess(10000, 400);
+  }
+
+  async function mcPostAuthWithFetch(form, mode) {
+    if (!form) return false;
+    if (mode === 'login') {
+      return await mcPostVolusionLoginTwoStep(form);
+    }
+    mcSetSignupFormAction();
+    var action = form.getAttribute('action') || '/AccountSettings.asp';
+    try {
+      await fetch(action, {
+        method: 'POST',
+        credentials: 'same-origin',
+        cache: 'no-store',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Accept: 'text/html,application/xhtml+xml',
+        },
+        body: mcAuthFormBody(form),
+        redirect: 'follow',
+      });
+    } catch (eFetch) {
+      return false;
+    }
+    return await mcWaitForAuthSuccess(12000, 500);
+  }
+
+  function mcLoginResponseLooksFailed(html, respUrl) {
+    var raw = String(html || '');
+    var stripped = raw
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<!--[\s\S]*?-->/g, ' ');
+    var lc = stripped.toLowerCase();
+    var url = String(respUrl || '').toLowerCase();
+    if (/the email address or password[^<]*invalid|invalid (?:email|login|password)|login failed|not recognized|could not log you in/i.test(lc)) {
+      return true;
+    }
+    if (typeof window.volusionMyAccountHtmlIndicatesLoggedIn === 'function' && window.volusionMyAccountHtmlIndicatesLoggedIn(raw)) {
+      return false;
+    }
+    if (/href\s*=\s*["'][^"']*logout\.asp[^"']*["']/i.test(stripped)) return false;
+    if (url.indexOf('/customer_login.asp') !== -1) return true;
+    if (url.indexOf('/login.asp') !== -1 && /<input[^>]+name\s*=\s*["']password["']/i.test(stripped)) {
+      return true;
+    }
+    if (/returning customers?|if you've purchased from us before/i.test(lc) && /<input[^>]+name\s*=\s*["']password["']/i.test(stripped)) {
+      return true;
+    }
+    return false;
+  }
+
+async function mcSubmitAuthForm(form, mode) {
+  if (!form) return false;
+  mcSetAuthStatus(mode, '', '');
+  mcToggleAuthPending(form, true);
+  mcSetAuthStatus(mode, mode === 'signup' ? 'Creating account.' : 'Signing in.', 'success');
+
+  var authFinished = false;
+  var watchdog = window.setTimeout(function () {
+    if (authFinished) return;
+    authFinished = true;
+    mcToggleAuthPending(form, false);
+    mcSetAuthStatus(
+      mode,
+      mode === 'signup'
+        ? 'Account setup timed out. Please try again.'
+        : 'Sign-in timed out. Check your email and password, or use “Open in a new tab” below.',
+      'error'
+    );
+  }, 28000);
+
+  try {
+    var confirmed = authFinished ? false : await mcPostAuthWithFetch(form, mode);
+    if (authFinished) return false;
+    if (confirmed) {
+      authFinished = true;
+      mcLoginModalRememberRecentAuth();
+      mcToggleAuthPending(form, false);
+      mcSetAuthStatus(
+        mode,
+        mode === "signup" ? "Account created." : "Signed in.",
+        "success"
+      );
+      mcFinishLoginModalAndRefreshPdp();
+      return true;
+    }
+    mcLoginModalClearRecentAuth();
+    mcSetAuthStatus(
+      mode,
+      mode === 'signup'
+        ? 'We could not confirm the new account. Please check your info and try again.'
+        : 'Sign-in failed. Check your email and password, or use “Open in a new tab” below.',
+      'error'
+    );
+    mcToggleAuthPending(form, false);
+    return false;
+  } catch (eAuthAll) {
+    if (!authFinished) {
+      mcLoginModalClearRecentAuth();
+      mcSetAuthStatus(
+        mode,
+        mode === 'signup'
+          ? 'Could not create the account right now. Please try again.'
+          : 'Could not sign in right now. Please try again.',
+        'error'
+      );
+      mcToggleAuthPending(form, false);
+    }
+    return false;
+  } finally {
+    authFinished = true;
+    window.clearTimeout(watchdog);
+  }
+}
+
+  window.mcSubmitAuthForm = mcSubmitAuthForm;
+
+  document.addEventListener('click', function (e) {
+    if (typeof window.mcHandleLoginCtaClick === 'function' && window.mcHandleLoginCtaClick(e)) return;
+
+    var t = e.target;
+    if (t && t.closest && t.closest('[data-mc-close-login]')) {
+      e.preventDefault();
+      mcCloseLoginModal();
+    }
+    var tabBtn = t && t.closest ? t.closest('[data-mc-login-tab]') : null;
+    if (tabBtn && tabBtn.getAttribute('data-mc-login-tab')) {
+      e.preventDefault();
+      mcSetModalTab(tabBtn.getAttribute('data-mc-login-tab'));
+    }
+    if (t && t.closest && t.closest('#mc-login-modal-switch-signup')) {
+      e.preventDefault();
+      mcSetModalTab('signup');
+    }
+    if (t && t.closest && t.closest('#mc-login-modal-switch-login')) {
+      e.preventDefault();
+      mcSetModalTab('login');
+    }
+  });
+
+  mcEnsureAuthFormBound();
+  document.addEventListener(
+    'submit',
+    function (ev) {
+      var f = ev.target;
+      if (!f || !f.id) return;
+      if (f.id !== 'mc-member-login-form' && f.id !== 'mc-member-signup-form') return;
+      ev.preventDefault();
+      ev.stopPropagation();
+      try {
+        ev.stopImmediatePropagation();
+      } catch (eCap) {}
+      if (f.id === 'mc-member-login-form') {
+        mcSubmitAuthForm(f, 'login');
+      } else {
+        var nameEl = document.getElementById('mc-signup-display-name');
+        var emailEl = document.getElementById('mc-signup-email');
+        var pwEl = document.getElementById('mc-signup-password');
+        var fn = document.getElementById('mc-signup-firstname');
+        var ln = document.getElementById('mc-signup-lastname');
+        var e2 = document.getElementById('mc-signup-email2');
+        var p2 = document.getElementById('mc-signup-password2');
+        if (!nameEl || !emailEl || !pwEl || !fn || !ln || !e2 || !p2) return;
+        var parts = mcSplitDisplayName(nameEl.value);
+        fn.value = parts.first;
+        ln.value = parts.last;
+        e2.value = emailEl.value;
+        p2.value = pwEl.value;
+        mcSetSignupFormAction();
+        mcSubmitAuthForm(f, 'signup');
+      }
+    },
+    true
+  );
+  document.addEventListener('keydown', function (ev) {
+    if (ev.key === 'Escape') {
+      var m = document.getElementById('mc-login-modal');
+      if (m && m.classList.contains('mc-login-modal--open')) mcCloseLoginModal();
+    }
+  });
+
+  function mcIsLikelyListingPage() {
+    var b = document.body;
+    var h = document.documentElement;
+    if (!b) return false;
+    if (/\/category-s\/157\.htm/i.test(location.pathname || '')) {
+      return true;
+    }
+    if (h && h.classList.contains('category')) return true;
+    if (b.classList.contains('category')) return true;
+    if (b.classList.contains('is-home')) return true;
+    var p = (location.pathname || '').toLowerCase();
+    if (p === '/' || p === '/default.asp' || p.indexOf('default.asp') !== -1) return true;
+    if (p.indexOf('searchresults') !== -1) return true;
+    if (/\/stationary-loveseats-s\/157\.htm/i.test(location.pathname || '')) {
+      return true;
+    }
+    if (p.indexOf('sitemap') !== -1) return false;
+    return false;
+  }
+
+  /** Product cards: Volusion sometimes renders outside #content_area (e.g. home widgets). */
+  function mcCollectGridProductCards() {
+    var sel =
+      '#content_area .v-product, #content_area_home .v-product, ' +
+      '.content_area-wrapper .v-product, [role="main"] .v-product, ' +
+      '.container--content .v-product';
+    var raw = document.querySelectorAll(sel);
+    var i;
+    var el;
+    var out = [];
+    /* Plain objects cannot key DOM nodes — all divs become "[object HTMLDivElement]" and only the first card was kept. */
+    var seen = new WeakSet();
+    function pushCard(node) {
+      if (!node || seen.has(node)) return;
+      if (node.closest && (node.closest('#footer') || node.closest('footer'))) return;
+
+      if (
+        node.closest &&
+        (
+          node.closest('#v65-product-parent') ||
+          node.closest('#related-products') ||
+          node.closest('#relateditems') ||
+          node.closest('table.relateditems') ||
+          node.closest('#related_products_content') ||
+          node.closest('#v65-product-related') ||
+          node.closest('.v65-product-related') ||
+          node.closest('.v65-product-related-item') ||
+          node.closest('.mc-related-carousel') ||
+          node.closest('.mc-related-carousel__viewport')
+        )
+      ) return;
+
+      seen.add(node);
+      out.push(node);
+    }
+
+    /*
+     * Volusion category PLP (e.g. /category-s/157.htm): nested table.v65-productDisplay — image row + separate title/price row.
+     * There is NO .v-product wrapper; member-grid paint must target each title <td> (a.productnamecolor, not productnamecolorsmall).
+     * When .v-product-grid exists, collect those first — nested v65 tables also appear on many PLPs (sort chrome, etc.); running
+     * the table branch first could return a tiny ineligible set and skip the real grid (regression after mc-product-page fix).
+     */
+    var onCategoryPlp =
+      (document.documentElement.classList.contains('category') || document.body.classList.contains('category')) &&
+      !document.body.classList.contains('productdetails') &&
+      !document.body.classList.contains('mc-product-page');
+    if (onCategoryPlp) {
+      var rawPlGrid = document.querySelectorAll(
+        '#content_area .v-product-grid .v-product, ' +
+          '#content_area .v-product-grid .v-product-grid-item, ' +
+          '#content_area ul.v-product-grid > li.v-product, ' +
+          '#content_area ul.v-product-grid > li.v-product-grid-item, ' +
+          '#content_area .v-product-grid li.v-product'
+      );
+      for (i = 0; i < rawPlGrid.length; i++) pushCard(rawPlGrid[i]);
+      if (out.length) return out;
+      raw = document.querySelectorAll('#content_area .v-product');
+      for (i = 0; i < raw.length; i++) pushCard(raw[i]);
+      if (out.length) return out;
+
+      var v65Grids = document.querySelectorAll('#content_area table.v65-productDisplay table.v65-productDisplay');
+      var gi;
+      for (gi = 0; gi < v65Grids.length; gi++) {
+        var v65g = v65Grids[gi];
+        if (v65g.closest && v65g.closest('#v65-product-related')) continue;
+        /* Volusion: title link is usually .productnamecolor; .colors_productname is not always present on loveseat PLP */
+        var nameAs = v65g.querySelectorAll('td a.productnamecolor');
+        if (!nameAs.length) {
+          nameAs = v65g.querySelectorAll('td a.colors_productname');
+        }
+        var na;
+        for (na = 0; na < nameAs.length; na++) {
+          var aNm = nameAs[na];
+          if (!aNm.classList || aNm.classList.contains('productnamecolorsmall')) continue;
+          var tdc = aNm.closest && aNm.closest('td');
+          if (tdc) pushCard(tdc);
+        }
+      }
+      if (out.length) return out;
+    }
+
+    /* Stationary Loveseats PLP: ul/div .v-product-grid when present (sidebar .v-product must not short-circuit first). */
+    var path157 =
+      /\/category-s\/157\.html?/i.test(location.pathname || '') ||
+      /\/stationary-loveseats-s\/157\.html?/i.test(location.pathname || '');
+    if (path157) {
+      var raw157 = document.querySelectorAll(
+        '#content_area .v-product-grid .v-product, ' +
+          '#content_area .v-product-grid .v-product-grid-item, ' +
+          '#content_area ul.v-product-grid > li.v-product, ' +
+          '#content_area ul.v-product-grid > li.v-product-grid-item, ' +
+          '#content_area .v-product-grid li.v-product'
+      );
+      for (i = 0; i < raw157.length; i++) pushCard(raw157[i]);
+      if (out.length) return out;
+    }
+
+    raw = document.querySelectorAll(sel);
+    for (i = 0; i < raw.length; i++) pushCard(raw[i]);
+    /* Related items: handled separately (image → title → price). Do not run PLP member-grid paint on these cells. */
+    if (out.length) return out;
+    if (mcIsLikelyListingPage()) {
+      raw = document.querySelectorAll('.v-product-grid .v-product, li.v-product');
+      for (i = 0; i < raw.length; i++) pushCard(raw[i]);
+    }
+    if (out.length) return out;
+    raw = document.querySelectorAll('.v-product-grid .v-product');
+    for (i = 0; i < raw.length; i++) pushCard(raw[i]);
+    return out;
+  }
+
+  /* MAP / teaser captions — match Volusion variants (case-insensitive) */
+  var MC_MAP_LINK_RE =
+    /add\s+to\s+cart\s+for\s+our\s+lowest\s+price|add\s+to\s+cart\s+for\s+the\s+lowest|our\s+lowest\s+price|add\s+to\s+cart\s+for\s+lowest|see\s+price\s+in\s+cart|click\s+for\s+price|call\s+for\s+price|call\s+for\s+pricing|add\s+to\s+cart\s+to\s+see/i;
+
+  function mcCardStillShowsMapPhrase(card) {
+    var t = (card.textContent || '').replace(/\s+/g, ' ');
+    return MC_MAP_LINK_RE.test(t);
+  }
+
+  function mcCloneCardSansMember(card) {
+    try {
+      var c = card.cloneNode(true);
+      var rm = c.querySelectorAll('.mc-member-grid-price');
+      var r;
+      for (r = 0; r < rm.length; r++) {
+        if (rm[r].parentNode) rm[r].parentNode.removeChild(rm[r]);
+      }
+      return c;
+    } catch (eC) {
+      return card;
+    }
+  }
+
+  function mcFormatMoneyShort(n) {
+    var v = Number(n);
+    if (!(v > 0)) return '';
+    if (typeof window.formatMcCurrency === 'function') return window.formatMcCurrency(v);
+    return '$' + v.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  }
+
+  /** List / MSRP / visible dollar on the card (Volusion often leaves this next to MAP). */
+  function mcExtractRegularPriceFromCard(card) {
+    var host = mcCloneCardSansMember(card);
+    var directBox = host.querySelector('.v-product__price, .product_price, .v65-product-related-price');
+    if (directBox) {
+      var dtxt = (directBox.textContent || '').replace(/\s+/g, ' ');
+      if (/\$[\d,]+/.test(dtxt) && !MC_MAP_LINK_RE.test(dtxt)) {
+        var dd0 = mcExtractDollarFromText(dtxt);
+        if (dd0) return dd0;
+      }
+    }
+    var el = host.querySelector('[itemprop="price"]');
+    if (el) {
+      var attr = el.getAttribute && el.getAttribute('content');
+      if (attr) {
+        var num = parseFloat(String(attr).replace(/[^0-9.]/g, ''));
+        if (num > 0) return mcFormatMoneyShort(num);
+      }
+      var d0 = mcExtractDollarFromText(el.textContent || '');
+      if (d0 && !MC_MAP_LINK_RE.test(el.textContent || '')) return d0;
+    }
+    var sels =
+      '.product_list_price, .listprice, [class*="list_price"], [class*="ListPrice"], .v65-product-price, .price_color, .formattedprice, span.price, .v-product__price .price';
+    var si;
+    for (si = 0; si < sels.split(', ').length; si++) {
+      var sel = sels.split(', ')[si];
+      var nodes = host.querySelectorAll(sel);
+      var nj;
+      for (nj = 0; nj < nodes.length; nj++) {
+        var tx = nodes[nj].textContent || '';
+        if (MC_MAP_LINK_RE.test(tx)) continue;
+        if (/lowest|add to cart for/i.test(tx)) continue;
+        var dol = mcExtractDollarFromText(tx);
+        if (dol) return dol;
+      }
+    }
+    var full = (host.textContent || '').replace(/\s+/g, ' ');
+    var parts = full.split(MC_MAP_LINK_RE);
+    if (parts[0]) {
+      var d1 = mcExtractDollarFromText(parts[0]);
+      if (d1) return d1;
+    }
+    var all = full.match(/\$[\d,]+(?:\.\d{2})?/g);
+    if (all && all.length === 1) return all[0];
+    if (all && all.length > 1) {
+      var pi;
+      for (pi = 0; pi < all.length; pi++) {
+        if (!MC_MAP_LINK_RE.test(all[pi])) return all[pi];
+      }
+      return all[0];
+    }
+    return '';
+  }
+
+  function mcGatherPriceLikeNodes(priceEl) {
+    var out = [];
+    if (!priceEl) return out;
+    var selfText = (priceEl.textContent || '').replace(/\s+/g, ' ').trim();
+    if (
+      priceEl.nodeType === 1 &&
+      (!priceEl.children || priceEl.children.length === 0) &&
+      /\$[\d,]+(?:\.\d{2})?/.test(selfText) &&
+      !MC_MAP_LINK_RE.test(selfText) &&
+      !/lowest|add to cart for our lowest/i.test(selfText)
+    ) {
+      if (!priceEl.closest || !priceEl.closest('.mc-member-grid-price')) {
+        out.push(priceEl.cloneNode(true));
+      }
+      return out;
+    }
+    var nodes = priceEl.querySelectorAll('span, div, del, s, b, strong, em, font, i, u, p, small');
+    var k;
+    for (k = 0; k < nodes.length; k++) {
+      var node = nodes[k];
+      if (node.closest && node.closest('.mc-member-grid-price')) continue;
+      var t = (node.textContent || '').replace(/\s+/g, ' ').trim();
+      if (!/\$[\d,]+(?:\.\d{2})?/.test(t)) continue;
+      if (t.length > 90) continue;
+      if (MC_MAP_LINK_RE.test(t) || /lowest|add to cart for our lowest/i.test(t)) continue;
+      out.push(node.cloneNode(true));
+    }
+    if (!out.length) {
+      var walk = priceEl.childNodes;
+      var wi;
+      for (wi = 0; wi < walk.length; wi++) {
+        var n = walk[wi];
+        if (n.nodeType !== 3) continue;
+        var tv = (n.nodeValue || '').replace(/\s+/g, ' ').trim();
+        if (!/\$[\d,]+(?:\.\d{2})?/.test(tv)) continue;
+        if (MC_MAP_LINK_RE.test(tv) || /lowest|add to cart for our lowest/i.test(tv)) continue;
+        var sp = document.createElement('span');
+        sp.className = 'mc-plp-preserve-text';
+        sp.textContent = tv;
+        out.push(sp);
+      }
+    }
+    return out;
+  }
+
+  function mcInstallInPriceContainer(priceEl, block) {
+    var tag = priceEl && priceEl.tagName ? priceEl.tagName.toUpperCase() : '';
+    if (tag === 'TD' || tag === 'TH') {
+      try {
+        var olds = priceEl.querySelectorAll('.mc-member-grid-price');
+        var oi;
+        for (oi = 0; oi < olds.length; oi++) {
+          try {
+            if (olds[oi] !== block && olds[oi].parentNode) olds[oi].parentNode.removeChild(olds[oi]);
+          } catch (eRmOld) {}
+        }
+      } catch (ePr) {}
+      try {
+        if (!priceEl.contains(block)) priceEl.appendChild(block);
+      } catch (eTd) {}
+      return;
+    }
+    try {
+      if (block && block.parentNode) block.parentNode.removeChild(block);
+    } catch (eDetBl) {}
+    var kept = mcGatherPriceLikeNodes(priceEl);
+    if (!kept.length && priceEl) {
+      var raw = (priceEl.textContent || '').replace(/\s+/g, ' ').trim();
+      var dol = mcExtractDollarFromText(raw);
+      if (dol && !MC_MAP_LINK_RE.test(raw) && !/lowest|add to cart for our lowest/i.test(raw)) {
+        var s = document.createElement('span');
+        s.className = 'mc-preserved-plp-price';
+        s.textContent = dol;
+        kept.push(s);
+      } else if (raw && /\$/.test(raw) && raw.length < 160 && !MC_MAP_LINK_RE.test(raw)) {
+        var s2 = document.createElement('span');
+        s2.className = 'mc-preserved-plp-price';
+        s2.textContent = raw;
+        kept.push(s2);
+      }
+    }
+    var i;
+    priceEl.innerHTML = '';
+    for (i = 0; i < kept.length; i++) priceEl.appendChild(kept[i]);
+    priceEl.appendChild(block);
+  }
+
+  function mcSwapMapElementsForBlock(card, block) {
+    var MAP_RE = MC_MAP_LINK_RE;
+    var k;
+    var as = card.querySelectorAll('a');
+    for (k = 0; k < as.length; k++) {
+      var a = as[k];
+      if (a.closest && a.closest('.mc-member-grid-price')) continue;
+      var ta = (a.textContent || '').replace(/\s+/g, ' ').trim();
+      if (!MAP_RE.test(ta) || ta.length > 140) continue;
+      a.parentNode.replaceChild(block, a);
+      return true;
+    }
+    var fonts = card.querySelectorAll('font');
+    for (k = 0; k < fonts.length; k++) {
+      var f = fonts[k];
+      if (f.closest && f.closest('.mc-member-grid-price')) continue;
+      var tf = (f.textContent || '').replace(/\s+/g, ' ').trim();
+      if (!MAP_RE.test(tf) || tf.length > 140) continue;
+      f.parentNode.replaceChild(block, f);
+      return true;
+    }
+    var spans = card.querySelectorAll('span');
+    for (k = 0; k < spans.length; k++) {
+      var sp = spans[k];
+      if (sp.closest && sp.closest('.mc-member-grid-price')) continue;
+      if (sp.children && sp.children.length) continue;
+      var ts = (sp.textContent || '').replace(/\s+/g, ' ').trim();
+      if (!MAP_RE.test(ts) || ts.length > 140) continue;
+      sp.parentNode.replaceChild(block, sp);
+      return true;
+    }
+    var bs = card.querySelectorAll('b, strong, p');
+    for (k = 0; k < bs.length; k++) {
+      var bx = bs[k];
+      if (bx.closest && bx.closest('.mc-member-grid-price')) continue;
+      if (bx.children && bx.children.length) continue;
+      var tb = (bx.textContent || '').replace(/\s+/g, ' ').trim();
+      if (!MAP_RE.test(tb) || tb.length > 140) continue;
+      bx.parentNode.replaceChild(block, bx);
+      return true;
+    }
+    /* Never replace <td>/<th>: a <div> cannot replace a table cell without destroying the row/column grid. */
+    return false;
+  }
+
+  function mcFindMapTextMount(card) {
+    try {
+      var walk = document.createTreeWalker(card, NodeFilter.SHOW_TEXT, null, false);
+      var n;
+      while ((n = walk.nextNode())) {
+        var v = n.nodeValue || '';
+        if (!MC_MAP_LINK_RE.test(v)) continue;
+        var p = n.parentNode;
+        if (p && p.nodeType === 1 && (!p.closest || !p.closest('.mc-member-grid-price'))) return p;
+      }
+    } catch (eW) {}
+    return null;
+  }
+
+  /**
+   * Volusion often puts MAP / "Add to cart for our lowest price" in a promo link or callout,
+   * not in .v-product__price — find the smallest matching node first, then fall back to price.
+   */
+  function mcFindCardPricingMount(card) {
+    var MAP_RE = MC_MAP_LINK_RE;
+    var quick = card.querySelector('.v-product__price, .product_price, .v65-product-related-price');
+    if (quick) {
+      var tq = (quick.textContent || '').replace(/\s+/g, ' ').trim();
+      if (/\$[\d,]+/.test(tq) && !MAP_RE.test(tq)) return quick;
+    }
+    var nodes = card.querySelectorAll('a, span, div, p, font, td, strong, em, li, b, i, u, label, small');
+    var best = null;
+    var bestLen = Infinity;
+    var i;
+    var el;
+    var t;
+    for (i = 0; i < nodes.length; i++) {
+      el = nodes[i];
+      if (el.closest && el.closest('.mc-member-grid-price')) continue;
+      t = (el.textContent || '').replace(/\s+/g, ' ').trim();
+      if (!MAP_RE.test(t)) continue;
+      if (t.length > 200) continue;
+      if (t.length < bestLen) {
+        bestLen = t.length;
+        best = el;
+      }
+    }
+    if (best) return best;
+    var byText = mcFindMapTextMount(card);
+    if (byText) return byText;
+    return (
+      card.querySelector('.v-product__price') ||
+      card.querySelector('.product_price') ||
+      card.querySelector('.v65-product-related-price') ||
+      card.querySelector('[itemprop="price"]')
+    );
+  }
+
+  /** Logged-in price restore — must stay in DOM after MAP anchor is replaced. */
+  function mcFindCardPriceContainerMount(card) {
+    if (!card || !card.querySelectorAll) return null;
+    var candidates = [
+      '.v-product__price',
+      '.product_price',
+      '.v65-product-related-price',
+      '.product_productprice',
+      '.product_saleprice',
+      '[class*="product_saleprice"]',
+      'font.colors_productprice',
+      'font.pricecolor.colors_productprice',
+      'font.pricecolor',
+      '[itemprop="price"]'
+    ];
+    var ci;
+    for (ci = 0; ci < candidates.length; ci++) {
+      var nodes = card.querySelectorAll(candidates[ci]);
+      var j;
+      for (j = 0; j < nodes.length; j++) {
+        var el = nodes[j];
+        if (el.closest && el.closest('.mc-member-grid-price')) continue;
+        var tx = (el.textContent || '').replace(/\s+/g, ' ').trim();
+        if (!/\$[\d,]+/.test(tx)) continue;
+        return el;
+      }
+    }
+    return null;
+  }
+
+  /** Narrow PLP price mount for visibility flash guard (image/title not hidden). */
+  function mcFindCardPriceWrapperForVisibility(card) {
+    if (!card || !card.querySelector) return null;
+    function pickNarrowPriceNode() {
+      return (
+        card.querySelector('.v-product__price') ||
+        card.querySelector('.product_price') ||
+        card.querySelector('.product_productprice') ||
+        card.querySelector('.product_saleprice') ||
+        card.querySelector('font.product_sale_price') ||
+        card.querySelector('.v65-product-related-price') ||
+        card.querySelector('[itemprop="price"]') ||
+        null
+      );
+    }
+    var w = mcFindCardPriceContainerMount(card) || mcFindCardPricingMount(card);
+    if (w) {
+      var tag = (w.tagName || '').toUpperCase();
+      var tooBroad =
+        w === card ||
+        tag === 'LI' ||
+        tag === 'UL' ||
+        tag === 'TR' ||
+        tag === 'TBODY' ||
+        tag === 'TABLE' ||
+        (w.querySelector && w.querySelector('img'));
+      if (!tooBroad) return w;
+    }
+    return pickNarrowPriceNode();
+  }
+  function mcCardUsesProductTileLayout(card) {
+    if (!card || !card.classList) return false;
+    return (
+      card.classList.contains('v-product') ||
+      card.classList.contains('v-product-grid-item')
+    );
+  }
+
+  function mcMarkCardPriceWrapperPending(card) {
+    if (!mcCardUsesProductTileLayout(card)) return;
+    var w = mcFindCardPriceWrapperForVisibility(card);
+    if (!w || !w.classList) return;
+    /* Avoid churn: repeated paints were removing mc-pricing-ready and re-adding pending on the same wrapper. */
+    if (w.classList.contains('mc-pricing-ready')) return;
+    try {
+      w.classList.remove('mc-pricing-ready');
+      w.classList.add('mc-pricing-pending');
+    } catch (eMpp) {}
+  }
+
+  function mcMarkCardPriceWrapperReady(card) {
+    if (!mcCardUsesProductTileLayout(card)) return;
+    var w = mcFindCardPriceWrapperForVisibility(card);
+    if (!w || !w.classList) return;
+    try {
+      w.classList.remove('mc-pricing-pending');
+      w.classList.add('mc-pricing-ready');
+    } catch (eMpr) {}
+  }
+
+  function mcExtractVolusionSalePriceFromCard(card) {
+    if (!card) return '';
+    var host = mcCloneCardSansMember(card);
+    var saleEl = host.querySelector(
+      'font.product_sale_price, .product_sale_price, .product_saleprice, [class*="product_sale_price"], [class*="product_saleprice"], span.product_sale_price'
+    );
+    if (saleEl) {
+      var sd = mcExtractDollarFromText(saleEl.textContent || '');
+      if (sd) return sd;
+    }
+    var full = (host.textContent || '').replace(/\s+/g, ' ');
+    var m = full.match(/\bsale\s*price\s*:?\s*(\$[\d,]+(?:\.\d{2})?)/i);
+    return m ? m[1] : '';
+  }
+  function mcExtractDollarFromText(txt) {
+    if (!txt) return '';
+    var m = String(txt).match(/\$[\d,]+(?:\.\d{2})?/);
+    return m ? m[0] : '';
+  }
+
+  function mcFmtCategoryPrice(n) {
+    if (typeof window.formatMcCurrency === 'function') return window.formatMcCurrency(n);
+    return '$' + Number(n || 0).toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  }
+
+  function mcFmtMoney(value) {
+    value = Number(value || 0);
+    if (!(value > 0)) return '';
+    return '$' + value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  }
+
+  function mcSetStableHtml(mount, html) {
+    if (!mount) return;
+    if (mount.getAttribute('data-mc-last-html') !== html) {
+      mount.innerHTML = html;
+      mount.setAttribute('data-mc-last-html', html);
+    }
+  }
+
+  function mcEnsureCardPriceMount(card) {
+    if (!card || !card.querySelector) return null;
+    var priceElPre = mcFindCardPricingMount(card);
+    var priceBox = priceElPre && priceElPre.closest && priceElPre.closest('.v-product__price');
+    var installTarget = priceBox || mcFindCardPriceContainerMount(card) || priceElPre;
+    if (!installTarget) {
+      installTarget =
+        card.querySelector('.v-product__price') ||
+        card.querySelector('.product_price') ||
+        card.querySelector('.v65-product-related-price') ||
+        card.querySelector('font.product_sale_price') ||
+        card.querySelector('.product_sale_price') ||
+        card.querySelector('.product_saleprice') ||
+        card.querySelector('font.price_color') ||
+        card.querySelector('.price_color') ||
+        card.querySelector('[class*="formattedprice"]') ||
+        card.querySelector('[itemprop="price"]');
+    }
+    if (!installTarget) return null;
+    var mount = null;
+    var child = installTarget.firstElementChild;
+    while (child) {
+      if (child.classList && child.classList.contains('mc-price-stack')) {
+        mount = child;
+        break;
+      }
+      child = child.nextElementSibling;
+    }
+    if (
+      !mount &&
+      installTarget.nextElementSibling &&
+      installTarget.nextElementSibling.classList &&
+      installTarget.nextElementSibling.classList.contains('mc-price-stack')
+    ) {
+      mount = installTarget.nextElementSibling;
+    }
+    if (!mount) {
+      mount = document.createElement('div');
+      mount.className = 'mc-price-stack';
+      try {
+        var tag = (installTarget.tagName || '').toUpperCase();
+        if ((tag === 'TD' || tag === 'TH') && installTarget.appendChild) {
+          installTarget.appendChild(mount);
+        } else if (installTarget.parentNode) {
+          if (installTarget.nextSibling) installTarget.parentNode.insertBefore(mount, installTarget.nextSibling);
+          else installTarget.parentNode.appendChild(mount);
+        } else if (installTarget.appendChild) {
+          installTarget.appendChild(mount);
+        }
+      } catch (eIns) {
+        try {
+          installTarget.appendChild(mount);
+        } catch (e2) {
+          return null;
+        }
+      }
+    }
+    return mount;
+  }
+
+function mcRenderUniformCardPricing(card, retailText, memberText, loginUrl, isLoggedIn) {
+    try {
+      if (!card || !card.querySelectorAll) return;
+
+      var customPrices = card.querySelectorAll(
+        '.mc-price-stack, .mc-member-grid-price, .mc-grid-regular-price'
+      );
+
+      var i;
+      for (i = 0; i < customPrices.length; i++) {
+        if (customPrices[i] && customPrices[i].parentNode) {
+          customPrices[i].parentNode.removeChild(customPrices[i]);
+        }
+      }
+
+      var nativePrices = card.querySelectorAll(
+        '.v-product__price, .product_price, .product_sale_price, .product_saleprice, font.product_sale_price, font.price_color, .price_color, [itemprop="price"]'
+      );
+
+      for (i = 0; i < nativePrices.length; i++) {
+        nativePrices[i].style.removeProperty('display');
+        nativePrices[i].style.removeProperty('visibility');
+        nativePrices[i].style.removeProperty('height');
+        nativePrices[i].style.removeProperty('max-height');
+        nativePrices[i].style.removeProperty('opacity');
+        nativePrices[i].style.removeProperty('overflow');
+        nativePrices[i].style.removeProperty('position');
+        nativePrices[i].style.removeProperty('left');
+        nativePrices[i].style.removeProperty('top');
+        nativePrices[i].style.removeProperty('float');
+        nativePrices[i].style.removeProperty('clear');
+        nativePrices[i].style.removeProperty('text-align');
+        nativePrices[i].style.removeProperty('line-height');
+        nativePrices[i].style.removeProperty('vertical-align');
+      }
+    } catch (eNativeVolusionPriceOnly) {}
+  }
+
+  function mcFindProductHref(card) {
+    var a =
+      card.querySelector('a[href*="ProductCode="]') ||
+      card.querySelector('a[href*="productcode="]') ||
+      card.querySelector('.v-product__name a, .productnamecolor a, a.v-product__link');
+    if (a && a.getAttribute('href') && !/^javascript:/i.test(a.getAttribute('href') || '')) return a.href;
+    var a2 = card.querySelector(
+      'a[href*="/p/"], a[href*="product.asp"], a[href*="ProductDetail"], a[href*="productdetails"], a[href*="p.asp"]'
+    );
+    if (a2 && a2.href) return a2.href;
+    var imgL = card.querySelector('a[href] img');
+    if (imgL && imgL.parentElement && imgL.parentElement.tagName === 'A') {
+      var ah = imgL.parentElement.getAttribute('href') || '';
+      if (ah && !/^javascript:/i.test(ah)) {
+        try {
+          return new URL(ah, window.location.origin).href;
+        } catch (eImgH) {}
+      }
+    }
+    return '';
+  }
+
+  /** Category id from a product or category URL (PLP card breadcrumbs, return links, etc.). */
+  function mcMemberGridParsedCategoryFromHref(href) {
+    if (!href) return null;
+    try {
+      var u = new URL(href, window.location.origin);
+      var path = (u.pathname || '').toLowerCase();
+      var mCat = path.match(/\/category-s\/(\d+)\.html?(?:[\?#]|$)/i);
+      if (mCat) return String(mCat[1]);
+      var mS = path.match(/-s\/(\d+)\.html?(?:[\?#]|$)/i);
+      if (mS) return String(mS[1]);
+      var idq =
+        u.searchParams.get('categoryid') ||
+        u.searchParams.get('category_id') ||
+        u.searchParams.get('c');
+      if (idq && /^\d+$/.test(String(idq).trim())) return String(idq).trim();
+    } catch (eHref) {}
+    return null;
+  }
+
+  function mcProductCodeFromHref(href) {
+    try {
+      var u = new URL(href, window.location.origin);
+      var c = u.searchParams.get('ProductCode') || u.searchParams.get('productcode');
+      return c ? String(c).trim() : '';
+    } catch (e) {
+      return '';
+    }
+  }
+
+  function mcCacheKeyForCategoryHref(href) {
+    var code = mcProductCodeFromHref(href);
+    if (code) return 'pc:' + code;
+    try {
+      var u = new URL(href, window.location.origin);
+      return 'path:' + u.pathname + u.search;
+    } catch (e2) {
+      return 'href:' + href;
+    }
+  }
+
+  /** Volusion `SalePrice` / saleprice field and visible sale row (from fetched PDP HTML). */
+  function mcExtractSalePriceFromPdpHtml(html) {
+    if (!html) return 0;
+    var pc = window.parseMcCurrency;
+    if (typeof pc !== 'function') return 0;
+    try {
+      var doc = new DOMParser().parseFromString(html, 'text/html');
+      var parent = doc.querySelector('#v65-product-parent') || doc.body;
+      var box = parent.querySelector('.colors_pricebox');
+      var searchRoot = box || parent;
+      var inputs = searchRoot.querySelectorAll('input, select, textarea');
+      var ii;
+      for (ii = 0; ii < inputs.length; ii++) {
+        var inp = inputs[ii];
+        var nm = ((inp.name || '') + ' ' + (inp.id || '')).toLowerCase().replace(/[^a-z0-9]/g, '');
+        if (nm.indexOf('saleprice') === -1) continue;
+        var val = pc(inp.value || inp.getAttribute('value') || '');
+        if (val > 0) return val;
+      }
+      if (box) {
+        var saleEl = box.querySelector(
+          '.product_sale_price, .product_sale_price b, font.product_sale_price, span.product_sale_price'
+        );
+        if (saleEl) {
+          var sp = pc(saleEl.textContent || '');
+          if (sp > 0) return sp;
+        }
+      }
+    } catch (eSale) {}
+    var patterns = [
+      /\bSalePrice\s*[=:]\s*['"]?\$?([\d,]+(?:\.\d+)?)/gi,
+      /\bwindow\.SalePrice\s*=\s*['"]?([\d,]+(?:\.\d+)?)/gi,
+      /["']SalePrice["']\s*:\s*["']?([\d,]+(?:\.\d+)?)/gi
+    ];
+    var pi;
+    for (pi = 0; pi < patterns.length; pi++) {
+      var r = patterns[pi];
+      var m;
+      r.lastIndex = 0;
+      while ((m = r.exec(html)) !== null) {
+        var p = pc(m[1]);
+        if (p > 0 && p < 50000000) return p;
+      }
+    }
+    return 0;
+  }
+
+  /** List / MSRP / main visible price on PDP when there is no SalePrice. */
+  function mcExtractRetailPriceFromPdpHtml(html) {
+    if (!html) return 0;
+    var pc = window.parseMcCurrency;
+    if (typeof pc !== 'function') return 0;
+    try {
+      var doc = new DOMParser().parseFromString(html, 'text/html');
+      var parent = doc.querySelector('#v65-product-parent') || doc.body;
+      var box = parent.querySelector('.colors_pricebox');
+      var searchRoot = box || parent;
+      var listEl = searchRoot.querySelector(
+        '.product_list_price, .product_list_price b, font.product_list_price, span.product_list_price, [class*="product_list_price"], .listprice'
+      );
+      if (listEl) {
+        var lp = pc(listEl.textContent || '');
+        if (lp > 0) return lp;
+      }
+      var inputs = searchRoot.querySelectorAll('input, select, textarea');
+      var ii;
+      for (ii = 0; ii < inputs.length; ii++) {
+        var inp = inputs[ii];
+        var nm = ((inp.name || '') + ' ' + (inp.id || '')).toLowerCase();
+        if (nm.indexOf('saleprice') !== -1) continue;
+        if (
+          nm.indexOf('listprice') === -1 &&
+          nm.indexOf('list_price') === -1 &&
+          nm.indexOf('productprice') === -1 &&
+          nm.indexOf('retail') === -1 &&
+          nm.indexOf('msrp') === -1
+        )
+          continue;
+        var val = pc(inp.value || inp.getAttribute('value') || '');
+        if (val > 0) return val;
+      }
+      var mainEl =
+        searchRoot.querySelector('#priceWithOptions, #priceWithOptionsNoTax') ||
+        searchRoot.querySelector('[itemprop="price"]');
+      if (mainEl) {
+        var ma = pc(
+          (mainEl.getAttribute && (mainEl.getAttribute('content') || mainEl.getAttribute('value'))) ||
+            mainEl.textContent ||
+            ''
+        );
+        if (ma > 0) return ma;
+      }
+    } catch (eRetail) {}
+    return 0;
+  }
+
+  function mcCachePdpSaleAmountFromDom() {
+    try {
+      if (window.__mcPdpSaleAmtCached > 0) return window.__mcPdpSaleAmtCached;
+      var amt = 0;
+      var pc = window.parseMcCurrency;
+      if (typeof pc === 'function') {
+        var nodes = document.querySelectorAll(
+          '#v65-product-parent input, #v65-product-parent textarea, #content_area input, #content_area textarea'
+        );
+        var ni;
+        for (ni = 0; ni < nodes.length; ni++) {
+          var inp = nodes[ni];
+          var nm = ((inp.name || '') + ' ' + (inp.id || '')).toLowerCase().replace(/[^a-z0-9]/g, '');
+          if (nm.indexOf('saleprice') === -1) continue;
+          amt = Number(pc(inp.value || inp.getAttribute('value') || '')) || 0;
+          if (amt > 0) break;
+        }
+      }
+      if (!(amt > 0)) amt = Number(mcExtractSalePriceFromPdpHtml(document.documentElement.innerHTML || '')) || 0;
+      if (amt > 0) window.__mcPdpSaleAmtCached = amt;
+      return amt;
+    } catch (eCacheSale) {
+      return 0;
+    }
+  }
+
+  function mcResolvePdpSaleAmount() {
+    var amt = Number(window.__mcPdpSaleAmtCached) || 0;
+    if (amt > 0) return amt;
+    amt = Number(mcCachePdpSaleAmountFromDom()) || 0;
+    if (amt > 0) return amt;
+    var pc = window.parseMcCurrency;
+    if (typeof pc !== 'function') return 0;
+    try {
+      var saleNode =
+        document.querySelector('#v65-product-parent .product_saleprice, #content_area .product_saleprice') ||
+        document.querySelector('#v65-product-parent .product_sale_price, #content_area .product_sale_price');
+      if (saleNode) amt = Number(pc(saleNode.textContent || '')) || 0;
+    } catch (eSaleDom) {}
+    if (amt > 0) {
+      window.__mcPdpSaleAmtCached = amt;
+      return amt;
+    }
+    try {
+      amt = Number(mcExtractSalePriceFromPdpHtml(document.documentElement.innerHTML || '')) || 0;
+    } catch (eSaleHtml) {}
+    if (amt > 0) window.__mcPdpSaleAmtCached = amt;
+    return amt;
+  }
+
+ function mcBuildPdpSaleLineHtml(saleAmt) {
+  return "";
+}
+
+  /** LOCKED canonical Palliser retail/member block — do not change structure in pricing fixes. */
+ function mcBuildCanonicalMemberPricingHtml(retailText, memberText, loginUrl, isLoggedIn) {
+  var retail = String(retailText || '').trim();
+  if (!retail) return '';
+
+  return (
+    '<div class="mc-pdp-retail-row mc-pdp-retail-row--regular-only">' +
+      '<div class="mc-pdp-retail-line">' +
+        '<span class="mc-pdp-stack-retail-amt">' + retail + '</span>' +
+      '</div>' +
+    '</div>'
+  );
+}
+function mcEnsurePdpPriceStack() {
+  var canonicalWrap = document.querySelector('.mc-pdp-member-pricing--canonical');  /*
+    Regular price only.
+    Do not force Retail/Member labels back into the custom PDP price stack.
+  */
+  if (canonicalWrap) {
+    try {
+      canonicalWrap.querySelectorAll(
+        '.mc-pdp-retail-label, .mc-pdp-member-line, .mc-pdp-member-line__label, .mc-pdp-member-line__amount, .mc-pdp-member-line--sale, .mc-pdp-sale-preview'
+      ).forEach(function (node) {
+        if (node && node.parentNode) node.parentNode.removeChild(node);
+      });
+
+      canonicalWrap.style.setProperty('display', 'block', 'important');
+      canonicalWrap.style.setProperty('visibility', 'visible', 'important');
+      canonicalWrap.style.setProperty('opacity', '1', 'important');
+      canonicalWrap.style.setProperty('height', 'auto', 'important');
+      canonicalWrap.style.setProperty('max-height', 'none', 'important');
+      canonicalWrap.style.setProperty('overflow', 'visible', 'important');
+
+      canonicalWrap.querySelectorAll('.mc-pdp-retail-row, .mc-pdp-retail-line, .mc-pdp-stack-retail-amt').forEach(function (row) {
+        row.style.removeProperty('display');
+        row.style.removeProperty('flex-direction');
+        row.style.removeProperty('align-items');
+        row.style.setProperty('visibility', 'visible', 'important');
+        row.style.setProperty('opacity', '1', 'important');
+        row.style.setProperty('height', 'auto', 'important');
+        row.style.setProperty('max-height', 'none', 'important');
+        row.style.setProperty('overflow', 'visible', 'important');
+      });
+    } catch (eCanonRegularOnly) {}
+
+    return true;
+  }
+
+  if (document.querySelector('.mc-pdp-member-row')) return true;
+
+  if (typeof window.mcIsPalliserProduct === 'function' && !window.mcIsPalliserProduct()) return false;
+
+  if (typeof window.mcForceRebuildCleanPriceStack === 'function') {
+    try {
+      window.mcForceRebuildCleanPriceStack();
+      return true;
+    } catch (eForce) {}
+  }
+
+  var wrap = document.querySelector('.mc-pdp-member-pricing');
+  var retailRow = document.querySelector('.mc-pdp-retail-row');
+
+  if (!wrap && !retailRow) return false;
+
+  try {
+    if (document.body) document.body.classList.add('mc-pdp-price-stack');
+  } catch (eCls) {}
+
+  /*
+    Logged-out Palliser PDPs must not surface live sale/member amounts
+    in the custom Retail/Member stack.
+  */
+  if (wrap) {
+    try {
+      wrap.querySelectorAll('.mc-pdp-member-line--sale, .mc-pdp-sale-preview').forEach(function (node) {
+        if (node && node.parentNode) node.parentNode.removeChild(node);
+      });
+    } catch (eRm) {}
+  }
+
+  if (!retailRow && typeof mcRenderRetailMemberOnPdp === 'function') {
+    try {
+      mcRenderRetailMemberOnPdp();
+    } catch (eRender) {}
+  }
+
+  try {
+    hideNativePdpSalePricing(document);
+    mcTidyMtlPriceBlock();
+    mcTidyPdpMemberPricing();
+    mcObservePdpPriceStackTidy();
+  } catch (eTidy) {}
+
+  return true;
+}
+
+  /** Member grid PDP fetch: SalePrice first, else retail; then legacy HowToGet / MAP scrapers. */
+  function mcExtractHowToGetFromPdpHtml(html) {
+    if (!html) return 0;
+    var sale = mcExtractSalePriceFromPdpHtml(html);
+    if (sale > 0) return sale;
+    var retail = mcExtractRetailPriceFromPdpHtml(html);
+    if (retail > 0) return retail;
+    var fn = window.extractVolusionAddToCartPriceFromHtml;
+    if (typeof fn === 'function') {
+      var v = fn(html);
+      if (v > 0) return v;
+    }
+    var mapAmt = 0;
+    try {
+      var doc = new DOMParser().parseFromString(html, 'text/html');
+      var mapEl = doc.querySelector('#priceWithOptions, [itemprop="price"], #priceWithOptionsNoTax');
+      if (mapEl && window.parseMcCurrency) {
+        mapAmt = window.parseMcCurrency(
+          (mapEl.getAttribute && (mapEl.getAttribute('content') || mapEl.getAttribute('value'))) ||
+            mapEl.textContent ||
+            ''
+        );
+      }
+    } catch (e1) {}
+    var fn2 = window.extractHowToGetSalePriceFromScripts;
+    if (typeof fn2 === 'function') {
+      var v2 = fn2(html, mapAmt, true);
+      if (v2 > 0) return v2;
+    }
+    return 0;
+  }
+
+  function mcEnsureAmountInMemberBlock(block, amountText) {
+    if (!block || !amountText) return;
+    if (block.getAttribute('data-mc-member-grid') === 'locked' || block.getAttribute('data-mc-guest-login') === '1') {
+      return;
+    }
+    var amt = block.querySelector('.mc-member-grid-price__amount');
+    if (!amt) {
+      amt = document.createElement('div');
+      amt.className = 'mc-member-grid-price__amount';
+      var label = block.querySelector('.mc-member-grid-price__label');
+      var hint = block.querySelector('.mc-member-grid-price__hint');
+      if (hint) {
+        block.insertBefore(amt, hint);
+      } else if (label) {
+        if (label.nextSibling) block.insertBefore(amt, label.nextSibling);
+        else block.appendChild(amt);
+      } else {
+        block.appendChild(amt);
+      }
+    }
+    amt.textContent = amountText;
+  }
+
+  function mcApplyHowToGetToAllCardsWithKey(cards, key, amt) {
+    if (!(amt > 0)) return;
+    var stHg = window.__mcMemberPricing || {};
+    if (!stHg.unlocked) return;
+    var txt = mcFmtCategoryPrice(amt);
+    var j;
+    for (j = 0; j < cards.length; j++) {
+      var c = cards[j];
+      var h = mcFindProductHref(c);
+      if (!h) continue;
+      if (mcCacheKeyForCategoryHref(h) !== key) continue;
+      var b = c.querySelector('.mc-member-grid-price');
+      if (b) {
+        mcEnsureAmountInMemberBlock(b, txt);
+      }
+    }
+  }
+
+  function mcHydrateCategoryHowToGetPrices() {
+    var stHyd = window.__mcMemberPricing || {};
+    if (!stHyd.unlocked) return;
+    var cards = mcCollectGridProductCards();
+    if (!cards.length) return;
+    var cache = (window.__mcCategoryHowToGetCache = window.__mcCategoryHowToGetCache || {});
+    var inflight = (window.__mcCategoryHowToGetInflight = window.__mcCategoryHowToGetInflight || {});
+    var queue = [];
+    var seenQ = {};
+    var ci;
+    for (ci = 0; ci < cards.length; ci++) {
+      var card = cards[ci];
+      var href = mcFindProductHref(card);
+      if (!href) continue;
+      var key = mcCacheKeyForCategoryHref(href);
+      if (cache[key] > 0) {
+        mcApplyHowToGetToAllCardsWithKey(cards, key, cache[key]);
+        continue;
+      }
+      if (cache[key] === 0) continue;
+      if (seenQ[key]) continue;
+      if (inflight[key]) continue;
+      seenQ[key] = true;
+      queue.push({ href: href, key: key });
+    }
+    if (!queue.length) return;
+
+    var maxConcurrent = 4;
+    var running = 0;
+    var qi = 0;
+
+    function pump() {
+      while (running < maxConcurrent && qi < queue.length) {
+        var item = queue[qi++];
+        var keyImmediate = item.key;
+        if (cache[keyImmediate] > 0 || cache[keyImmediate] === 0) continue;
+        if (inflight[keyImmediate]) continue;
+        inflight[keyImmediate] = true;
+        running++;
+        (function (href, key, cardsSnap) {
+          fetch(href, { credentials: 'same-origin', cache: 'no-store' })
+            .then(function (r) {
+              return r.text();
+            })
+            .then(function (html) {
+              return mcExtractHowToGetFromPdpHtml(html);
+            })
+            .then(function (amt) {
+              cache[key] = amt > 0 ? amt : 0;
+              if (amt > 0) mcApplyHowToGetToAllCardsWithKey(cardsSnap, key, amt);
+            })
+            .catch(function () {
+              cache[key] = 0;
+            })
+            .finally(function () {
+              delete inflight[key];
+              running--;
+              pump();
+            });
+        })(item.href, item.key, cards);
+      }
+    }
+    pump();
+  }
+
+  /** Keep at most one .mc-member-grid-price per listing card (idempotent repaints / nested install targets). */
+  function mcDedupeMemberGridBlocksInCard(card) {
+    if (!card || !card.querySelectorAll) return;
+    var all = Array.prototype.slice.call(card.querySelectorAll('.mc-member-grid-price, .mc-member-price'));
+    var roots = all.filter(function (n) {
+      var pi;
+      for (pi = 0; pi < all.length; pi++) {
+        var o = all[pi];
+        if (o !== n && o.contains(n)) return false;
+      }
+      return true;
+    });
+    if (roots.length > 1) {
+      var ri;
+      for (ri = 1; ri < roots.length; ri++) {
+        try {
+          if (roots[ri] && roots[ri].parentNode) roots[ri].parentNode.removeChild(roots[ri]);
+        } catch (eDed) {}
+      }
+    }
+  }
+
+  function mcRemoveMemberGridBlocks(card) {
+    if (!card || !card.querySelectorAll) return;
+    if (mcIsRelatedItemsNode(card)) return;
+    var blocks = card.querySelectorAll('.mc-member-grid-price');
+    var i;
+    for (i = 0; i < blocks.length; i++) {
+      try {
+        if (blocks[i] && blocks[i].parentNode) blocks[i].parentNode.removeChild(blocks[i]);
+      } catch (e) {}
+    }
+  }
+
+  /** Category 103 PLP only — skip McCabe member grid paint (list + sale only). Other categories unchanged. */
+  function mcPathLooksLikeCategory103Listing() {
+    try {
+      if (/\/category-s\/157\.htm/i.test(location.pathname || '')) {
+        return false;
+      }
+      if (/\/stationary-loveseats-s\/157\.htm/i.test(location.pathname || '')) {
+        return false;
+      }
+      var gq =
+        typeof window.mcGetQueryParamValue === 'function'
+          ? window.mcGetQueryParamValue
+          : function () {
+              return null;
+            };
+      var qs = window.location.search || '';
+      var path = (location.pathname || '').toLowerCase();
+      var listingCat =
+        typeof window.mcListingCategoryIdFromVolusion === 'function'
+          ? window.mcListingCategoryIdFromVolusion()
+          : null;
+      if (listingCat === '103') return true;
+      if (/(?:\?|&)cat=103(?:&|$)/i.test(qs)) return true;
+      var cid = gq('categoryid') || gq('category_id');
+      var cParam = gq('c');
+      if (cid === '103' || cParam === '103') return true;
+      if (/-s\/103\.html?(?:\?|#|$)/i.test(path)) return true;
+      if (!/product|productdetail|\/p\//i.test(path) && /\/103\.html?(?:\?|#|$)/i.test(path)) return true;
+      return false;
+    } catch (eCat103) {
+      return false;
+    }
+  }
+
+  function mcCardHasSalePricing(card) {
+    if (!card) return false;
+    var saleEl = card.querySelector(
+      'font.product_sale_price, .product_sale_price, .product_saleprice, [class*="product_sale_price"], [class*="product_saleprice"]'
+    );
+    if (!saleEl) return false;
+    var saleTxt = (saleEl.textContent || '').replace(/\s+/g, ' ').trim();
+    var saleAmt = mcExtractDollarFromText(saleTxt);
+    if (!saleAmt && !/\$/.test(saleTxt)) return false;
+    var listEl = card.querySelector(
+      'font.product_list_price, .product_list_price, [class*="product_list_price"]'
+    );
+    var listAmt = listEl ? mcExtractDollarFromText(listEl.textContent || '') : '';
+    if (listAmt && saleAmt && listAmt !== saleAmt) return true;
+    var box = card.querySelector('.v-product__price');
+    if (box) {
+      var dollars = (box.textContent || '').match(/\$[\d,]+(?:\.\d{2})?/g);
+      if (dollars && dollars.length >= 2) return true;
+    }
+    return /\bsale\s+price\b/i.test((card.textContent || '').replace(/\s+/g, ' '));
+  }
+
+  /** MAP callout may live in a div/span whose textContent still matches (split text nodes break mcFindMapTextMount). */
+  function mcFindSmallestMapElement(card) {
+    if (!card || !card.querySelectorAll) return null;
+    var nodes = card.querySelectorAll('a, span, div, p, font, strong, em, b, i, u, label, small');
+    var best = null;
+    var bestLen = Infinity;
+    var i;
+    for (i = 0; i < nodes.length; i++) {
+      var el = nodes[i];
+      if (el.closest && el.closest('.mc-member-grid-price')) continue;
+      if (el.querySelector && el.querySelector('img')) continue;
+      if (el.querySelector && el.querySelector('table')) continue;
+      var t = (el.textContent || '').replace(/\s+/g, ' ').trim();
+      if (!MC_MAP_LINK_RE.test(t) || t.length > 200) continue;
+      if (t.length >= bestLen) continue;
+      bestLen = t.length;
+      best = el;
+    }
+    return best;
+  }
+
+  function mcRemoveGuestSaleElements(card) {
+    if (!card || !card.querySelectorAll) return;
+    if (document.body.classList.contains('mc-member-logged-in')) return;
+    function isNarrowPriceNode(node) {
+      if (!node || !node.tagName) return false;
+      var t = node.tagName.toUpperCase();
+      if (t !== 'SPAN' && t !== 'FONT' && t !== 'B' && t !== 'STRONG' && t !== 'EM' && t !== 'SMALL') return false;
+      if (node.querySelector && node.querySelector('img, table, tr, td, th, .v-product, .productnamecolor, a[href*="-p/"]')) return false;
+      return true;
+    }
+    var rmSel =
+      'font.product_sale_price, .product_sale_price, .product_saleprice, [class*="product_sale_price"], [class*="product_saleprice"], span.product_sale_price, [class*="formatted_sale"], [class*="FormattedSale"]';
+    var nodes = card.querySelectorAll(rmSel);
+    var i;
+    for (i = 0; i < nodes.length; i++) {
+      var n = nodes[i];
+      if (n.closest && n.closest('.mc-member-grid-price')) continue;
+      if (!isNarrowPriceNode(n)) continue;
+      try {
+        n.style.setProperty('display', 'none', 'important');
+      } catch (eRs) {}
+    }
+    var labels = card.querySelectorAll('font, span, b, strong, em, small');
+    for (i = 0; i < labels.length; i++) {
+      var el = labels[i];
+      if (el.closest && el.closest('.mc-member-grid-price')) continue;
+      if (!isNarrowPriceNode(el)) continue;
+      var tx = (el.textContent || '').replace(/\s+/g, ' ').trim();
+      if (!/^sale\s*price/i.test(tx) && !/\bsale\s*price\s*:/i.test(tx)) continue;
+      if (tx.length > 100) continue;
+      try {
+        el.style.setProperty('display', 'none', 'important');
+      } catch (eR2) {}
+    }
+  }
+
+  function mcReplaceMapCalloutWithBlock(card, block) {
+    if (!card || !block) return false;
+    if (mcSwapMapElementsForBlock(card, block)) return true;
+    var mapEl = mcFindSmallestMapElement(card);
+    if (mapEl && mapEl.parentNode) {
+      var tag = mapEl.tagName ? mapEl.tagName.toUpperCase() : '';
+      if (tag !== 'TD' && tag !== 'TH') {
+        var mte = (mapEl.textContent || '').replace(/\s+/g, ' ').trim();
+        if (MC_MAP_LINK_RE.test(mte) && mte.length <= 200) {
+          try {
+            mapEl.parentNode.replaceChild(block, mapEl);
+            return true;
+          } catch (eRepSm) {}
+        }
+      }
+    }
+    var mapMount = mcFindMapTextMount(card);
+    if (
+      !mapMount ||
+      !mapMount.parentNode ||
+      (mapMount.closest && mapMount.closest('.mc-member-grid-price'))
+    ) {
+      return false;
+    }
+    var mt = (mapMount.textContent || '').replace(/\s+/g, ' ').trim();
+    if (!MC_MAP_LINK_RE.test(mt) || mt.length > 200) return false;
+    try {
+      mapMount.parentNode.replaceChild(block, mapMount);
+      return true;
+    } catch (eRep) {}
+    return false;
+  }
+
+  function mcIsPdpCardOrRelated(node) {
+    if (!node) return false;
+    return !!(
+      node.closest('#v65-product-parent') ||
+      node.closest('#related-products') ||
+      node.closest('.v65-product-related') ||
+      node.closest('.v65-product-related-item') ||
+      node.closest('.mc-related-carousel') ||
+      /\/product-p\//i.test(location.pathname || '')
+    );
+  }
+
+  /** PLP member-grid: category ids that override bean-only PLP handling (e.g. 157 nested-table layout). */
+  var MC_MEMBER_PRICING_GRID_CATEGORY_IDS = { 157: true, 139: true };
+
+  function mcMemberPricingGridListingEligible() {
+    if (typeof mcPathLooksLikeCategory103Listing === 'function' && mcPathLooksLikeCategory103Listing()) {
+      return false;
+    }
+    try {
+      var b = document.body;
+      if (!b || b.classList.contains('productdetails') || b.classList.contains('is-home')) return false;
+
+      var pagePath = (location.pathname || '').toLowerCase();
+      var lid = null;
+      try {
+        lid = typeof mcListingCategoryIdFromVolusion === 'function' ? mcListingCategoryIdFromVolusion() : null;
+      } catch (eLidEl) {}
+
+      if (lid === '103' || Number(lid) === 103) return false;
+      /* Any resolved listing category (except 103): card hrefs are /product-p/... and rarely carry category id. */
+      if (lid && /^\d+$/.test(String(lid))) return true;
+
+      if (/-s\/\d+\.html?/i.test(pagePath)) return true;
+
+      var h = document.documentElement;
+      var onCat = (h && h.classList.contains('category')) || b.classList.contains('category');
+      if (onCat) {
+        var ca = document.getElementById('content_area');
+        if (
+          ca &&
+          (ca.querySelector('ul.v-product-grid li') ||
+            ca.querySelector('.v-product-grid .v-product') ||
+            ca.querySelector('table.v65-productDisplay table.v65-productDisplay td a.productnamecolor'))
+        ) {
+          return true;
+        }
+      }
+    } catch (eMpgle) {}
+    return false;
+  }
+
+  function mcMemberPricingGridCardEligible(card) {
+    var pagePath = location.pathname || '';
+    var h = mcFindProductHref(card);
+    var pid = mcMemberGridParsedCategoryFromHref(h);
+    if (
+      pid === '157' ||
+      Number(pid) === 157 ||
+      /\/category-s\/157\.htm/i.test(pagePath) ||
+      /\/category-s\/157\.htm/i.test(h || '') ||
+      /\/category-s\/157\.html?/i.test(pagePath) ||
+      /\/category-s\/157\.html?/i.test(h || '')
+    ) {
+      return true;
+    }
+    if (/\/stationary-loveseats-s\/157\.htm/i.test(pagePath) || /\/stationary-loveseats-s\/157\.html?/i.test(pagePath))
+      return true;
+    if (
+      pid === '139' ||
+      Number(pid) === 139 ||
+      /\/sectionals-s\/139\.htm/i.test(pagePath) ||
+      /\/sectionals-s\/139\.html?/i.test(pagePath) ||
+      /\/sectionals-s\/139\.htm/i.test(h || '') ||
+      /\/sectionals-s\/139\.html?/i.test(h || '')
+    ) {
+      return true;
+    }
+    if (mcMemberPricingGridListingEligible()) return true;
+    if (/\/stationary-loveseats-s\/157\.htm/i.test(h || '') || /\/stationary-loveseats-s\/157\.html?/i.test(h || '')) return true;
+    if (pid && MC_MEMBER_PRICING_GRID_CATEGORY_IDS[pid]) return true;
+    return false;
+  }
+
+  function mcIsRelatedItemsNode(node) {
+    if (!node) return false;
+    return !!(
+      node.closest &&
+      (
+        node.closest('#related-products') ||
+        node.closest('#relateditems') ||
+        node.closest('table.relateditems') ||
+        node.closest('#related_products_content') ||
+        node.closest('#v65-product-related') ||
+        node.closest('.v65-product-related') ||
+        node.closest('.v65-product-related-item') ||
+        node.closest('.mc-related-carousel') ||
+        node.closest('.mc-related-carousel__viewport')
+      )
+    );
+  }
+
+  /** Bean bag category (103) skips member grid paint; still show PLP hint under title. */
+  function mcEnsureBeanBagPlpSubline(card) {
+    if (!card || !card.querySelector) return;
+    if (!mcPathLooksLikeCategory103Listing()) return;
+    var title =
+      card.querySelector('.v-product__name') ||
+      card.querySelector('.productnamecolor') ||
+      card.querySelector('h2') ||
+      card.querySelector('h3');
+    if (!title || !title.parentNode) return;
+    if (!card.querySelector('.mc-plp-bean-subline')) {
+      var sub = document.createElement('div');
+      sub.className = 'mc-plp-bean-subline';
+      sub.textContent = 'More sizes and colors available';
+      try {
+        title.parentNode.insertBefore(sub, title.nextSibling);
+      } catch (eBeanSub) {}
+    }
+    if (card.querySelector('.vol-free-shipping-icon')) return;
+    var price = card.querySelector('.v-product__price, .product_productprice');
+    if (!price || !price.parentNode) return;
+    var shipping = document.createElement('div');
+    shipping.className = 'vol-free-shipping-icon';
+    shipping.innerHTML = '<i class="icon-free-shipping"></i>';
+    try {
+      price.parentNode.insertBefore(shipping, price.nextSibling);
+    } catch (eBeanShipping) {}
+  }
+
+  var __mcMemberPlpPendingRevealToken = 0;
+
+  function mcPaintCategoryGridMemberPricing() {
+    var plpPathLow = (location.pathname || '').toLowerCase();
+    var on157MemberGatedPlp =
+      /\/category-s\/157\.html?/i.test(plpPathLow) || /\/stationary-loveseats-s\/157\.html?/i.test(plpPathLow);
+    try {
+      try {
+        if (typeof window.mcEnsureCategoryListingClasses === 'function') window.mcEnsureCategoryListingClasses();
+      } catch (eEnsCat) {}
+      /* Do not re-add mc-member-plp-price-pending here: mcPaint runs on a 350ms interval + observers.
+         Re-applying pending every pass hid all PLP prices repeatedly (visible → blank → visible flicker). */
+      var cat103NoMember = mcPathLooksLikeCategory103Listing();
+      try {
+        var _mcGridLid =
+          typeof mcListingCategoryIdFromVolusion === 'function' ? mcListingCategoryIdFromVolusion() : null;
+        if (
+          _mcGridLid &&
+          MC_MEMBER_PRICING_GRID_CATEGORY_IDS[_mcGridLid] &&
+          !(typeof mcPathLooksLikeCategory103Listing === 'function' && mcPathLooksLikeCategory103Listing())
+        ) {
+          cat103NoMember = false;
+        }
+      } catch (e157Grid) {}
+
+      /* Only drop html.mc-member-plp-price-pending after we have cards to paint; otherwise finally
+         used to fire on products.length===0 and revealed raw Volusion prices before member paint (flicker). */
+      var scheduleMemberPlpReveal = false;
+      var products = mcCollectGridProductCards();
+      if (cat103NoMember && !products.length) {
+        try {
+          var stray = document.querySelectorAll(
+            '#content_area .mc-member-grid-price, #content_area_home .mc-member-grid-price, [role="main"] .mc-member-grid-price'
+          );
+          var si;
+          for (si = 0; si < stray.length; si++) {
+            var blk = stray[si];
+            if (blk && blk.parentNode) blk.parentNode.removeChild(blk);
+          }
+        } catch (eStrayBean) {}
+      }
+      if (!products.length) {
+        return;
+      }
+      scheduleMemberPlpReveal = true;
+
+      if (typeof window !== 'undefined' && window.__MC_DEBUG_MEMBER_GRID) {
+        try {
+          var _mcDbgLid =
+            typeof mcListingCategoryIdFromVolusion === 'function' ? mcListingCategoryIdFromVolusion() : null;
+          console.log('[MC member pricing eligibility]', {
+            pathname: location.pathname,
+            parsedListingCategoryId: _mcDbgLid,
+            cat103NoMember: cat103NoMember,
+            listingEligible: mcMemberPricingGridListingEligible(),
+            productsLength: products.length
+          });
+        } catch (eDbgElig) {}
+      }
+
+      var st = window.__mcMemberPricing || {};
+      var unlocked = !!st.unlocked;
+      try {
+        if (unlocked) document.body.classList.add('mc-member-logged-in');
+        else document.body.classList.remove('mc-member-logged-in');
+        if (typeof window.mcSyncPalliserPdpBodyClasses === 'function') {
+          window.mcSyncPalliserPdpBodyClasses(unlocked);
+        }
+      } catch (eCls2) {}
+      try {
+        if (on157MemberGatedPlp && !unlocked) {
+          document.documentElement.classList.add('mc-cat157-plp-guest');
+        } else {
+          document.documentElement.classList.remove('mc-cat157-plp-guest');
+        }
+      } catch (e157Tok2) {}
+      var i;
+      for (i = 0; i < products.length; i++) {
+        var card = products[i];
+      var cardHref = mcFindProductHref(card);
+      var cardParsedCat = mcMemberGridParsedCategoryFromHref(cardHref);
+
+      if (mcIsRelatedItemsNode(card)) {
+        if (typeof window !== 'undefined' && window.__MC_DEBUG_MEMBER_GRID) {
+          console.log('[MC member pricing skipped card]', {
+            href: cardHref,
+            parsedCategoryId: cardParsedCat,
+            reason: 'related-items-node'
+          });
+        }
+        continue;
+      }
+      if (card.closest && card.closest('#relateditems, table.relateditems, #related_products_content')) {
+        if (typeof window !== 'undefined' && window.__MC_DEBUG_MEMBER_GRID) {
+          console.log('[MC member pricing skipped card]', {
+            href: cardHref,
+            parsedCategoryId: cardParsedCat,
+            reason: 'legacy-relateditems-selector'
+          });
+        }
+        continue;
+      }
+      if (cat103NoMember) {
+        if (typeof window !== 'undefined' && window.__MC_DEBUG_MEMBER_GRID) {
+          console.log('[MC member pricing skipped card]', {
+            href: cardHref,
+            parsedCategoryId: cardParsedCat,
+            reason: 'category-103-bean-plp'
+          });
+        }
+        mcRemoveMemberGridBlocks(card);
+        try {
+          card.removeAttribute('data-mc-member-grid');
+        } catch (eCat103Card) {}
+        try {
+          if (!mcIsPdpCardOrRelated(card)) {
+            mcEnsureBeanBagPlpSubline(card);
+          }
+        } catch (eBeanPl) {}
+        try {
+          mcMarkCardPriceWrapperReady(card);
+        } catch (e103Vis) {}
+        continue;
+      }
+      mcDedupeMemberGridBlocksInCard(card);
+      var regStr = mcExtractRegularPriceFromCard(card);
+      var retailAmt = parseFloat(String(regStr || '').replace(/[^0-9.]/g, '')) || 0;
+      if (!(retailAmt > 0)) {
+        var cloneTxt = (mcCloneCardSansMember(card).textContent || '').replace(/\s+/g, ' ');
+        var fallD = mcExtractDollarFromText(cloneTxt);
+        retailAmt = parseFloat(String(fallD || '').replace(/[^0-9.]/g, '')) || 0;
+      }
+      var memberStr = unlocked ? mcExtractVolusionSalePriceFromCard(card) : '';
+      var memberAmt = parseFloat(String(memberStr || '').replace(/[^0-9.]/g, '')) || 0;
+      if (unlocked && !(memberAmt > 0)) {
+        memberAmt =
+          parseFloat(
+            String(mcExtractDollarFromText(mcExtractVolusionSalePriceFromCard(card) || '') || '').replace(
+              /[^0-9.]/g,
+              ''
+            )
+          ) || 0;
+      }
+      if (!(retailAmt > 0) && unlocked && memberAmt > 0) {
+        retailAmt = memberAmt;
+      }
+      var retailText = mcFmtMoney(retailAmt);
+      if (!retailText) {
+        var anyD = mcExtractDollarFromText(
+          (mcCloneCardSansMember(card).textContent || '').replace(/\s+/g, ' ')
+        );
+        if (anyD && !MC_MAP_LINK_RE.test(card.textContent || '')) {
+          retailText = anyD;
+        }
+      }
+      var memberText = unlocked && memberAmt > 0 ? mcFmtMoney(memberAmt) : '';
+
+      mcRenderUniformCardPricing(card, retailText, memberText, window.getMemberLoginUrl(), unlocked);
+      try {
+        mcMarkCardPriceWrapperReady(card);
+      } catch (eRd) {}
+      card.setAttribute('data-mc-member-grid', unlocked ? 'unlocked' : 'locked');
+      try {
+        card.setAttribute('data-mc-priced', '1');
+        var stkPriced = card.querySelector('.mc-price-stack');
+        if (stkPriced) stkPriced.setAttribute('data-mc-priced', '1');
+      } catch (ePriced) {}
+    }
+    for (i = 0; i < products.length; i++) {
+      try {
+        if (mcIsRelatedItemsNode(products[i])) continue;
+        if (!mcIsPdpCardOrRelated(products[i])) {
+          if (cat103NoMember && !mcMemberPricingGridCardEligible(products[i])) {
+            mcEnsureBeanBagPlpSubline(products[i]);
+          }
+        }
+      } catch (eOrdAll) {}
+    }
+    for (i = 0; i < products.length; i++) {
+      try {
+        var cVis = products[i];
+        if (mcIsRelatedItemsNode(cVis)) continue;
+        if (cat103NoMember && !mcMemberPricingGridCardEligible(cVis)) continue;
+        mcMarkCardPriceWrapperReady(cVis);
+      } catch (eVisR) {}
+    }
+    try {
+      mcHydrateCategoryHowToGetPrices();
+    } catch (eHyd) {}
+    try {
+      if (typeof window.mcFixCategoryGrid === 'function') {
+        window.mcFixCategoryGrid();
+      }
+    } catch (eMcG) {}
+    } finally {
+      if (scheduleMemberPlpReveal) {
+        try {
+          var htmlPl = document.documentElement;
+          var revealTok = ++__mcMemberPlpPendingRevealToken;
+          var finishPlpFlash = function () {
+            if (revealTok !== __mcMemberPlpPendingRevealToken) return;
+            try {
+              if (typeof window.mcFixCategoryGrid === 'function') {
+                window.mcFixCategoryGrid();
+              }
+            } catch (eMcGf) {}
+            try {
+              htmlPl.classList.remove('mc-member-plp-price-pending');
+              htmlPl.classList.remove('mc-cat157-plp-pricing-pending');
+            } catch (e157Fn) {}
+          };
+          if (typeof window.requestAnimationFrame === 'function') {
+            window.requestAnimationFrame(function () {
+              window.requestAnimationFrame(function () {
+                window.requestAnimationFrame(finishPlpFlash);
+              });
+            });
+          } else {
+            setTimeout(finishPlpFlash, 48);
+          }
+        } catch (eDeferPl) {}
+      }
+    }
+  }
+  window.mcPaintCategoryGridMemberPricing = mcPaintCategoryGridMemberPricing;
+
+  function mcTidyMtlPriceBlock() {
+    var blocks = document.querySelectorAll(
+      "#v65-product-parent .mtl-product-price-block, #content_area .mtl-product-price-block, #v65-product-parent .colors_pricebox, #content_area .colors_pricebox, #v65-product-parent, #content_area"
+    );
+    var bi;
+    for (bi = 0; bi < blocks.length; bi++) {
+      var pb = blocks[bi];
+      if (!pb || !pb.querySelectorAll) continue;
+      pb.querySelectorAll(
+        ".product_sale_price, .product_saleprice, font.product_sale_price, [class*='product_sale_price'], [class*='product_saleprice']"
+      ).forEach(function (node) {
+        if (node.closest && node.closest(".mc-pdp-member-line--sale")) return;
+        node.style.setProperty("display", "none", "important");
+        node.style.setProperty("visibility", "hidden", "important");
+        node.style.setProperty("height", "0", "important");
+        node.style.setProperty("max-height", "0", "important");
+        node.style.setProperty("margin", "0", "important");
+        node.style.setProperty("padding", "0", "important");
+        node.style.setProperty("overflow", "hidden", "important");
+        node.style.setProperty("opacity", "0", "important");
+        node.style.setProperty("pointer-events", "none", "important");
+      });
+    }
+  }
+
+  function mcObservePdpPriceStackTidy() {
+    if (window.__mcPdpPriceTidyObs) return;
+    var target =
+      document.querySelector(".mtl-product-price-block") ||
+      document.querySelector("#v65-product-parent .colors_pricebox") ||
+      document.getElementById("v65-product-parent");
+    if (!target || typeof MutationObserver !== "function") return;
+    window.__mcPdpPriceTidyObs = new MutationObserver(function () {
+      try {
+        hideNativePdpSalePricing(document);
+        mcTidyMtlPriceBlock();
+        mcTidyPdpMemberPricing();
+      } catch (eObs) {}
+    });
+    window.__mcPdpPriceTidyObs.observe(target, { childList: true, subtree: true });
+  }
+
+  function mcTidyPdpMemberPricing() {
+    var wrap = document.querySelector(".mc-pdp-member-pricing");
+    if (!wrap) return;
+    if (wrap.querySelector(".mc-pdp-member-row") || wrap.classList.contains("mc-pdp-member-pricing--canonical")) {
+      return;
+    }
+    try {
+      wrap.querySelectorAll(
+        ".product_sale_price, .product_saleprice, font.product_sale_price, .mc-member-price-caption, .option_pricing"
+      ).forEach(function (node) {
+        if (node.closest && node.closest(".mc-pdp-member-line")) return;
+        node.style.setProperty("display", "none", "important");
+        node.style.setProperty("visibility", "hidden", "important");
+      });
+      wrap.querySelectorAll(".mc-pdp-member-line").forEach(function (line) {
+        line.style.setProperty("display", "flex", "important");
+        line.style.setProperty("flex-direction", "column", "important");
+        line.style.setProperty("align-items", "flex-start", "important");
+        line.style.setProperty("gap", "2px", "important");
+        line.style.setProperty("width", "100%", "important");
+        line.style.setProperty("position", "static", "important");
+      });
+      wrap.querySelectorAll(".mc-pdp-member-line__label").forEach(function (el) {
+        el.style.setProperty("display", "block", "important");
+        el.style.setProperty("letter-spacing", "0.16em", "important");
+        el.style.setProperty("white-space", "normal", "important");
+      });
+      wrap.querySelectorAll(".mc-pdp-member-line__amount, .mc-pdp-sale-preview").forEach(function (el) {
+        el.style.setProperty("display", "block", "important");
+        el.style.setProperty("letter-spacing", "0.02em", "important");
+        el.style.setProperty("white-space", "normal", "important");
+        el.style.setProperty("position", "static", "important");
+        el.style.setProperty("width", "100%", "important");
+      });
+    } catch (eTidyM) {}
+  }
+
+  function mcHideDuplicatePdpMemberFragments() {
+    var root = document.querySelector('#v65-product-parent');
+    if (!root) return;
+    if (!document.querySelector('.mc-pdp-member-pricing, .mc-pdp-retail-member')) return;
+    var nodes = root.querySelectorAll(
+      '.mc-member-price, .member-price, .members-price, .mc-member-price-row, .mc-member-price-wrap, .mc-member-price-caption'
+    );
+    var i;
+    for (i = 0; i < nodes.length; i++) {
+      var n = nodes[i];
+      if (!n) continue;
+      if (n.closest && n.closest('.mc-pdp-member-pricing')) continue;
+      try {
+        n.style.setProperty('display', 'none', 'important');
+      } catch (eH) {}
+    }
+  }
+
+  function mcRenderPdpRetailAndMember(retailText, memberText, loginUrl, isLoggedIn) {
+    if (typeof window.mcIsPalliserProduct === 'function' && !window.mcIsPalliserProduct()) return false;
+    if (typeof window.mcSyncPalliserPdpBodyClasses === 'function') window.mcSyncPalliserPdpBodyClasses(isLoggedIn);
+    if (document.getElementById('mc-pdp-top-price-panel')) {
+  return true;
+}
+    var retailDisplay = String(retailText || '').trim();
+    if (!retailDisplay) return false;
+
+    try {
+      if (document.body) document.body.classList.add('mc-pdp-price-stack');
+    } catch (eStackCls) {}
+
+    var priceBox =
+      document.querySelector('#v65-product-parent .colors_pricebox') ||
+      document.querySelector('#content_area .colors_pricebox');
+    var insertParent =
+      priceBox ||
+      document.querySelector('#v65-product-parent [itemprop="offers"]') ||
+      document.getElementById('v65-product-parent');
+    if (!insertParent) return false;
+
+    var wrap = document.querySelector('.mc-pdp-member-pricing');
+    if (!wrap) {
+      wrap = document.createElement('div');
+      wrap.className = 'mc-pdp-member-pricing mc-pdp-member-pricing--canonical';
+    } else if (!wrap.classList.contains('mc-pdp-member-pricing--canonical')) {
+      wrap.classList.add('mc-pdp-member-pricing--canonical');
+    }
+
+    if (wrap.parentNode !== insertParent) {
+      try {
+        if (priceBox) priceBox.insertBefore(wrap, priceBox.firstChild);
+        else insertParent.insertBefore(wrap, insertParent.firstChild);
+      } catch (eIns) {
+        insertParent.appendChild(wrap);
+      }
+    }
+
+    mcSetStableHtml(
+  wrap,
+  mcBuildCanonicalMemberPricingHtml(retailDisplay, memberText, loginUrl, isLoggedIn)
+);
+
+/* Regular price only: Retail/Member labels disabled */
+try {
+  wrap.querySelectorAll('.mc-pdp-retail-label, .mc-pdp-member-line, .mc-pdp-member-line__label, .mc-pdp-member-line__amount').forEach(function (el) {
+    if (el && el.parentNode) el.parentNode.removeChild(el);
+  });
+
+  wrap.style.setProperty('display', 'block', 'important');
+  wrap.style.setProperty('visibility', 'visible', 'important');
+  wrap.style.setProperty('height', 'auto', 'important');
+  wrap.style.setProperty('max-height', 'none', 'important');
+  wrap.style.setProperty('opacity', '1', 'important');
+  wrap.style.setProperty('overflow', 'visible', 'important');
+} catch (eRegularOnlyCanon) {}
+
+mcHideDuplicatePdpMemberFragments();
+return true;
+}
+  function mcHideOldPdpMemberFragmentsOnly() {
+    mcHideDuplicatePdpMemberFragments();
+  }
+
+  async function mcRenderRetailMemberOnPdp() {
+    if (typeof window.mcIsPalliserProduct === 'function' && !window.mcIsPalliserProduct()) return;
+    var root = document.querySelector('#v65-product-parent');
+    if (!root) return;
+
+    /* Paint retail label + member row from the live DOM before any await so the first paint
+       is not a bare Volusion price followed by labels after async session/fetch work. */
+    function mcPdpSyncLoggedInGuess() {
+      try {
+        if (document.body && document.body.classList.contains('mc-member-logged-in')) return true;
+      } catch (eG1) {}
+      try {
+        if (sessionStorage.getItem('mc_recent_member_auth')) return true;
+      } catch (eG2) {}
+      return false;
+    }
+    function mcPdpSyncRetailAmountFromDom() {
+  var amounts = [];
+
+  function addMoneyFromText(txt) {
+    if (typeof window.parseMcCurrency !== "function") return;
+    var matches = String(txt || "").match(/\$[\d,]+(?:\.\d{2})?/g);
+    if (!matches) return;
+
+    matches.forEach(function (m) {
+      var n = Number(window.parseMcCurrency(m)) || 0;
+      if (n > 0 && n < 50000000) amounts.push(n);
+    });
+  }
+
+  /*
+    Retail Price should be the native/list/highest amount,
+    NOT priceWithOptions / selected sale amount.
+    Titan example:
+      Retail/List = 4870
+      Selected/Sale = 3970
+  */
+  try {
+    var root =
+      document.querySelector("#v65-product-parent") ||
+      document.querySelector("#content_area") ||
+      document;
+
+    var box = root.querySelector(".colors_pricebox") || root;
+
+    box.querySelectorAll(
+      ".product_list_price, " +
+      "font.product_list_price, " +
+      "span.product_list_price, " +
+      "[class*='product_list_price'], " +
+      ".listprice, " +
+      "[class*='listprice'], " +
+      "[class*='retail'], " +
+      "[class*='msrp']"
+    ).forEach(function (el) {
+      addMoneyFromText(el.textContent || "");
+      try {
+        addMoneyFromText(el.getAttribute("content") || el.getAttribute("value") || "");
+      } catch (eAttr) {}
+    });
+
+    if (amounts.length) {
+      return Math.max.apply(Math, amounts);
+    }
+
+    /*
+      Fallback: scan the native price box text.
+      Do NOT use #priceWithOptions first because that is the selected/sale price.
+    */
+    addMoneyFromText(box.textContent || "");
+
+    if (amounts.length) {
+      return Math.max.apply(Math, amounts);
+    }
+  } catch (eRetailScan) {}
+
+  return 0;
+}
+    function mcPdpSyncMemberAmountFromDom() {
+      var amt = 0;
+      try {
+        amt = Number(mcExtractSalePriceFromPdpHtml(document.documentElement.innerHTML || '')) || 0;
+      } catch (eM0) {}
+      if (amt > 0) return amt;
+      try {
+        amt = Number(getVolusionAddToCartSeatPrice(document)) || 0;
+      } catch (eM1) {}
+      if (amt > 0) return amt;
+      if (typeof window.parseMcCurrency !== 'function') return 0;
+      try {
+        var saleNode =
+          document.querySelector('#priceWithOptions') ||
+          document.querySelector('#priceWithOptionsNoTax') ||
+          document.querySelector('#content_area .product_saleprice, #content_area .product_sale_price') ||
+          document.querySelector('#v65-product-parent .product_saleprice, #v65-product-parent .product_sale_price');
+        if (saleNode) {
+          amt =
+            Number(
+              window.parseMcCurrency(
+                (saleNode.getAttribute && (saleNode.getAttribute('value') || saleNode.getAttribute('content'))) ||
+                  saleNode.textContent ||
+                  ''
+              )
+            ) || 0;
+        }
+      } catch (eM2) {}
+      return amt;
+    }
+    var retailAmtSync = mcPdpSyncRetailAmountFromDom();
+    var retailTextSync = mcFmtMoney(retailAmtSync);
+    if (retailTextSync) {
+      try {
+        var loginUrlEarly =
+          typeof window.getMemberLoginUrl === 'function' ? window.getMemberLoginUrl() : '#';
+        var guessLoggedInEarly = mcPdpSyncLoggedInGuess();
+        var memberAmtEarly = guessLoggedInEarly ? mcPdpSyncMemberAmountFromDom() : 0;
+        var memberTextEarly =
+          guessLoggedInEarly && memberAmtEarly > 0 ? mcFmtMoney(memberAmtEarly) : '';
+        mcRenderPdpRetailAndMember(retailTextSync, memberTextEarly, loginUrlEarly, guessLoggedInEarly);
+      } catch (eEarlyPdp) {}
+    }
+
+ var st = null;
+var isLoggedIn = false;
+try {
+  st =
+    typeof window.detectMemberPricingState === 'function'
+      ? await window.detectMemberPricingState()
+      : typeof detectMemberPricingState === 'function'
+        ? await detectMemberPricingState()
+        : null;
+  isLoggedIn = !!(st && st.unlocked);
+} catch (e1) {}
+
+try {
+  if (!isLoggedIn && document.body && document.body.classList.contains('mc-member-logged-in')) {
+    isLoggedIn = true;
+  }
+} catch (eBody) {}
+
+try {
+  if (!isLoggedIn) {
+    var recentAuth = sessionStorage.getItem('mc_recent_member_auth');
+    if (recentAuth) isLoggedIn = true;
+  }
+} catch (eSess) {}
+
+try {
+  var liveAuth = await mcAuthSucceeded();
+  if (liveAuth) {
+    isLoggedIn = true;
+  }
+} catch (e1b) {}
+
+if (st) {
+  st.unlocked = isLoggedIn;
+}
+
+if (document.body) {
+  if (isLoggedIn) document.body.classList.add('mc-member-logged-in');
+  else document.body.classList.remove('mc-member-logged-in');
+}
+if (typeof window.mcSyncPalliserPdpBodyClasses === 'function') {
+  window.mcSyncPalliserPdpBodyClasses(isLoggedIn);
+}
+
+if (!isLoggedIn) {
+  mcLoginModalClearRecentAuth();
+}
+    var retailAmt = 0;
+    var memberAmt = 0;
+
+    try {
+      retailAmt = Number(mcExtractRetailPriceFromPdpHtml(document.documentElement.innerHTML || '')) || 0;
+    } catch (e2) {}
+    if (!(retailAmt > 0) && st && st.publicSeatPrice > 0) {
+      retailAmt = Number(st.publicSeatPrice) || 0;
+    }
+    if (!(retailAmt > 0)) {
+      try {
+        retailAmt = Number(getDisplayedPublicSeatPrice()) || 0;
+      } catch (e2b) {}
+    }
+
+    if (isLoggedIn) {
+      try {
+        var url = new URL(window.location.href);
+        url.searchParams.delete('CartID');
+        var resp = await fetch(url.pathname + url.search, { credentials: 'same-origin', cache: 'no-store' });
+        var html = await resp.text();
+
+        memberAmt = Number(mcExtractSalePriceFromPdpHtml(html)) || 0;
+        if (!(retailAmt > 0)) {
+          retailAmt = Number(mcExtractRetailPriceFromPdpHtml(html)) || 0;
+        }
+      } catch (e3) {}
+      if (!(memberAmt > 0) && st && st.memberSeatPrice > 0) {
+        memberAmt = Number(st.memberSeatPrice) || 0;
+      }
+      if (!(memberAmt > 0)) {
+        try {
+          memberAmt = Number(getVolusionAddToCartSeatPrice(document)) || 0;
+        } catch (e3b) {}
+      }
+      if (!(memberAmt > 0)) {
+        try {
+          var selectedPriceNode =
+            document.querySelector('#priceWithOptions') ||
+            document.querySelector('#priceWithOptionsNoTax') ||
+            document.querySelector('#content_area .product_saleprice, #content_area .product_sale_price') ||
+            document.querySelector('#v65-product-parent .product_saleprice, #v65-product-parent .product_sale_price');
+          if (selectedPriceNode && typeof window.parseMcCurrency === 'function') {
+            memberAmt = Number(
+              window.parseMcCurrency(
+                (selectedPriceNode.getAttribute && (selectedPriceNode.getAttribute('value') || selectedPriceNode.getAttribute('content'))) ||
+                selectedPriceNode.textContent ||
+                ''
+              )
+            ) || 0;
+          }
+        } catch (e3c) {}
+      }
+    }
+
+    var retailText = mcFmtMoney(retailAmt);
+    var memberText = isLoggedIn ? mcFmtMoney(memberAmt) : '';
+
+    if (!retailText) return;
+
+    mcRenderPdpRetailAndMember(retailText, memberText, window.getMemberLoginUrl(), isLoggedIn);
+ 
+}
+  function mcIsPdpLikePage() {
+    if (document.getElementById('v65-product-parent')) return true;
+    var p = (location.pathname || '').toLowerCase();
+    if (/\/product-p\//.test(p)) return true;
+    if (document.body && (document.body.classList.contains('productdetails') || document.body.classList.contains('mc-product-page'))) {
+      return true;
+    }
+    return /\.htm(?:\?|$)/i.test(p) && !!document.querySelector('.colors_pricebox, #v65-product-parent');
+  }
+
+ function mcBootPdpRetailMemberOnly() {
+  if (typeof window.mcPageType === 'function' && window.mcPageType() !== 'pdp' && !mcIsPdpLikePage()) return;
+  if (!mcIsPdpLikePage()) return;
+  if (window.__mcPdpRetailMemberBooted) return;
+
+  window.__mcPdpRetailMemberBooted = true;
+
+  function run() {
+    try {
+      mcCachePdpSaleAmountFromDom();
+      mcRenderRetailMemberOnPdp();
+      mcEnsurePdpPriceStack();
+    } catch (e) {}
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', run, { once: true });
+  } else {
+    run();
+  }
+
+  window.addEventListener('load', run);
+  window.addEventListener('mcMemberPricingReady', run);
+}
+  window.mcBootPdpRetailMemberOnly = mcBootPdpRetailMemberOnly;
+  window.mcRenderRetailMemberOnPdp = mcRenderRetailMemberOnPdp;
+  window.mcHideOldPdpMemberFragmentsOnly = mcHideOldPdpMemberFragmentsOnly;
+  window.mcHideDuplicatePdpMemberFragments = mcHideDuplicatePdpMemberFragments;
+  window.mcRenderPdpRetailAndMember = mcRenderPdpRetailAndMember;
+  window.mcBuildCanonicalMemberPricingHtml = mcBuildCanonicalMemberPricingHtml;
+  window.mcEnsurePdpPriceStack = mcEnsurePdpPriceStack;
+  window.mcResolvePdpSaleAmount = mcResolvePdpSaleAmount;
+  window.mcFmtMoney = mcFmtMoney;
+
+  function mcMarkMemberPlpPricesPendingEarly() {
+    return;
+  }
+
+  function mcBootCategoryGrid() {
+    if (window.__mcCategoryBootStarted) return;
+    window.__mcCategoryBootStarted = true;
+    if (typeof window.mcPageType === 'function' && window.mcPageType() !== 'category') return;
+
+    function runPaint(force) {
+      try {
+        if (typeof window.mcResolveVolusionSession === 'function') window.mcResolveVolusionSession();
+      } catch (e1) {}
+      if (!force) {
+        var unpriced = document.querySelector(
+          '#content_area .v-product:not([data-mc-priced="1"]), #content_area li.v-product:not([data-mc-priced="1"]), #content_area .mc-price-stack:not([data-mc-priced="1"])'
+        );
+        if (!unpriced) return;
+      }
+      try {
+        mcPaintCategoryGridMemberPricing();
+      } catch (e2) {}
+    }
+
+    if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', function () {
+    runPaint(true);
+  });
+} else {
+  runPaint(true);
+}
+
+window.addEventListener('load', function () {
+  runPaint(true);
+});
+
+window.addEventListener('mcMemberPricingReady', function () {
+  runPaint(true);
+});
+
+    if (window.__mcCategoryPriceObserver) {
+      try {
+        window.__mcCategoryPriceObserver.disconnect();
+      } catch (e3) {}
+    }
+
+    var gridRoot =
+      document.querySelector('#content_area .v-product-grid') ||
+      document.querySelector('#content_area') ||
+      document.body;
+
+    var debounceTimer = null;
+    window.__mcCategoryPriceObserver = new MutationObserver(function () {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(function () {
+        runPaint(false);
+      }, 120);
+    });
+
+    if (gridRoot) {
+      window.__mcCategoryPriceObserver.observe(gridRoot, { childList: true, subtree: true });
+    }
+  }
+  window.mcBootCategoryGrid = mcBootCategoryGrid;
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', mcBootCategoryGrid);
+  } else {
+    mcBootCategoryGrid();
+  }
+  window.mcPathLooksLikeCategory103Listing = mcPathLooksLikeCategory103Listing;
+  try {
+    mcBootPdpRetailMemberOnly();
+  } catch (ePdpRm) {}
+})();
+</script>
+
+<script>
+(function () {
+  var qs = window.location.search || '';
+  var isCategory103 =
+    (typeof window.mcPathLooksLikeCategory103Listing === 'function' && window.mcPathLooksLikeCategory103Listing()) ||
+    /(?:\?|&)cat=103(?:&|$)/i.test(qs);
+
+  if (!isCategory103) return;
+
+  document.documentElement.classList.add('mtl-cat103-no-member');
+
+  function cleanCategory103Pricing(root) {
+    root = root || document;
+
+    root.querySelectorAll(
+      [
+        '.member-price',
+        '.members-price',
+        '.memberPricing',
+        '.member-pricing',
+        '.price-member',
+        '.price_member',
+        '.product-member-price',
+        '.member-price-wrap',
+        '.member-pricing-wrap',
+        '.mtl-member-price',
+        '.mtl-member-badge',
+        '.mtl-member-savings',
+        '.login-for-price',
+        '.members-only-price',
+        '.mc-member-grid-price',
+        '.mc-member-grid-price__label',
+        '.mc-member-grid-price__amount',
+        '.mc-member-grid-price__hint',
+        '.mc-member-grid-price__login'
+      ].join(',')
+    ).forEach(function (el) {
+      el.remove();
+    });
+
+    root.querySelectorAll(
+      [
+        '.price',
+        '.product_price',
+        '.v65-productDisplay-price',
+        '.price_sale',
+        '.product_saleprice',
+        '.saleprice',
+        '.price-old',
+        '.oldprice',
+        '.product_retailprice',
+        '.listprice',
+        '.retailprice',
+        '.v-product__price',
+        'font.product_sale_price',
+        'font.product_list_price',
+        '.product_sale_price',
+        '.product_list_price'
+      ].join(',')
+    ).forEach(function (el) {
+      el.style.removeProperty('display');
+      el.style.removeProperty('visibility');
+      el.style.removeProperty('opacity');
+      el.hidden = false;
+      el.classList.remove('hide', 'hidden', 'is-hidden');
+    });
+
+    root.querySelectorAll('.price, .product_price, .v65-productDisplay-price, .v-product__price').forEach(function (el) {
+      if (el.closest && el.closest('.mc-pdp-member-pricing, .mc-member-grid-price')) return;
+      var html = el.innerHTML || '';
+      html = html.replace(/member price/gi, '');
+      html = html.replace(/members price/gi, '');
+      html = html.replace(/members-only price/gi, '');
+      html = html.replace(/login for price/gi, '');
+      html = html.replace(/log in to see member pricing/gi, '');
+      el.innerHTML = html;
+    });
+  }
+
+  cleanCategory103Pricing(document);
+
+  var mo = new MutationObserver(function (mutations) {
+    mutations.forEach(function (m) {
+      m.addedNodes.forEach(function (node) {
+        if (node && node.nodeType === 1) cleanCategory103Pricing(node);
+      });
+    });
+  });
+
+  mo.observe(document.body, { childList: true, subtree: true });
+})();
+</script>
+
+<style id="mc-final-mobile-layout-fixes">
+@media (max-width: 991px) {
+  /* 1) Homepage hero logo — smaller on phones/tablets; desktop unchanged (this query is mobile-only) */
+  body.is-home #slideshow-container .mc-hero-overlay .hero-logo-img,
+  #if_homepage #slideshow-container .mc-hero-overlay .hero-logo-img {
+    width: 68% !important;
+    max-width: min(400px, 92vw) !important;
+    height: auto !important;
+  }
+  body.is-home #slideshow-container .mc-hero-overlay .hero-logo-wrap,
+  #if_homepage #slideshow-container .mc-hero-overlay .hero-logo-wrap {
+    max-width: 96vw !important;
+  }
+
+  /* 2) Category grid — full product photo visible (contain, centered; no top crop) */
+  :is(html.category, body.category) .v-product-grid .v-product .v-product__img,
+  :is(html.category, body.category) .v-product-grid .v-product a.v-product__img,
+  :is(html.category, body.category) ul.v-product-grid > li.v-product .v-product__img {
+    height: 260px !important;
+    min-height: 260px !important;
+    max-height: 260px !important;
+    overflow: visible !important;
+    padding: 8px !important;
+    margin: 0 !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    background: #ffffff !important;
+    box-sizing: border-box !important;
+  }
+  :is(html.category, body.category) .v-product-grid .v-product .v-product__img img,
+  :is(html.category, body.category) .v-product-grid .v-product a.v-product__img > img,
+  :is(html.category, body.category) ul.v-product-grid > li.v-product .v-product__img img {
+    width: 100% !important;
+    height: 100% !important;
+    max-width: 100% !important;
+    max-height: 100% !important;
+    min-width: 0 !important;
+    min-height: 0 !important;
+    object-fit: contain !important;
+    object-position: center center !important;
+    margin: 0 auto !important;
+    border: 0 !important;
+  }
+  :is(html.category, body.category) .v-product-grid .v-product .v-product__name,
+  :is(html.category, body.category) .v-product-grid .v-product .productnamecolor,
+  :is(html.category, body.category) .v-product-grid .v-product h2,
+  :is(html.category, body.category) .v-product-grid .v-product h3,
+  :is(html.category, body.category) .v-product-grid .v-product h4 {
+    min-height: 0 !important;
+    margin-top: 3px !important;
+    margin-bottom: 0 !important;
+    padding-top: 0 !important;
+    align-items: flex-start !important;
+    justify-content: flex-start !important;
+    text-align: left !important;
+  }
+  :is(html.category, body.category) .v-product-grid .v-product {
+    gap: 0 !important;
+    row-gap: 0 !important;
+  }
+
+  /* 3) PDP — stop price / “price with options” overlapping alt thumbnails */
+  html body.productdetails #content_area #v65-product-parent [itemprop="offers"],
+  html body.mc-product-page #content_area #v65-product-parent [itemprop="offers"],
+  html body.productdetails #content_area [itemprop="offers"],
+  html body.mc-product-page #content_area [itemprop="offers"] {
+    margin-left: 0 !important;
+    margin-top: 16px !important;
+    clear: both !important;
+  }
+
+  html body.mc-product-page #content_area #altviews,
+  html body.productdetails #content_area #altviews,
+  html body.mc-product-page #content_area span#altviews,
+  html body.productdetails #content_area span#altviews,
+  html body.mc-product-page #v65-product-parent #altviews,
+  html body.productdetails #v65-product-parent #altviews,
+  html body.mc-product-page #v65-product-parent span#altviews,
+  html body.productdetails #v65-product-parent span#altviews {
+    display: flex !important;
+    flex-wrap: wrap !important;
+    justify-content: center !important;
+    align-items: flex-start !important;
+    margin: 8px 0 40px 0 !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    float: none !important;
+    clear: both !important;
+    box-sizing: border-box !important;
+  }
+
+  html body.mc-product-page #content_area .mc-pdp-options-td,
+  html body.productdetails #content_area .mc-pdp-options-td,
+  html body.mc-product-page #content_area td:has(.colors_pricebox),
+  html body.productdetails #content_area td:has(.colors_pricebox),
+  html body.mc-product-page #content_area td:has(#priceWithOptions),
+  html body.productdetails #content_area td:has(#priceWithOptions) {
+    padding-top: 24px !important;
+    margin-top: 16px !important;
+    clear: both !important;
+  }
+
+  /* Bean Bag mobile purchase column: its native table reserves the media-row
+     height even after the PDP controls are moved. Keep this correction local
+     to Bean Bag pages so other product layouts retain their own spacing. */
+  @media (max-width: 991px) {
+    html body.mc-bean-bag-pdp.mc-product-page #content_area .mc-pdp-options-td,
+    html body.mc-bean-bag-pdp.productdetails #content_area .mc-pdp-options-td,
+    html body.mc-bean-bag-pdp.mc-product-page #content_area td:has(.colors_pricebox),
+    html body.mc-bean-bag-pdp.productdetails #content_area td:has(.colors_pricebox),
+    html body.mc-bean-bag-pdp.mc-product-page #content_area td:has(#priceWithOptions),
+    html body.mc-bean-bag-pdp.productdetails #content_area td:has(#priceWithOptions) {
+      padding-top: 78px !important;
+      margin-top: -280px !important;
+    }
+  }
+
+  html body.mc-product-page #content_area table.colors_pricebox,
+  html body.productdetails #content_area table.colors_pricebox,
+  html body.mc-product-page #v65-product-parent table.colors_pricebox,
+  html body.productdetails #v65-product-parent table.colors_pricebox {
+    margin-top: 12px !important;
+    clear: both !important;
+    position: relative !important;
+    z-index: 2 !important;
+  }
+
+  html body.mc-product-page #content_area .option_pricing,
+  html body.productdetails #content_area .option_pricing,
+  html body.mc-product-page #v65-product-parent .option_pricing,
+  html body.productdetails #v65-product-parent .option_pricing,
+  html body.mc-product-page #content_area #priceWithOptions,
+  html body.productdetails #content_area #priceWithOptions,
+  html body.mc-product-page #v65-product-parent #priceWithOptions,
+  html body.productdetails #v65-product-parent #priceWithOptions {
+    margin-top: 18px !important;
+    clear: both !important;
+    position: relative !important;
+    z-index: 2 !important;
+  }
+}
+
+/* Category PLP thumbs: white stage + contain — see mc-category-grid-critical, custom-safe --mc-plp-*, ~15666 */
+
+:is(html.category, body.category) .v-product-grid .v-product .v-product__name,
+:is(html.category, body.category) .v-product-grid .v-product .productnamecolor,
+:is(html.category, body.category) .v-product-grid .v-product h2,
+:is(html.category, body.category) .v-product-grid .v-product h3,
+:is(html.category, body.category) .v-product-grid .v-product h4 {
+  min-height: 0 !important;
+  align-items: flex-start !important;
+  justify-content: flex-start !important;
+  text-align: left !important;
+  margin-top: 4px !important;
+}
+
+:is(html.category, body.category) .v-product-grid .v-product .v-product__price,
+:is(html.category, body.category) .v-product-grid .v-product .product_price,
+:is(html.category, body.category) .v-product-grid .v-product .mc-member-grid-price {
+  min-height: 0 !important;
+  text-align: left !important;
+  align-items: flex-start !important;
+  display: flex !important;
+  flex-direction: column !important;
+}
+</style>
+<!-- Last in document: wins over v/vspfiles/templates/266/css/template.css for category grid -->
+<style id="mc-category-grid-tail">
+@media (min-width: 992px) {
+  body:not(.productdetails) #content_area .v-product-grid {
+    display: grid !important;
+    grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+    gap: 20px !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    float: none !important;
+    clear: both !important;
+  }
+}
+@media (min-width: 576px) and (max-width: 991px) {
+  body:not(.productdetails) #content_area .v-product-grid {
+    display: grid !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    gap: 16px !important;
+    width: 100% !important;
+  }
+}
+@media (max-width: 575px) {
+  body:not(.productdetails) #content_area .v-product-grid {
+    display: grid !important;
+    grid-template-columns: minmax(0, 1fr) !important;
+    gap: 12px !important;
+  }
+}
+body:not(.productdetails) #content_area .v-product-grid > .v-product,
+body:not(.productdetails) #content_area ul.v-product-grid > li.v-product {
+  display: flex !important;
+  flex-direction: column !important;
+  width: 100% !important;
+  max-width: 100% !important;
+  min-width: 100% !important;
+  box-sizing: border-box !important;
+  float: none !important;
+}
+</style>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  function unwrapBadBoldAroundCards() {
+    document.querySelectorAll('.v-product').forEach(function (card) {
+      var p = card.parentElement;
+      while (p && p.tagName === 'B') {
+        var bad = p;
+        p = bad.parentNode;
+        while (bad.firstChild) {
+          p.insertBefore(bad.firstChild, bad);
+        }
+        p.removeChild(bad);
+      }
+    });
+  }
+
+  unwrapBadBoldAroundCards();
+  setTimeout(unwrapBadBoldAroundCards, 300);
+  setTimeout(unwrapBadBoldAroundCards, 1000);
+  setTimeout(unwrapBadBoldAroundCards, 2000);
+});
+</script>
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'9e598c4c0cafe88f',t:'MTc3NTA2Njk5OQ=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script>
+
+  <style>
+  .rh-fixed-pager{
+    display:flex !important;
+    justify-content:center !important;
+    align-items:center !important;
+    gap:14px !important;
+    margin:36px 0 28px !important;
+    padding:0 20px !important;
+    clear:both !important;
+    width:100% !important;
+    position:relative !important;
+    z-index:99999 !important;
+  }
+
+  .rh-fixed-pager-btn{
+    display:inline-flex !important;
+    align-items:center !important;
+    justify-content:center !important;
+    min-width:150px !important;
+    padding:14px 22px !important;
+    border:1px solid #d8d2c8 !important;
+    background:#fff !important;
+    color:#1f1f1f !important;
+    text-decoration:none !important;
+    font-family:Inter, Arial, sans-serif !important;
+    font-size:11px !important;
+    font-weight:500 !important;
+    letter-spacing:.18em !important;
+    text-transform:uppercase !important;
+    line-height:1 !important;
+    box-sizing:border-box !important;
+    transition:all .22s ease !important;
+    cursor:pointer !important;
+    pointer-events:auto !important;
+    position:relative !important;
+    z-index:99999 !important;
+  }
+
+  .rh-fixed-pager-btn:hover{
+    background:#1f1f1f !important;
+    color:#fff !important;
+    border-color:#1f1f1f !important;
+    text-decoration:none !important;
+  }
+
+  .rh-fixed-pager-btn.is-disabled{
+    opacity:.35 !important;
+    pointer-events:none !important;
+    cursor:default !important;
+  }
+
+  .rh-fixed-pager-divider{
+    width:28px !important;
+    height:1px !important;
+    background:#d8d2c8 !important;
+    flex:0 0 28px !important;
+  }
+
+  @media (max-width:767px){
+    .rh-fixed-pager{
+      gap:10px !important;
+      margin:26px 0 18px !important;
+      padding:0 14px !important;
+    }
+
+    .rh-fixed-pager-btn{
+      min-width:0 !important;
+      flex:1 1 0 !important;
+      padding:13px 14px !important;
+      font-size:10px !important;
+      letter-spacing:.16em !important;
+    }
+
+    .rh-fixed-pager-divider{
+      display:none !important;
+    }
+  }
+</style>
+
+
+
+<script>
+(function(){
+  if (window.__RH_PAGER_FINAL__) return;
+  window.__RH_PAGER_FINAL__ = true;
+
+  function removeOldPagers(){
+    ['.rh-fixed-pager', '.rh-native-pager', '.rh-cat-nav-wrap'].forEach(function(sel){
+      document.querySelectorAll(sel).forEach(function(el){ el.remove(); });
+    });
+  }
+
+  function getCurrentPage(){
+    var text = document.body.innerText || '';
+    var m = text.match(/Page\s+(\d+)\s+of\s+(\d+)/i);
+    if (m) return parseInt(m[1], 10) || 1;
+
+    var q = location.href.match(/[?&]page=(\d+)/i);
+    return q ? parseInt(q[1], 10) : 1;
+  }
+
+  function getTotalPages(){
+    var text = document.body.innerText || '';
+    var m = text.match(/Page\s+\d+\s+of\s+(\d+)/i) || text.match(/Page\s+of\s+(\d+)/i);
+    return m ? parseInt(m[1], 10) : 1;
+  }
+
+  function getPagerForm(){
+    return document.forms[1] || null;
+  }
+
+  function getPageInput(form){
+    if (!form) return null;
+
+    var inputs = Array.prototype.slice.call(
+      form.querySelectorAll('input[type="text"], input[type="number"], input:not([type])')
+    );
+
+    inputs = inputs.filter(function(input){
+      var style = window.getComputedStyle(input);
+      return style.display !== 'none' &&
+             style.visibility !== 'hidden' &&
+             input.offsetWidth > 0 &&
+             input.offsetHeight > 0;
+    });
+
+    return inputs.length ? inputs[inputs.length - 1] : null;
+  }
+
+  function getNativeNext(form){
+    if (!form) return null;
+    return form.querySelector('input[type="image"][src*="btn_nextpage"]');
+  }
+
+  function getNativePrev(form){
+    if (!form) return null;
+    return form.querySelector('input[type="image"][src*="btn_prevpage"]');
+  }
+
+  function submitPage(page){
+    var form = getPagerForm();
+    var input = getPageInput(form);
+
+    if (!form || !input) return false;
+
+    input.value = String(page);
+    input.setAttribute('value', String(page));
+    input.dispatchEvent(new Event('input', { bubbles:true }));
+    input.dispatchEvent(new Event('change', { bubbles:true }));
+
+    form.submit();
+    return true;
+  }
+
+  function goNext(){
+    var form = getPagerForm();
+    var nativeNext = getNativeNext(form);
+
+    if (nativeNext && typeof nativeNext.click === 'function'){
+      nativeNext.click();
+      return true;
+    }
+
+    return submitPage(getCurrentPage() + 1);
+  }
+
+  function goPrev(){
+    var form = getPagerForm();
+    var nativePrev = getNativePrev(form);
+
+    if (nativePrev && typeof nativePrev.click === 'function'){
+      nativePrev.click();
+      return true;
+    }
+
+    return submitPage(getCurrentPage() - 1);
+  }
+
+  function insertPager(){
+    removeOldPagers();
+
+    if (!/\/category-s\/\d+\.htm/i.test(location.pathname)) return;
+
+    var currentPage = getCurrentPage();
+    var totalPages = getTotalPages();
+
+    if (totalPages <= 1) return;
+
+    var wrap = document.createElement('div');
+    wrap.className = 'rh-fixed-pager';
+    wrap.id = 'rh-fixed-pager';
+
+    var prev = document.createElement('a');
+    prev.className = 'rh-fixed-pager-btn';
+    prev.textContent = 'Previous';
+    prev.href = '#';
+
+    var divider = document.createElement('div');
+    divider.className = 'rh-fixed-pager-divider';
+
+    var next = document.createElement('a');
+    next.className = 'rh-fixed-pager-btn';
+    next.textContent = 'Next';
+    next.href = '#';
+
+    if (currentPage <= 1){
+      prev.classList.add('is-disabled');
+      prev.removeAttribute('href');
+    } else {
+      prev.addEventListener('click', function(e){
+        e.preventDefault();
+        goPrev();
+      });
+    }
+
+    if (currentPage >= totalPages){
+      next.classList.add('is-disabled');
+      next.removeAttribute('href');
+    } else {
+      next.addEventListener('click', function(e){
+        e.preventDefault();
+        goNext();
+      });
+    }
+
+    wrap.appendChild(prev);
+    wrap.appendChild(divider);
+    wrap.appendChild(next);
+
+    var target =
+      document.querySelector('.category-footer') ||
+      document.querySelector('#content_area') ||
+      document.body;
+
+    if (target === document.body || target.id === 'content_area'){
+      target.appendChild(wrap);
+    } else {
+      target.parentNode.insertBefore(wrap, target.nextSibling);
+    }
+  }
+
+  function run(){
+    insertPager();
+  }
+
+  if (document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', run, { once:true });
+  } else {
+    run();
+  }
+
+  window.addEventListener('load', run, { once:true });
+})();
+</script>
+
+<script>
+(function(){
+  if (window.__MC_FINANCE_STABILIZER__) return;
+  window.__MC_FINANCE_STABILIZER__ = true;
+
+  function getOffersWrap(){
+    return (
+      document.querySelector('#v65-product-parent [itemprop="offers"]') ||
+      document.querySelector('#v65-product-parent #v65-productdetail-action-wrapper')
+    );
+  }
+
+  function stabilizeFinanceHeight(){
+    var wrap = getOffersWrap();
+    if (!wrap) return;
+
+    var h = wrap.offsetHeight || 0;
+    if (!h) return;
+
+    var saved = parseInt(wrap.dataset.mcStableMinHeight || '0', 10);
+    if (h > saved){
+      wrap.dataset.mcStableMinHeight = String(h);
+      wrap.style.minHeight = h + 'px';
+    } else if (saved > 0){
+      wrap.style.minHeight = saved + 'px';
+    }
+  }
+
+  function run(){
+    stabilizeFinanceHeight();
+  }
+
+  if (document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', run);
+  } else {
+    run();
+  }
+
+  window.addEventListener('load', function(){
+    run();
+    setTimeout(run, 250);
+    setTimeout(run, 700);
+    setTimeout(run, 1400);
+    setTimeout(run, 2200);
+  });
+
+  var obs = new MutationObserver(function(){
+    stabilizeFinanceHeight();
+  });
+
+  function startObs(){
+    var wrap = getOffersWrap();
+    if (!wrap) return;
+    obs.observe(wrap, {
+      childList:true,
+      subtree:true,
+      characterData:true
+    });
+  }
+
+  if (document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', startObs);
+  } else {
+    startObs();
+  }
+
+  window.addEventListener('load', startObs);
+})();
+</script>
+
+<script>
+(function () {
+  function ready(fn){
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', fn);
+    } else {
+      fn();
+    }
+  }
+
+  function isVertexPage(){
+    var txt = ((document.title || '') + ' ' + ((document.body && (document.body.innerText || document.body.textContent)) || '')).toLowerCase();
+    return txt.indexOf('vertex') !== -1;
+  }
+
+  ready(function () {
+    if (!isVertexPage()) return;
+
+    var tries = 0;
+
+    function collectVertexImages() {
+      var allImgs = Array.from(document.images);
+
+      var matches = allImgs.filter(function (img) {
+        var src = (img.currentSrc || img.src || '').toLowerCase();
+        return src.indexOf('/v/vspfiles/photos/customers/vertex') !== -1;
+      });
+
+      var seen = new Set();
+      var items = [];
+
+      matches.forEach(function (img) {
+        var src = (img.currentSrc || img.src || '').trim();
+        if (!src || seen.has(src)) return;
+        seen.add(src);
+
+        items.push({
+          img: img,
+          full: src,
+          thumb: src,
+          alt: img.alt || 'Vertex image'
+        });
+      });
+
+      return items;
+    }
+
+    function buildFlipbook(items) {
+      if (!items || items.length < 2) return false;
+      if (document.getElementById('vertex-replace-flipbook')) return true;
+
+      document.body.classList.add('vertex-flipbook-ready');
+
+      var firstImg = items[0].img;
+      var firstBlock = firstImg.closest('a, div, td, li, p') || firstImg.parentNode;
+      if (!firstBlock || !firstBlock.parentNode) return false;
+
+      var parent = firstBlock.parentNode;
+      var wrappers = [];
+      var started = false;
+
+      Array.from(parent.children).forEach(function (child) {
+        var hasVertexImg = child.querySelector && child.querySelector('img[src*="/v/vspfiles/photos/customers/vertex"], img[src*="/v/vspfiles/photos/customers/Vertex"]');
+        if (child === firstBlock || hasVertexImg) started = true;
+        if (started && hasVertexImg) wrappers.push(child);
+      });
+
+      if (!wrappers.length) {
+        wrappers = items.map(function (item) {
+          return item.img.closest('a, div, td, li, p') || item.img;
+        });
+      }
+
+      var flipWrap = document.createElement('section');
+      flipWrap.className = 'vertex-desc-flipbook-wrap';
+
+      var flip = document.createElement('div');
+      flip.id = 'vertex-replace-flipbook';
+
+      flip.innerHTML =
+        '<div class="vf-stage"></div>' +
+        '<div style="display:flex;align-items:center;justify-content:center;min-height:56px;padding:0 16px;border-top:1px solid #e9e6e1;background:#fff;position:relative;">' +
+          '<div class="vf-count">Image <span class="vf-current">1</span> / <span class="vf-total">' + items.length + '</span></div>' +
+          '<button type="button" class="vf-prev" aria-label="Previous image" style="appearance:none;border:0;background:transparent;color:#4f4a43;width:48px;height:56px;cursor:pointer;font-size:18px;line-height:1;position:absolute;left:0;top:0;">&#10094;</button>' +
+          '<button type="button" class="vf-next" aria-label="Next image" style="appearance:none;border:0;background:transparent;color:#4f4a43;width:48px;height:56px;cursor:pointer;font-size:18px;line-height:1;position:absolute;right:0;top:0;">&#10095;</button>' +
+        '</div>' +
+        '<div class="vf-thumbs" style="display:flex;gap:10px;padding:14px 14px 16px;border-top:1px solid #e9e6e1;background:#fff;overflow-x:auto;overflow-y:hidden;"></div>';
+
+      flipWrap.appendChild(flip);
+      wrappers[0].parentNode.insertBefore(flipWrap, wrappers[0]);
+
+      var stage = flip.querySelector('.vf-stage');
+      var thumbs = flip.querySelector('.vf-thumbs');
+      var currentEl = flip.querySelector('.vf-current');
+      var prevBtn = flip.querySelector('.vf-prev');
+      var nextBtn = flip.querySelector('.vf-next');
+
+      items.forEach(function (item, i) {
+        var slide = document.createElement('div');
+        slide.style.position = 'absolute';
+        slide.style.inset = '0';
+        slide.style.opacity = i === 0 ? '1' : '0';
+        slide.style.pointerEvents = i === 0 ? 'auto' : 'none';
+        slide.style.background = '#f6f4ef';
+        slide.style.zIndex = i === 0 ? '2' : '1';
+        slide.style.transition = 'opacity .22s ease';
+
+        var img = document.createElement('img');
+        img.src = item.full;
+        img.alt = item.alt;
+        img.loading = i === 0 ? 'eager' : 'lazy';
+        img.decoding = 'async';
+        img.style.width = '100%';
+        img.style.height = '100%';
+        img.style.objectFit = 'contain';
+        img.style.display = 'block';
+
+        slide.appendChild(img);
+        stage.appendChild(slide);
+
+        var thumb = document.createElement('button');
+        thumb.type = 'button';
+        thumb.setAttribute('data-index', i);
+        thumb.style.appearance = 'none';
+        thumb.style.border = i === 0 ? '1px solid #7c7468' : '1px solid transparent';
+        thumb.style.background = '#f6f4ef';
+        thumb.style.padding = '0';
+        thumb.style.cursor = 'pointer';
+        thumb.style.overflow = 'hidden';
+        thumb.style.flex = '0 0 78px';
+        thumb.style.width = '78px';
+
+        var thumbImg = document.createElement('img');
+        thumbImg.src = item.thumb;
+        thumbImg.alt = '';
+        thumbImg.loading = 'lazy';
+        thumbImg.style.width = '100%';
+        thumbImg.style.height = '78px';
+        thumbImg.style.objectFit = 'cover';
+        thumbImg.style.display = 'block';
+
+        thumb.appendChild(thumbImg);
+        thumbs.appendChild(thumb);
+      });
+
+      var slides = Array.from(stage.children);
+      var thumbButtons = Array.from(thumbs.querySelectorAll('button'));
+      var index = 0;
+
+      function goTo(i) {
+        index = (i + slides.length) % slides.length;
+
+        slides.forEach(function (slide, n) {
+          var active = n === index;
+          slide.style.opacity = active ? '1' : '0';
+          slide.style.pointerEvents = active ? 'auto' : 'none';
+          slide.style.zIndex = active ? '2' : '1';
+        });
+
+        thumbButtons.forEach(function (btn, n) {
+          btn.style.border = n === index ? '1px solid #7c7468' : '1px solid transparent';
+        });
+
+        currentEl.textContent = index + 1;
+      }
+
+      prevBtn.addEventListener('click', function () { goTo(index - 1); });
+      nextBtn.addEventListener('click', function () { goTo(index + 1); });
+
+      thumbButtons.forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          goTo(parseInt(btn.getAttribute('data-index'), 10));
+        });
+      });
+               items.forEach(function (item) {
+        var img = item.img;
+        if (!img || flip.contains(img)) return;
+
+        var wrap =
+          img.closest('a') ||
+          img.closest('p') ||
+          img.closest('li') ||
+          img.closest('div') ||
+          img.closest('td') ||
+          img.parentElement;
+
+        if (!wrap || flip.contains(wrap)) return;
+
+        var txt = ((wrap.innerText || wrap.textContent || '').replace(/\s+/g,' ').trim());
+        var imgCount = wrap.querySelectorAll('img').length;
+
+        if (imgCount === 1 && txt.length < 120) {
+          wrap.classList.add('vertex-original-desc-image-wrap');
+        } else {
+          img.classList.add('vertex-original-desc-image-wrap');
+        }
+      });
+                     
+      return true;
+    }
+
+    function boot() {
+      tries++;
+      var items = collectVertexImages();
+      if (buildFlipbook(items)) return;
+      if (tries < 30) setTimeout(boot, 400);
+    }
+
+    boot();
+  });
+})();
+</script>
+<style>
+body.vertex-flipbook-ready .vertex-desc-flipbook-wrap{
+  max-width:720px;
+  margin:18px auto 28px;
+}
+
+body.vertex-flipbook-ready #vertex-replace-flipbook{
+  position:relative;
+  background:#fff;
+  border:1px solid #e9e6e1;
+  overflow:hidden;
+}
+
+body.vertex-flipbook-ready #vertex-replace-flipbook .vf-stage{
+  position:relative;
+  aspect-ratio:1 / 1;
+  background:#f6f4ef;
+  overflow:hidden;
+}
+
+body.vertex-flipbook-ready #vertex-replace-flipbook .vf-count{
+  font-family:Inter, Arial, sans-serif;
+  font-size:11px;
+  line-height:1;
+  font-weight:500;
+  letter-spacing:.18em;
+  text-transform:uppercase;
+  color:#6e6a64;
+}
+
+body.vertex-flipbook-ready #vertex-replace-flipbook .vf-thumb-active{
+  border:1px solid #7c7468 !important;
+}
+
+body.vertex-flipbook-ready .vertex-original-desc-image-wrap{
+  display:none !important;
+}
+
+body.vertex-flipbook-ready img.vertex-original-desc-image-wrap{
+  display:none !important;
+}
+
+
+</style>
+
+<!-- Last stylesheet in document: must load after Volusion /a/c/vnav.css (injected mid-body) or layout fixes never win. -->
+<link rel="stylesheet" href="/v/vspfiles/templates/266/css/mccabe-overrides.css?v=20260520plp-mat" id="mc-mccabe-overrides-body-last" />
+<link rel="stylesheet" href="/v/vspfiles/css/mc-plp-body-last.css?v=20260706a" id="mc-plp-body-last-css" />
+<link rel="stylesheet" href="/v/vspfiles/css/mc-live-patch.css?v=20260521type" id="mc-live-patch-last" />
+
+<script id="mc-safe-final-qty-fix">
+(function () {
+  function root() {
+    return document.querySelector("#v65-product-parent") || document.querySelector("#content_area") || document;
+  }
+
+  function findQtyInput(r) {
+    return (
+      r.querySelector("#mc-surgical-qty-row input.v65-productdetail-cartqty") ||
+      r.querySelector("input.v65-productdetail-cartqty") ||
+      r.querySelector('input[name^="QTY."]') ||
+      r.querySelector('input[name="QTY"]') ||
+      r.querySelector('input[name="Qty"]') ||
+      r.querySelector('input[name="qty"]')
+    );
+  }
+
+  function findConfig(r) {
+    return r.querySelector("#mc-inline-config");
+  }
+
+  function findAddToCart(r) {
+    return (
+      r.querySelector('input[name="btnaddtocart"]') ||
+      r.querySelector("#btn_addtocart") ||
+      Array.from(r.querySelectorAll("input, button, a")).find(function (el) {
+        return /add\s*to\s*cart/i.test(String(el.value || el.textContent || ""));
+      })
+    );
+  }
+
+  function removeRawQtyTextOnly(scope, keepRow) {
+    if (!scope) return;
+
+    var walker = document.createTreeWalker(scope, NodeFilter.SHOW_TEXT);
+    var nodes = [];
+
+    while (walker.nextNode()) {
+      nodes.push(walker.currentNode);
+    }
+
+    nodes.forEach(function (node) {
+      if (keepRow && keepRow.contains(node.parentNode)) return;
+
+      var txt = String(node.nodeValue || "")
+        .replace(/[\u200b\uFEFF]/g, "")
+        .replace(/\u00a0/g, " ")
+        .replace(/\s+/g, " ")
+        .trim()
+        .toLowerCase();
+
+      if (txt === "quantity:" || txt === "quantity" || txt === "qty:" || txt === "qty") {
+        node.nodeValue = "";
+      }
+    });
+  }
+
+  function fixQty() {
+    if (
+      !document.body ||
+      (!document.body.classList.contains("mc-theater-seating-pdp") &&
+        !document.documentElement.classList.contains("mc-paragon-pdp"))
+    ) {
+      return;
+    }
+    var r = root();
+    var qty = findQtyInput(r);
+    var config = findConfig(r);
+    var add = findAddToCart(r);
+
+    if (!qty || !config || !add) return;
+
+    var scope =
+      config.closest(".mc-pdp-options-td") ||
+      qty.closest(".mc-pdp-options-td") ||
+      add.closest(".mc-pdp-options-td") ||
+      config.closest("td") ||
+      qty.closest("td") ||
+      add.closest("td") ||
+      r;
+
+    var row = document.getElementById("mc-surgical-qty-row");
+
+    if (!row) {
+      row = document.createElement("div");
+      row.id = "mc-surgical-qty-row";
+    }
+
+    row.innerHTML = "quantity:";
+
+    var label = document.createElement("label");
+    label.textContent = "";
+
+    if (!qty.id) qty.id = "mc-real-product-qty";
+    label.setAttribute("for", qty.id);
+
+    row.appendChild(label);
+    row.appendChild(qty);
+
+    removeRawQtyTextOnly(scope, row);
+
+    config.insertAdjacentElement("afterend", row);
+
+    var addBlock =
+      add.closest("tr") ||
+      add.closest("td") ||
+      add.closest("div") ||
+      add.parentElement;
+
+    if (addBlock && addBlock.parentNode === row.parentNode) {
+      row.parentNode.insertBefore(addBlock, row.nextSibling);
+    }
+
+    config.style.setProperty("display", "block", "important");
+    config.style.setProperty("width", "100%", "important");
+    config.style.setProperty("max-width", "420px", "important");
+    config.style.setProperty("margin", "12px auto 12px", "important");
+    config.style.setProperty("clear", "both", "important");
+    config.style.setProperty("float", "none", "important");
+
+    row.style.setProperty("display", "flex", "important");
+    row.style.setProperty("align-items", "center", "important");
+    row.style.setProperty("justify-content", "center", "important");
+    row.style.setProperty("gap", "10px", "important");
+    row.style.setProperty("width", "100%", "important");
+    row.style.setProperty("max-width", "320px", "important");
+    row.style.setProperty("margin", "10px auto 18px", "important");
+    row.style.setProperty("clear", "both", "important");
+    row.style.setProperty("float", "none", "important");
+
+    label.style.setProperty("display", "inline-flex", "important");
+    label.style.setProperty("align-items", "center", "important");
+    label.style.setProperty("width", "auto", "important");
+    label.style.setProperty("margin", "0", "important");
+    label.style.setProperty("font-family", "Inter, Arial, sans-serif", "important");
+    label.style.setProperty("font-size", "11px", "important");
+    label.style.setProperty("font-weight", "400", "important");
+    label.style.setProperty("letter-spacing", ".16em", "important");
+    label.style.setProperty("text-transform", "uppercase", "important");
+    label.style.setProperty("white-space", "nowrap", "important");
+
+    qty.style.setProperty("display", "inline-block", "important");
+    qty.style.setProperty("visibility", "visible", "important");
+    qty.style.setProperty("opacity", "1", "important");
+    qty.style.setProperty("width", "58px", "important");
+    qty.style.setProperty("height", "36px", "important");
+    qty.style.setProperty("margin", "0", "important");
+    qty.style.setProperty("text-align", "center", "important");
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", fixQty);
+  } else {
+    fixQty();
+  }
+
+  window.addEventListener("load", function () {
+    fixQty();
+    setTimeout(fixQty, 300);
+    setTimeout(fixQty, 900);
+  });
+})();
+</script>
+
+<script id="mc-remove-all-quantity-final">
+(function () {
+  function mcDomCleanQuantityPlannerBillable() {
+    try {
+      if (typeof window.mcGetPlannerBillableQty === "function") {
+        var w = Number(window.mcGetPlannerBillableQty() || 0);
+        if (w > 0) return w;
+      }
+    } catch (eW) {}
+    if (!window.__mcPlannerConfigApplied) return 0;
+    var calc = window.mccabeRoomPlannerPriceCalc || {};
+    var n =
+      Number(calc.effectiveSeats) ||
+      Number(calc.billableSeats) ||
+      Number(calc.seats) ||
+      0;
+    if (n > 0) return n;
+    var data = window.__mcLastPlannerPayload;
+    if (data && Number(data.seatCount) > 0) return Number(data.seatCount);
+    if (data && data.options && typeof data.options === "object") {
+      var total = 0;
+      Object.keys(data.options).forEach(function (key) {
+        var q = Number(data.options[key] || 0);
+        if (!q) return;
+        var id = String(key).toUpperCase();
+        total += id === "4L" ? q * 2 : q;
+      });
+      if (total > 0) return total;
+    }
+    return 0;
+  }
+
+  function cleanQuantity() {
+    if (
+      document.body &&
+      (document.body.classList.contains("mc-theater-seating-pdp") ||
+        document.documentElement.classList.contains("mc-paragon-pdp"))
+    ) {
+      /* Theater / Paragon: keep planner-driven qty hidden. */
+    } else {
+      return;
+    }
+    var root =
+      document.querySelector("#v65-product-parent") ||
+      document.querySelector("#content_area") ||
+      document;
+
+    var qtyInputs = Array.from(root.querySelectorAll(
+      'input.v65-productdetail-cartqty, input[name^="QTY."], input[name="QTY"], input[name="Qty"], input[name="qty"]'
+    ));
+
+    qtyInputs.forEach(function (input) {
+      var bill = mcDomCleanQuantityPlannerBillable();
+      var v = bill > 0 ? bill : 1;
+      input.value = String(v);
+      input.setAttribute("value", String(v));
+      input.style.setProperty("display", "none", "important");
+      input.style.setProperty("visibility", "hidden", "important");
+      input.style.setProperty("opacity", "0", "important");
+      input.style.setProperty("height", "0", "important");
+      input.style.setProperty("width", "0", "important");
+
+      var parent = input.parentElement;
+      if (parent && parent.id && /qty|quantity/i.test(parent.id)) {
+        parent.style.setProperty("display", "none", "important");
+      }
+    });
+
+    Array.from(root.querySelectorAll("#mc-surgical-qty-row, #mc-final-qty-row, #mc-simple-final-qty-row")).forEach(function (el) {
+      el.style.setProperty("display", "none", "important");
+      el.style.setProperty("visibility", "hidden", "important");
+      el.style.setProperty("height", "0", "important");
+      el.style.setProperty("margin", "0", "important");
+      el.style.setProperty("padding", "0", "important");
+    });
+
+    var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    var nodes = [];
+
+    while (walker.nextNode()) nodes.push(walker.currentNode);
+
+    nodes.forEach(function (node) {
+      var txt = String(node.nodeValue || "")
+        .replace(/[\u200b\uFEFF]/g, "")
+        .replace(/\u00a0/g, " ")
+        .replace(/\s+/g, " ")
+        .trim()
+        .toLowerCase();
+
+      if (txt === "quantity:" || txt === "quantity" || txt === "qty:" || txt === "qty") {
+        node.nodeValue = "";
+      }
+    });
+
+    Array.from(root.querySelectorAll("label, span, div, p, td")).forEach(function (el) {
+      if (el.querySelector("input, button, a, select, textarea, #mc-inline-config")) return;
+
+      var txt = String(el.textContent || "")
+        .replace(/[\u200b\uFEFF]/g, "")
+        .replace(/\u00a0/g, " ")
+        .replace(/\s+/g, " ")
+        .trim()
+        .toLowerCase();
+
+      if (txt === "quantity:" || txt === "quantity" || txt === "qty:" || txt === "qty") {
+        el.style.setProperty("display", "none", "important");
+        el.setAttribute("aria-hidden", "true");
+      }
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", cleanQuantity);
+  } else {
+    cleanQuantity();
+  }
+
+  window.addEventListener("load", function () {
+    cleanQuantity();
+    setTimeout(cleanQuantity, 250);
+    setTimeout(cleanQuantity, 750);
+    setTimeout(cleanQuantity, 1500);
+  });
+})();
+</script>
+<style id="mc-search-final-position-lines-fix">
+  #mcHeroSearchOverlay,
+  #mcHeroSearchOverlay *,
+  .mc-hero-search-overlay,
+  .mc-hero-search-overlay * {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    height: 0 !important;
+    max-height: 0 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    border: 0 !important;
+    border-bottom: 0 !important;
+    box-shadow: none !important;
+    pointer-events: none !important;
+    overflow: hidden !important;
+  }
+
+  header.header .mc-header-search-cart-wrap,
+  header.header .mc-header-search-below-nav,
+  header.header .header__section--middle,
+  header.header .collapsing-search,
+  header.header #collapsingSearch,
+  header.header .collapsing-search__form,
+  header.header .collapsing-search__form .container,
+  header.header .collapsing-search__form .row {
+    border: 0 !important;
+    border-bottom: 0 !important;
+    box-shadow: none !important;
+    background-image: none !important;
+  }
+
+  header.header .mc-header-search-cart-wrap label,
+  header.header .mc-header-search-cart-wrap .collapsing-search__label,
+  header.header .mc-header-search-cart-wrap .search-label {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+  }
+
+  @media (min-width: 992px) {
+    html.mc-search-open header.header .mc-header-search-cart-wrap,
+    body.mc-search-open header.header .mc-header-search-cart-wrap {
+      display: flex !important;
+      position: fixed !important;
+      top: 52px !important;
+      right: 140px !important;
+      left: auto !important;
+      width: 460px !important;
+      max-width: calc(100vw - 180px) !important;
+      min-height: 64px !important;
+      height: auto !important;
+      padding: 14px 18px !important;
+      background: #fff !important;
+      border: 0 !important;
+      border-bottom: 0 !important;
+      border-radius: 4px !important;
+      box-shadow: 0 10px 34px rgba(0,0,0,.16) !important;
+      align-items: center !important;
+      justify-content: center !important;
+      gap: 10px !important;
+      z-index: 10075 !important;
+      opacity: 1 !important;
+      visibility: visible !important;
+      pointer-events: auto !important;
+      box-sizing: border-box !important;
+    }
+
+    html.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search,
+    html.mc-search-open header.header .mc-header-search-cart-wrap #collapsingSearch,
+    html.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search__form,
+    html.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search__form .container,
+    html.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search__form .row,
+    body.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search,
+    body.mc-search-open header.header .mc-header-search-cart-wrap #collapsingSearch,
+    body.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search__form,
+    body.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search__form .container,
+    body.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search__form .row {
+      display: flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+      width: 100% !important;
+      max-width: 100% !important;
+      height: auto !important;
+      min-height: 0 !important;
+      padding: 0 !important;
+      margin: 0 !important;
+      border: 0 !important;
+      border-bottom: 0 !important;
+      box-shadow: none !important;
+      background: transparent !important;
+      background-image: none !important;
+    }
+
+    html.mc-search-open header.header .mc-header-search-cart-wrap #search,
+    html.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search__input,
+    body.mc-search-open header.header .mc-header-search-cart-wrap #search,
+    body.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search__input {
+      display: inline-block !important;
+      visibility: visible !important;
+      opacity: 1 !important;
+      width: 380px !important;
+      max-width: 100% !important;
+      height: 42px !important;
+      min-height: 42px !important;
+      padding: 0 12px !important;
+      margin: 0 !important;
+      border: 0 !important;
+      border-bottom: 1px solid #999 !important;
+      box-shadow: none !important;
+      outline: none !important;
+      background: #fff !important;
+      background-image: none !important;
+      font-family: Inter, Arial, sans-serif !important;
+      font-size: 15px !important;
+      font-weight: 300 !important;
+      letter-spacing: .04em !important;
+      color: #111 !important;
+      box-sizing: border-box !important;
+    }
+
+    html.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search__submit,
+    body.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search__submit {
+      display: inline-flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+      width: 42px !important;
+      height: 42px !important;
+      min-width: 42px !important;
+      padding: 0 !important;
+      margin: 0 !important;
+      border: 0 !important;
+      border-bottom: 0 !important;
+      background: transparent !important;
+      box-shadow: none !important;
+      opacity: 1 !important;
+      visibility: visible !important;
+      pointer-events: auto !important;
+    }
+  }
+</style>
+<style id="mc-search-one-controller-css">
+  html:not(.mc-search-open) header.header .mc-header-search-cart-wrap,
+  body:not(.mc-search-open) header.header .mc-header-search-cart-wrap {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+  }
+
+  html.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search,
+  html.mc-search-open header.header .mc-header-search-cart-wrap #collapsingSearch,
+  html.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search__form,
+  html.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search__form .container,
+  html.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search__form .row,
+  body.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search,
+  body.mc-search-open header.header .mc-header-search-cart-wrap #collapsingSearch,
+  body.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search__form,
+  body.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search__form .container,
+  body.mc-search-open header.header .mc-header-search-cart-wrap .collapsing-search__form .row {
+    border: 0 !important;
+    border-bottom: 0 !important;
+    box-shadow: none !important;
+    background-image: none !important;
+  }
+</style>
+
+<script id="mc-search-float-toggle">
+(function () {
+  function getWrap() {
+    return document.querySelector("header.header .mc-header-search-cart-wrap");
+  }
+
+  function getInput() {
+    var wrap = getWrap();
+    return wrap && (
+      wrap.querySelector("#search") ||
+      wrap.querySelector(".collapsing-search__input") ||
+      wrap.querySelector('input[type="search"]') ||
+      wrap.querySelector('input[type="text"]')
+    );
+  }
+
+  function cleanInnerLines(wrap) {
+    if (!wrap) return;
+
+    Array.from(wrap.querySelectorAll(
+      ".collapsing-search, #collapsingSearch, .collapsing-search__form, .collapsing-search__form .container, .collapsing-search__form .row"
+    )).forEach(function (el) {
+      el.style.setProperty("border", "0", "important");
+      el.style.setProperty("border-bottom", "0", "important");
+      el.style.setProperty("box-shadow", "none", "important");
+      el.style.setProperty("background-image", "none", "important");
+      el.style.setProperty("margin", "0", "important");
+      el.style.setProperty("padding", "0", "important");
+    });
+  }
+
+  function openSearch() {
+    var wrap = getWrap();
+    var input = getInput();
+
+    document.documentElement.classList.add("mc-search-open");
+    if (document.body) document.body.classList.add("mc-search-open");
+
+    if (wrap) {
+      wrap.style.setProperty("display", "flex", "important");
+      wrap.style.setProperty("position", "fixed", "important");
+      wrap.style.setProperty("top", "52px", "important");
+      wrap.style.setProperty("right", "140px", "important");
+      wrap.style.setProperty("width", "460px", "important");
+      wrap.style.setProperty("max-width", "calc(100vw - 180px)", "important");
+      wrap.style.setProperty("min-height", "64px", "important");
+      wrap.style.setProperty("padding", "14px 18px", "important");
+      wrap.style.setProperty("background", "#fff", "important");
+      wrap.style.setProperty("border", "0", "important");
+      wrap.style.setProperty("border-bottom", "0", "important");
+      wrap.style.setProperty("box-shadow", "0 10px 34px rgba(0,0,0,.16)", "important");
+      wrap.style.setProperty("border-radius", "4px", "important");
+      wrap.style.setProperty("align-items", "center", "important");
+      wrap.style.setProperty("justify-content", "center", "important");
+      wrap.style.setProperty("gap", "10px", "important");
+      wrap.style.setProperty("z-index", "10075", "important");
+      wrap.style.setProperty("opacity", "1", "important");
+      wrap.style.setProperty("visibility", "visible", "important");
+      wrap.style.setProperty("pointer-events", "auto", "important");
+    }
+
+    cleanInnerLines(wrap);
+
+    if (input) {
+      input.style.setProperty("display", "inline-block", "important");
+      input.style.setProperty("visibility", "visible", "important");
+      input.style.setProperty("opacity", "1", "important");
+      input.style.setProperty("width", "380px", "important");
+      input.style.setProperty("max-width", "100%", "important");
+      input.style.setProperty("height", "42px", "important");
+      input.style.setProperty("padding", "0 12px", "important");
+      input.style.setProperty("border", "0", "important");
+      input.style.setProperty("border-bottom", "1px solid #999", "important");
+      input.style.setProperty("box-shadow", "none", "important");
+      input.style.setProperty("outline", "none", "important");
+      input.style.setProperty("background", "#fff", "important");
+      input.style.setProperty("background-image", "none", "important");
+
+      setTimeout(function () {
+        try { input.focus(); } catch(e) {}
+      }, 30);
+    }
+  }
+
+  function closeSearch() {
+    document.documentElement.classList.remove("mc-search-open");
+    if (document.body) document.body.classList.remove("mc-search-open");
+
+    var wrap = getWrap();
+    var input = getInput();
+
+    if (input) {
+      try { input.blur(); } catch(e) {}
+    }
+
+    if (wrap) {
+      wrap.style.setProperty("display", "none", "important");
+      wrap.style.setProperty("visibility", "hidden", "important");
+      wrap.style.setProperty("opacity", "0", "important");
+      wrap.style.setProperty("pointer-events", "none", "important");
+    }
+  }
+
+  document.addEventListener("click", function (e) {
+    var btn = e.target.closest(".mc-search-float");
+    var wrap = getWrap();
+
+    if (btn) {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (document.documentElement.classList.contains("mc-search-open")) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+      return;
+    }
+
+    if (
+      document.documentElement.classList.contains("mc-search-open") &&
+      wrap &&
+      !wrap.contains(e.target)
+    ) {
+      closeSearch();
+    }
+  }, true);
+
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape") closeSearch();
+  });
+
+  window.mcOpenSearch = openSearch;
+  window.mcCloseSearch = closeSearch;
+})();
+</script>
+<script id="mc-hide-armless-option-visual-only">
+(function () {
+  function text(el) {
+    return String(el && (el.textContent || el.innerText || "") || "")
+      .replace(/\s+/g, " ")
+      .trim()
+      .toLowerCase();
+  }
+
+  function selectLooksArmless(sel) {
+    if (!sel || !sel.options) return false;
+
+    var optionText = Array.from(sel.options).map(function (o) {
+      return text(o);
+    }).join(" | ");
+
+    var sig = String((sel.name || "") + " " + (sel.id || "") + " " + (sel.title || "")).toLowerCase();
+
+    return /armless|4l|loveseat|discount/.test(optionText + " " + sig);
+  }
+
+  function hideDisplay(el) {
+    if (!el || !el.style) return;
+    el.style.setProperty("display", "none", "important");
+  }
+
+  function hideRowFor(el) {
+    if (!el) return;
+    var row =
+      el.closest("tr") ||
+      el.closest(".v65-productdetail-options-row") ||
+      el.closest(".productnamecolor") ||
+      el.closest("li") ||
+      null;
+    hideDisplay(row || el);
+  }
+
+  function hideArmlessOptionRows() {
+    var root = document.querySelector("#v65-product-parent") || document.querySelector("#content_area") || document;
+
+    Array.from(root.querySelectorAll("select")).forEach(function (sel) {
+      if (!selectLooksArmless(sel)) return;
+
+      sel.disabled = false;
+
+      hideRowFor(sel);
+
+      if (sel.labels && sel.labels.length) {
+        Array.from(sel.labels).forEach(hideRowFor);
+      }
+      if (sel.id) {
+        var q = 'label[for="' + String(sel.id).replace(/\\/g, "\\\\").replace(/"/g, '\\"') + '"]';
+        Array.from(root.querySelectorAll(q)).forEach(hideRowFor);
+      }
+
+      var tr = sel.closest("tr");
+      if (tr && tr.previousElementSibling && tr.previousElementSibling.tagName === "TR") {
+        var prev = tr.previousElementSibling;
+        var ptxt = text(prev);
+        if (ptxt && /armless|loveseat|\b4\s*l\b|discount/.test(ptxt) && ptxt.length < 120) hideDisplay(prev);
+      }
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", hideArmlessOptionRows);
+  } else {
+    hideArmlessOptionRows();
+  }
+
+  window.addEventListener("load", function () {
+    hideArmlessOptionRows();
+    setTimeout(hideArmlessOptionRows, 300);
+    setTimeout(hideArmlessOptionRows, 1000);
+  });
+
+  window.mcHideArmlessOptionRows = hideArmlessOptionRows;
+})();
+</script>
+  <!--Start of Tawk.to Script-->
+<script type="text/javascript">
+var Tawk_API=Tawk_API||{}, Tawk_LoadStart=new Date();
+(function(){
+var s1=document.createElement("script"),s0=document.getElementsByTagName("script")[0];
+s1.async=true;
+s1.src='https://embed.tawk.to/6a04bd3e2df0a01c36f9d799/1joh86fip';
+s1.charset='UTF-8';
+s1.setAttribute('crossorigin','*');
+s0.parentNode.insertBefore(s1,s0);
+})();
+</script>
+<!--End of Tawk.to Script-->
+  <script id="mc-plp-enforcer-js" src="/v/vspfiles/js/mc-plp-enforcer.js?v=20260716freeship1"></script>
+ 
+  <script id="mc-my-boards-template-boot">
+(function () {
+  var path = String(location.pathname || '');
+  var onBoards =
+    /\/my-boards\.html/i.test(path) ||
+    document.getElementById('mc-boards-main') ||
+    document.getElementById('mc-boards-styles') ||
+    document.querySelector('.mc-boards');
+  if (!onBoards) return;
+  document.documentElement.classList.add('mc-my-boards-page');
+  if (document.body) document.body.classList.add('mc-my-boards-page');
+  if (!window.MC_BOARDS_API_BASE) {
+    var p = String(location.pathname || '');
+    window.MC_BOARDS_API_BASE =
+      p.indexOf('/v/vspfiles/') !== -1 ? '/v/vspfiles/boards/' : '/v/vspfiles/boards/';
+  }
+  if (!document.querySelector('link[href*="fonts.googleapis.com"][href*="Cormorant"]')) {
+    var gf = document.createElement('link');
+    gf.rel = 'stylesheet';
+    gf.href =
+      'https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap';
+    document.head.appendChild(gf);
+  }
+  var hrefs = [
+    '/v/vspfiles/boards/my-boards-bundle.css?v=20260535',
+    '/v/vspfiles/boards/my-boards-bundle.css?v=20260535'
+  ];
+  var have = {};
+  document.querySelectorAll('link[rel="stylesheet"]').forEach(function (l) {
+    if (l.href) have[l.href.split('?')[0]] = true;
+  });
+  hrefs.forEach(function (h) {
+    var base = h.split('?')[0];
+    if (have[base]) return;
+    var link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = h;
+    document.head.appendChild(link);
+    have[base] = true;
+  });
+  if (!document.querySelector('script[src*="board-styles.js"]')) {
+    function loadBoardsPageJs() {
+      var s2 = document.createElement('script');
+      s2.src = '/v/vspfiles/boards/my-boards-page.js?v=20260535';
+      document.body.appendChild(s2);
+    }
+    function loadBoardStyles(src) {
+      var s1 = document.createElement('script');
+      s1.src = src;
+      s1.onload = loadBoardsPageJs;
+      s1.onerror = function () {
+        if (src.indexOf('/v/vspfiles/') === -1) {
+          loadBoardStyles('/v/vspfiles/boards/board-styles.js?v=20260535');
+        }
+      };
+      document.body.appendChild(s1);
+    }
+    loadBoardStyles('/v/vspfiles/boards/board-styles.js?v=20260535');
+  }
+})();
+  </script>
+
+<!-- MC HOME HERO VIDEO FINAL FORCE -->
+<style id="mc-home-video-final-force-css">
+  html.mc-allow-home-hero body.is-home #if_homepage,
+  html.category body.is-home #if_homepage,
+  body.category.is-home #if_homepage {
+    display: block !important;
+    visibility: visible !important;
+    height: auto !important;
+    max-height: none !important;
+    opacity: 1 !important;
+    overflow: visible !important;
+    pointer-events: auto !important;
+  }
+
+  html.mc-allow-home-hero body.is-home #slideshow-container,
+  html.category body.is-home #slideshow-container,
+  body.category.is-home #slideshow-container {
+    display: block !important;
+    visibility: visible !important;
+    position: relative !important;
+    width: 100vw !important;
+    max-width: 100vw !important;
+    height: 620px !important;
+    min-height: 620px !important;
+    max-height: none !important;
+    opacity: 1 !important;
+    overflow: hidden !important;
+    background: #000 !important;
+    margin-left: calc(-50vw + 50%) !important;
+    margin-right: calc(-50vw + 50%) !important;
+    z-index: 2 !important;
+  }
+
+  html.mc-allow-home-hero body.is-home #slideshow-container .mc-hero-video,
+  html.category body.is-home #slideshow-container .mc-hero-video,
+  body.category.is-home #slideshow-container .mc-hero-video {
+    display: block !important;
+    visibility: visible !important;
+    position: absolute !important;
+    inset: 0 !important;
+    width: 100% !important;
+    height: 620px !important;
+    min-height: 620px !important;
+    max-height: none !important;
+    opacity: 1 !important;
+    overflow: hidden !important;
+    background: #000 !important;
+    z-index: 1 !important;
+    pointer-events: none !important;
+  }
+
+  html.mc-allow-home-hero body.is-home #slideshow-container video.mc-hero-video-el,
+  html.category body.is-home #slideshow-container video.mc-hero-video-el,
+  body.category.is-home #slideshow-container video.mc-hero-video-el {
+    display: block !important;
+    visibility: visible !important;
+    position: absolute !important;
+    inset: 0 !important;
+    width: 100% !important;
+    height: 620px !important;
+    min-height: 620px !important;
+    max-height: none !important;
+    object-fit: cover !important;
+    object-position: center center !important;
+    opacity: 1 !important;
+    background: #000 !important;
+    z-index: 1 !important;
+    pointer-events: none !important;
+  }
+
+  html.mc-allow-home-hero body.is-home #slideshow-container .mc-hero-overlay,
+  html.category body.is-home #slideshow-container .mc-hero-overlay,
+  body.category.is-home #slideshow-container .mc-hero-overlay {
+    display: flex !important;
+    visibility: visible !important;
+    position: absolute !important;
+    inset: 0 !important;
+    opacity: 1 !important;
+    z-index: 10 !important;
+    pointer-events: none !important;
+  }
+
+  html.mc-allow-home-hero body.is-home #slideshow-container .hero-menu,
+  html.mc-allow-home-hero body.is-home #slideshow-container .hero-nav,
+  html.category body.is-home #slideshow-container .hero-menu,
+  html.category body.is-home #slideshow-container .hero-nav,
+  body.category.is-home #slideshow-container .hero-menu,
+  body.category.is-home #slideshow-container .hero-nav {
+    display: flex !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+    height: auto !important;
+    overflow: visible !important;
+    pointer-events: auto !important;
+    z-index: 50 !important;
+  }
+</style>
+
+<script id="mc-home-video-final-force-js">
+(function () {
+  function isHomePage() {
+    var p = String(location.pathname || "").toLowerCase();
+    return (
+      p === "/" ||
+      p === "/default.asp" ||
+      p === "/default.htm" ||
+      p === "/default.html" ||
+      p === "/index.htm" ||
+      p === "/index.html"
+    );
+  }
+
+  if (!isHomePage()) return;
+
+  function forceHomeVideoHero() {
+    document.documentElement.classList.add("mc-allow-home-hero", "home");
+    document.documentElement.classList.remove("is-category-or-listing-page");
+    document.documentElement.setAttribute("data-mc-category-plp", "0");
+
+    if (document.body) {
+      document.body.classList.add("is-home");
+      document.body.classList.remove("productdetails", "mc-product-page", "is-category-or-listing-page");
+    }
+
+    var sc = document.getElementById("slideshow-container");
+    var wrap = document.querySelector("#slideshow-container .mc-hero-video");
+    var v = document.querySelector("#slideshow-container video.mc-hero-video-el");
+
+    if (sc) {
+      sc.style.setProperty("display", "block", "important");
+      sc.style.setProperty("visibility", "visible", "important");
+      sc.style.setProperty("position", "relative", "important");
+      sc.style.setProperty("width", "100vw", "important");
+      sc.style.setProperty("max-width", "100vw", "important");
+      sc.style.setProperty("height", "620px", "important");
+      sc.style.setProperty("min-height", "620px", "important");
+      sc.style.setProperty("max-height", "none", "important");
+      sc.style.setProperty("opacity", "1", "important");
+      sc.style.setProperty("overflow", "hidden", "important");
+      sc.style.setProperty("background", "#000", "important");
+      sc.style.setProperty("margin-left", "calc(-50vw + 50%)", "important");
+      sc.style.setProperty("margin-right", "calc(-50vw + 50%)", "important");
+      sc.style.setProperty("z-index", "2", "important");
+    }
+
+    if (wrap) {
+      wrap.style.setProperty("display", "block", "important");
+      wrap.style.setProperty("visibility", "visible", "important");
+      wrap.style.setProperty("position", "absolute", "important");
+      wrap.style.setProperty("inset", "0", "important");
+      wrap.style.setProperty("width", "100%", "important");
+      wrap.style.setProperty("height", "620px", "important");
+      wrap.style.setProperty("min-height", "620px", "important");
+      wrap.style.setProperty("max-height", "none", "important");
+      wrap.style.setProperty("opacity", "1", "important");
+      wrap.style.setProperty("overflow", "hidden", "important");
+      wrap.style.setProperty("background", "#000", "important");
+      wrap.style.setProperty("z-index", "1", "important");
+    }
+
+    if (v) {
+      v.style.setProperty("display", "block", "important");
+      v.style.setProperty("visibility", "visible", "important");
+      v.style.setProperty("position", "absolute", "important");
+      v.style.setProperty("inset", "0", "important");
+      v.style.setProperty("width", "100%", "important");
+      v.style.setProperty("height", "620px", "important");
+      v.style.setProperty("min-height", "620px", "important");
+      v.style.setProperty("object-fit", "cover", "important");
+      v.style.setProperty("object-position", "center center", "important");
+      v.style.setProperty("opacity", "1", "important");
+      v.style.setProperty("z-index", "1", "important");
+
+      if (typeof window.mcPlayWindsorHeroAtSeven === "function") {
+        window.mcPlayWindsorHeroAtSeven(v);
+      } else {
+        var wantSrc = "/v/vspfiles/windsor-home.mp4";
+        var srcEl = v.querySelector("source");
+        var cur = srcEl
+          ? String(srcEl.getAttribute("src") || srcEl.src || "")
+          : String(v.getAttribute("src") || v.src || "");
+        if (cur.indexOf("windsor-home.mp4") === -1 || v.dataset.mcWindsorHomeApplied !== wantSrc) {
+          if (srcEl) srcEl.setAttribute("src", wantSrc);
+          else v.setAttribute("src", wantSrc);
+          try {
+            delete v.dataset.mcStartedAtSeven;
+          } catch (eDelSrc) {}
+          v.dataset.mcWindsorHomeApplied = wantSrc;
+          try {
+            v.load();
+          } catch (eLoadSrc) {}
+        }
+
+        v.muted = true;
+        v.loop = true;
+        v.playsInline = true;
+        v.autoplay = true;
+        v.classList.remove("is-preloading");
+        v.classList.add("is-ready");
+
+        function seekAndPlayFallback() {
+          try {
+            if (!v.dataset.mcStartedAtSeven) {
+              v.dataset.mcStartedAtSeven = "1";
+              v.currentTime = 7;
+            }
+            v.play && v.play().catch(function () {});
+          } catch (eSeekFb) {}
+        }
+
+        if (v.readyState >= 1) {
+          seekAndPlayFallback();
+        } else {
+          v.addEventListener("loadedmetadata", seekAndPlayFallback, { once: true });
+        }
+      }
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", forceHomeVideoHero);
+  } else {
+    forceHomeVideoHero();
+  }
+
+  window.addEventListener("load", forceHomeVideoHero);
+  setTimeout(forceHomeVideoHero, 250);
+  setTimeout(forceHomeVideoHero, 1000);
+  setTimeout(forceHomeVideoHero, 2500);
+})();
+</script>
+<!-- MC FIX: remove duplicate selected configuration summary card -->
+<script id="mc-remove-duplicate-selected-config-summary">
+(function () {
+  function removeDuplicateSelectedConfigSummary() {
+    try {
+      document.querySelectorAll("#v65-product-parent div, #v65-product-parent section, #v65-product-parent article").forEach(function (el) {
+        var txt = String(el.textContent || "").replace(/\s+/g, " ").trim();
+
+        if (
+          /^Selected Configuration\s+[0-9]{2}-[0-9]{2}\s+For custom quotes send us an email\.?$/i.test(txt) ||
+          /^Selected Configuration\s+[0-9]{2}\/[0-9]{2}\s+For custom quotes send us an email\.?$/i.test(txt)
+        ) {
+          if (el.parentNode) el.parentNode.removeChild(el);
+        }
+      });
+    } catch (e) {}
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", removeDuplicateSelectedConfigSummary);
+  } else {
+    removeDuplicateSelectedConfigSummary();
+  }
+
+  window.addEventListener("load", removeDuplicateSelectedConfigSummary);
+  setTimeout(removeDuplicateSelectedConfigSummary, 300);
+  setTimeout(removeDuplicateSelectedConfigSummary, 1200);
+})();
+</script>
+<script id="mc-hide-config-non-theater-pdps">
+(function () {
+  function mcIsTrueTheaterSeatingPdp() {
+    var path = "";
+    var title = "";
+    var pc = "";
+
+    try {
+      path = String(location.pathname || "").toLowerCase();
+      title = String(document.title || "").toLowerCase();
+
+      var pcInput = document.querySelector('input[name="ProductCode"]');
+      pc = pcInput ? String(pcInput.value || "").toLowerCase() : "";
+    } catch (e) {}
+
+    /*
+      IMPORTANT:
+      Do NOT use "palliser" alone here.
+      Titan, Barrett, sectional, sofa, recliner pages are also Palliser.
+    */
+    return (
+      document.documentElement.classList.contains("mc-paragon-pdp") ||
+      path.indexOf("theater-chair") !== -1 ||
+      path.indexOf("theatre-chair") !== -1 ||
+      title.indexOf("theater chair") !== -1 ||
+      title.indexOf("theatre chair") !== -1 ||
+      title.indexOf("home theater chair") !== -1 ||
+      title.indexOf("home theatre chair") !== -1 ||
+      title.indexOf("theater seating") !== -1 ||
+      title.indexOf("theatre seating") !== -1 ||
+      pc.indexOf("theater") !== -1 ||
+      pc.indexOf("theatre") !== -1
+    );
+  }
+
+  function mcHideConfigBoxUnlessTheater() {
+    var isTheater = mcIsTrueTheaterSeatingPdp();
+
+    try {
+      if (document.body) {
+        if (isTheater) {
+          document.body.classList.add("mc-theater-seating-pdp");
+        } else {
+          document.body.classList.remove("mc-theater-seating-pdp");
+        }
+      }
+    } catch (eClass) {}
+
+    if (isTheater) return;
+
+    [
+      "#mcConfigurationBlock",
+      ".mc-configuration-rh",
+      "#mcPlannerMemberPriceAboveAtc",
+      "#mcPlannerLoginGate"
+    ].forEach(function (sel) {
+      document.querySelectorAll(sel).forEach(function (el) {
+        try {
+          el.style.setProperty("display", "none", "important");
+          el.style.setProperty("visibility", "hidden", "important");
+          el.style.setProperty("height", "0", "important");
+          el.style.setProperty("max-height", "0", "important");
+          el.style.setProperty("margin", "0", "important");
+          el.style.setProperty("padding", "0", "important");
+          el.style.setProperty("overflow", "hidden", "important");
+          el.style.setProperty("opacity", "0", "important");
+          el.style.setProperty("pointer-events", "none", "important");
+        } catch (eHide) {}
+      });
+    });
+  }
+
+  window.mcHideConfigBoxUnlessTheater = mcHideConfigBoxUnlessTheater;
+
+  mcHideConfigBoxUnlessTheater();
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", mcHideConfigBoxUnlessTheater);
+  } else {
+    mcHideConfigBoxUnlessTheater();
+  }
+
+  window.addEventListener("load", mcHideConfigBoxUnlessTheater);
+
+  [0, 250, 750, 1500, 3000, 6000].forEach(function (ms) {
+    setTimeout(mcHideConfigBoxUnlessTheater, ms);
+  });
+})();
+</script>
+<script id="mc-fix-price-with-selected-options-label">
+(function () {
+  function fixLabel() {
+    document.querySelectorAll("#v65-product-parent, #content_area").forEach(function (root) {
+      root.querySelectorAll("*").forEach(function (el) {
+        if (!el || !el.childNodes || el.childNodes.length > 3) return;
+
+        var txt = (el.textContent || "").replace(/\s+/g, " ").trim().toUpperCase();
+
+        if (txt === "PRICE WITH SELECTED OPTIONS:" || txt === "PRICE WITH SELECTED OPTIONS") {
+          el.textContent = "PRICE";
+        }
+      });
+    });
+  }
+
+  fixLabel();
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", fixLabel);
+  } else {
+    fixLabel();
+  }
+
+  window.addEventListener("load", fixLabel);
+  setTimeout(fixLabel, 500);
+  setTimeout(fixLabel, 1500);
+})();
+</script>
+<style id="mc-regular-price-only-cleanup">
+/* Align PDP title/price column to top of main image */
+body.productdetails #v65-product-parent td,
+body.mc-product-page #v65-product-parent td {
+  vertical-align: top !important;
+}
+
+/* Product title: no top gap */
+body.productdetails #mc-pdp-title-right,
+body.mc-product-page #mc-pdp-title-right,
+body.productdetails #mc-pdp-title-right h1,
+body.mc-product-page #mc-pdp-title-right h1,
+body.productdetails .vp-product-title,
+body.mc-product-page .vp-product-title {
+  margin-top: 0 !important;
+  padding-top: 0 !important;
+}
+
+/* Regular price directly under title */
+body.productdetails .mc-pdp-retail-row--regular-only,
+body.mc-product-page .mc-pdp-retail-row--regular-only,
+body.productdetails .mc-pdp-top-retail-row--regular-only,
+body.mc-product-page .mc-pdp-top-retail-row--regular-only {
+  margin: 6px 0 12px 0 !important;
+  padding: 0 !important;
+}
+
+/* Kill member-pricing remnants */
+.mc-pdp-member-line,
+.mc-pdp-top-member-row,
+.mc-member-grid-price,
+.mc-member-price,
+.mc-member-pricing,
+.mc-member-price-row,
+.mc-member-login,
+.mc-member-grid-price__label,
+.mc-member-grid-price__hint,
+.mc-member-grid-price__login {
+  display: none !important;
+  visibility: hidden !important;
+}
+
+/* Hide accordion on PDPs that don't use the McCabe accordion layout */
+body:not(.mc-saranoni-pdp):not(.mc-steve-silver-altview-pdp):not(.mc-mahjong-house-pdp):not(.mc-bean-bag-pdp):not(.mc-pdp-accordion-pdp):not(:has(#v65-product-parent input[name="ProductCode"][value^="SS-"])) #mc-pdp-accordion,
+body:not(.mc-saranoni-pdp):not(.mc-steve-silver-altview-pdp):not(.mc-mahjong-house-pdp):not(.mc-bean-bag-pdp):not(.mc-pdp-accordion-pdp):not(:has(#v65-product-parent input[name="ProductCode"][value^="SS-"])) .mc-pdp-accordion {
+  display: none !important;
+  visibility: hidden !important;
+}
+
+/* Steve Silver / Mahjong: keep accordion visible (beats legacy unscoped hide rules) */
+html body.mc-steve-silver-altview-pdp #mc-pdp-accordion,
+html body.mc-steve-silver-altview-pdp .mc-pdp-accordion,
+html body.mc-mahjong-house-pdp #mc-pdp-accordion,
+html body.mc-mahjong-house-pdp .mc-pdp-accordion,
+html body.mc-bean-bag-pdp #mc-pdp-accordion,
+html body.mc-bean-bag-pdp .mc-pdp-accordion,
+html body.mc-pdp-accordion-pdp #mc-pdp-accordion,
+html body.mc-pdp-accordion-pdp .mc-pdp-accordion,
+html body.productdetails:has(#v65-product-parent input[name="ProductCode"][value^="SS-"]) #mc-pdp-accordion,
+html body.productdetails:has(#v65-product-parent input[name="ProductCode"][value^="SS-"]) .mc-pdp-accordion,
+html body.mc-product-page:has(#v65-product-parent input[name="ProductCode"][value^="SS-"]) #mc-pdp-accordion,
+html body.mc-product-page:has(#v65-product-parent input[name="ProductCode"][value^="SS-"]) .mc-pdp-accordion {
+  display: block !important;
+  visibility: visible !important;
+}
+</style>
+<script id="mc-pdp-regular-price-only-kill-switch">
+(function () {
+  var mcPdpPriceCleanTimer = null;
+
+  function mcIsProductPageForPriceCleanup() {
+    var p = String(window.location.pathname || "").toLowerCase();
+    return (
+      /\/product-p\//i.test(p) ||
+      /productdetails\.asp/i.test(p) ||
+      !!document.getElementById("v65-product-parent")
+    );
+  }
+
+  function mcRemoveNode(node) {
+    try {
+      if (node && node.parentNode) node.parentNode.removeChild(node);
+    } catch (e) {}
+  }
+
+  function mcRestoreVisible(node) {
+    if (!node || !node.style) return;
+    node.style.removeProperty("display");
+    node.style.removeProperty("visibility");
+    node.style.removeProperty("height");
+    node.style.removeProperty("max-height");
+    node.style.removeProperty("opacity");
+    node.style.removeProperty("overflow");
+    node.style.removeProperty("position");
+    node.style.removeProperty("left");
+    node.style.removeProperty("top");
+    node.style.removeProperty("float");
+  }
+
+  function mcPdpRegularPriceOnly() {
+    try {
+      if (!mcIsProductPageForPriceCleanup()) return;
+
+      document.documentElement.setAttribute("data-mc-price-cleanup", "regular-only-active");
+
+      var root =
+        document.getElementById("v65-product-parent") ||
+        document.getElementById("content_area") ||
+        document.body;      if (!root || !root.querySelectorAll) return;
+
+      /*
+        Strong PDP price cleanup:
+        Some Volusion price labels are plain text nodes inside .colors_pricebox,
+        not classed elements, so class selectors alone will not remove them.
+      */
+
+      var cleanPriceEl = root.querySelector(
+        ".mc-pdp-stack-retail-amt, #mc-pdp-top-price-panel .mc-pdp-top-price-value"
+      );
+
+      var cleanPriceTxt = cleanPriceEl
+        ? String(cleanPriceEl.textContent || "").replace(/\s+/g, " ").trim()
+        : "";
+
+      if (cleanPriceEl && /\$[\d,]+/.test(cleanPriceTxt)) {
+        try {
+          var nativePriceBoxes = root.querySelectorAll(".colors_pricebox, .mtl-product-price-block");
+
+          for (var nb = 0; nb < nativePriceBoxes.length; nb++) {
+            nativePriceBoxes[nb].style.setProperty("display", "none", "important");
+            nativePriceBoxes[nb].style.setProperty("visibility", "hidden", "important");
+            nativePriceBoxes[nb].style.setProperty("height", "0", "important");
+            nativePriceBoxes[nb].style.setProperty("max-height", "0", "important");
+            nativePriceBoxes[nb].style.setProperty("margin", "0", "important");
+            nativePriceBoxes[nb].style.setProperty("padding", "0", "important");
+            nativePriceBoxes[nb].style.setProperty("overflow", "hidden", "important");
+            nativePriceBoxes[nb].style.setProperty("opacity", "0", "important");
+          }
+        } catch (eHideNativePriceBox) {}
+      }
+
+      try {
+        var priceZones = root.querySelectorAll(
+          ".mc-pdp-member-pricing, #mc-pdp-top-price-panel, .colors_pricebox, .mtl-product-price-block, [itemprop='offers']"
+        );
+
+        for (var z = 0; z < priceZones.length; z++) {
+          var walker = document.createTreeWalker(priceZones[z], NodeFilter.SHOW_TEXT, null, false);
+          var textNode;
+
+          while ((textNode = walker.nextNode())) {
+            textNode.nodeValue = String(textNode.nodeValue || "")
+              .replace(/Retail Price/gi, "")
+              .replace(/Member Price/gi, "")
+              .replace(/Sale Price/gi, "")
+              .replace(/Log in to see member pricing/gi, "")
+              .replace(/to see member pricing/gi, "");
+          }
+        }
+
+        var loginLinks = root.querySelectorAll("a[data-mc-open-login], .mc-member-grid-price__login");
+
+        for (var ll = 0; ll < loginLinks.length; ll++) {
+          if (/log in/i.test(String(loginLinks[ll].textContent || ""))) {
+            loginLinks[ll].style.setProperty("display", "none", "important");
+            loginLinks[ll].style.setProperty("visibility", "hidden", "important");
+          }
+        }
+      } catch (eTextLabelClean) {}
+
+      /*
+        Do NOT remove the whole top price panel or whole member-pricing wrapper.
+        Keep the actual regular price value. Remove only labels/member/sale custom rows.
+      */
+      var removeNodes = root.querySelectorAll(
+        ".mc-pdp-retail-label, " +
+        ".mc-pdp-member-line, " +
+        ".mc-pdp-member-line__label, " +
+        ".mc-pdp-member-line__amount, " +
+        ".mc-pdp-top-member-row, " +
+        ".mc-pdp-top-sale-row, " +
+        ".mc-pdp-member-line--sale, " +
+        ".mc-pdp-sale-preview, " +
+        "#mc-pdp-top-price-panel .mc-pdp-top-price-label"
+      );
+
+      var i;
+      for (i = 0; i < removeNodes.length; i++) {
+        mcRemoveNode(removeNodes[i]);
+      }
+
+      var customPriceRows = root.querySelectorAll(
+        "#mc-pdp-top-price-panel .mc-pdp-top-price-row, " +
+        ".mc-pdp-member-pricing .mc-pdp-retail-row"
+      );
+
+      for (i = 0; i < customPriceRows.length; i++) {
+        var rowText = String(customPriceRows[i].textContent || "").replace(/\s+/g, " ").trim();
+
+        if (/member price|log in to see member pricing|sale price/i.test(rowText)) {
+          mcRemoveNode(customPriceRows[i]);
+          continue;
+        }
+
+        mcRestoreVisible(customPriceRows[i]);
+      }
+
+      var keepVisible = root.querySelectorAll(
+        "#mc-pdp-top-price-panel, " +
+        "#mc-pdp-top-price-panel .mc-pdp-top-retail-row, " +
+        "#mc-pdp-top-price-panel .mc-pdp-top-price-value, " +
+        ".mc-pdp-member-pricing, " +
+        ".mc-pdp-retail-row, " +
+        ".mc-pdp-retail-line, " +
+        ".mc-pdp-stack-retail-amt, " +
+        ".colors_pricebox, " +
+        ".product_productprice, " +
+        ".product_price, " +
+        ".product_list_price, " +
+        "[itemprop='price']"
+      );
+
+      for (i = 0; i < keepVisible.length; i++) {
+        mcRestoreVisible(keepVisible[i]);
+      }
+    } catch (eClean) {}
+  }
+
+  function mcSchedulePdpRegularPriceOnly() {
+    if (mcPdpPriceCleanTimer) return;
+    mcPdpPriceCleanTimer = window.setTimeout(function () {
+      mcPdpPriceCleanTimer = null;
+      mcPdpRegularPriceOnly();
+    }, 20);
+  }
+
+  mcPdpRegularPriceOnly();
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", mcPdpRegularPriceOnly);
+  }
+
+  window.addEventListener("load", mcPdpRegularPriceOnly);
+
+  window.setTimeout(mcPdpRegularPriceOnly, 100);
+  window.setTimeout(mcPdpRegularPriceOnly, 400);
+  window.setTimeout(mcPdpRegularPriceOnly, 1000);
+  window.setTimeout(mcPdpRegularPriceOnly, 2500);
+  window.setTimeout(mcPdpRegularPriceOnly, 5000);
+
+  if (window.MutationObserver) {
+    try {
+      new MutationObserver(mcSchedulePdpRegularPriceOnly).observe(document.documentElement, {
+        childList: true,
+        subtree: true
+      });
+    } catch (eObs) {}
+  }
+})();
+</script>
+<style id="mc-related-items-restore-inline-20260612">
+/* MC PDP RELATED ITEMS FULL WIDTH RESTORE INLINE 20260612 */
+
+/* Restore PDP related-items full width */
+html.mc-url-looks-like-pdp body #v65-product-related,
+html.mc-url-looks-like-pdp body #related_products_content,
+body.productdetails #v65-product-related,
+body.productdetails #related_products_content,
+body.mc-product-page #v65-product-related,
+body.mc-product-page #related_products_content {
+  display: block !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+  width: 100% !important;
+  max-width: 100% !important;
+  min-width: 0 !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  clear: both !important;
+  overflow: visible !important;
+}
+
+/* Restore native related table */
+html.mc-url-looks-like-pdp body #related_products_content table,
+html.mc-url-looks-like-pdp body #v65-product-related table,
+body.productdetails #related_products_content table,
+body.productdetails #v65-product-related table,
+body.mc-product-page #related_products_content table,
+body.mc-product-page #v65-product-related table {
+  display: table !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+  width: 100% !important;
+  max-width: 100% !important;
+  table-layout: fixed !important;
+  margin: 0 auto !important;
+  border-collapse: collapse !important;
+  overflow: visible !important;
+}
+
+/* Restore rows */
+html.mc-url-looks-like-pdp body #related_products_content tr,
+html.mc-url-looks-like-pdp body #v65-product-related tr,
+body.productdetails #related_products_content tr,
+body.productdetails #v65-product-related tr,
+body.mc-product-page #related_products_content tr,
+body.mc-product-page #v65-product-related tr {
+  display: table-row !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+  height: auto !important;
+  max-height: none !important;
+  overflow: visible !important;
+}
+
+/* Restore cells */
+html.mc-url-looks-like-pdp body #related_products_content td,
+html.mc-url-looks-like-pdp body #v65-product-related td,
+body.productdetails #related_products_content td,
+body.productdetails #v65-product-related td,
+body.mc-product-page #related_products_content td,
+body.mc-product-page #v65-product-related td {
+  display: table-cell !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+  width: 25% !important;
+  max-width: 25% !important;
+  min-width: 0 !important;
+  height: auto !important;
+  max-height: none !important;
+  padding: 10px 14px !important;
+  text-align: center !important;
+  vertical-align: top !important;
+  float: none !important;
+  clear: none !important;
+  position: static !important;
+  overflow: visible !important;
+}
+
+/* Restore related item image links */
+html.mc-url-looks-like-pdp body #related_products_content td a,
+html.mc-url-looks-like-pdp body #v65-product-related td a,
+body.productdetails #related_products_content td a,
+body.productdetails #v65-product-related td a,
+body.mc-product-page #related_products_content td a,
+body.mc-product-page #v65-product-related td a {
+  display: inline-flex !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+  align-items: center !important;
+  justify-content: center !important;
+  text-align: center !important;
+}
+
+/* Restore related item images */
+html.mc-url-looks-like-pdp body #related_products_content img,
+html.mc-url-looks-like-pdp body #v65-product-related img,
+body.productdetails #related_products_content img,
+body.productdetails #v65-product-related img,
+body.mc-product-page #related_products_content img,
+body.mc-product-page #v65-product-related img {
+  display: block !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+  width: auto !important;
+  height: auto !important;
+  max-width: 180px !important;
+  max-height: 160px !important;
+  margin: 0 auto 10px auto !important;
+  object-fit: contain !important;
+  object-position: center center !important;
+  float: none !important;
+  clear: none !important;
+  position: static !important;
+}
+
+/* Mobile */
+@media (max-width: 991px) {
+  html.mc-url-looks-like-pdp body #related_products_content td,
+  html.mc-url-looks-like-pdp body #v65-product-related td,
+  body.productdetails #related_products_content td,
+  body.productdetails #v65-product-related td,
+  body.mc-product-page #related_products_content td,
+  body.mc-product-page #v65-product-related td {
+    width: 50% !important;
+    max-width: 50% !important;
+    padding: 8px !important;
+  }
+}
+</style>
+
+<script>
+(function () {
+  function removeOnlyStaleCustomSafeCss() {
+    var stale = document.querySelectorAll('link[data-mc-pdp-fix="20260713relbb1"][href*="custom-safe.css"]');
+    stale.forEach(function (link) { if (link.parentNode) link.parentNode.removeChild(link); });
+  }
+  removeOnlyStaleCustomSafeCss();
+  window.addEventListener('load', removeOnlyStaleCustomSafeCss, { once: true });
+})();
+</script>
+<script src="/v/vspfiles/js/mc-pdp-alt-view-row.js?v=20260718altall5"></script>
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496" integrity="sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==" data-cf-beacon='{"version":"2024.11.0","token":"219322d1a28c40a88da65ab074cf5d58","server_timing":{"name":{"cfCacheStatus":true,"cfEdge":true,"cfExtPri":true,"cfL4":true,"cfOrigin":true,"cfSpeedBrain":true},"location_startswith":null}}' crossorigin="anonymous"></script>
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'a1c9facf1ed8f075',t:'MTc4NDI5ODk5NQ=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script>
+
+
+<script type="text/javascript">function store_init(event){} AttachEvent(window, 'load', store_init);</script>
+
+<script type="text/javascript">
+    if (!/\/shoppingcart\.asp/i.test(window.location.pathname)) {
+        jQuery(document).ready(function() {
+            jQuery('a').each(AddCartLink)
+        });
+    }
+</script>
+
+  <script>
+     if (document.getElementsByName("MailingList")[0]) {
+        var emailSubscribeForm = document.getElementsByName("MailingList")[0];
+        disableSubscribeSubmit = function() {
+          emailSubscribeButton.removeAttribute("type");
+        }
+        forwardToMailingList = function(e) {
+            var subscribeEmail = emailSubscribeForm.querySelector("input").value;
+          sessionStorage.setItem("subEmailAddress", subscribeEmail);
+          emailSubscribeForm.submit();
+        }
+
+        if (emailSubscribeForm.querySelector("button")) {
+            var emailSubscribeButton = emailSubscribeForm.querySelector("button");
+            emailSubscribeButton.addEventListener("click", forwardToMailingList);
+        }
+    }
+  </script>
+<script src="/a/j/class-name-watcher.js" defer ></script>
+
+    <script src="/a/j/push-cart.js" defer ></script>
+
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'a1d69f609819f25b',t:'MTc4NDQzMTU2NA=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script><script defer src="https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496" integrity="sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==" data-cf-beacon='{"version":"2024.11.0","token":"219322d1a28c40a88da65ab074cf5d58","server_timing":{"name":{"cfCacheStatus":true,"cfEdge":true,"cfExtPri":true,"cfL4":true,"cfOrigin":true,"cfSpeedBrain":true},"location_startswith":null}}' crossorigin="anonymous"></script>
+</body>
+</html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
JPG lifestyle images from The Mahjong House are already live under `/v/vspfiles/mahjong/*.jpg`, but `/mahjong-s/201.htm` still points at `.webp` (404) and an inline repair script keeps re-applying those URLs.

This uploads a patched `201.htm` with `.jpg` refs (and a small coerce in the inline repair script), plus deploy wiring to publish `/mahjong-s/201.htm`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f782e-2d7f-77bd-ac55-8d037b3bb65d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f782e-2d7f-77bd-ac55-8d037b3bb65d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

