### PR TITLE
Strengthen Mahjong landing image remap

### DIFF
--- a/template_266.html
+++ b/template_266.html
@@ -1666,7 +1666,7 @@ html.mc-mahjong-pdp-init:not(.mc-mahjong-pdp-ready) #mc-pdp-accordion{
 })(window, document);
   </script>
   <script id="mc-plp-enforcer-bridge">
-(function(g,d){var W="20260719mahjong1",vn=function(v){var n=parseInt(String(v||"").replace(/\D/g,""),10);return isNaN(n)?0:n;};
+(function(g,d){var W="20260719mahjong2",vn=function(v){var n=parseInt(String(v||"").replace(/\D/g,""),10);return isNaN(n)?0:n;};
 
 function cat(){try{var p=String(g.location.pathname||"").toLowerCase();
 var isHome =
@@ -14631,7 +14631,7 @@ s0.parentNode.insertBefore(s1,s0);
 })();
 </script>
 <!--End of Tawk.to Script-->
-  <script id="mc-plp-enforcer-js" src="/v/vspfiles/js/mc-plp-enforcer.js?v=20260719mahjong1"></script>
+  <script id="mc-plp-enforcer-js" src="/v/vspfiles/js/mc-plp-enforcer.js?v=20260719mahjong2"></script>
  
   <script id="mc-my-boards-template-boot">
 (function () {

--- a/vspfiles/js/mc-plp-enforcer.js
+++ b/vspfiles/js/mc-plp-enforcer.js
@@ -1,13 +1,13 @@
 /**
  * PLP fixes — DOM-driven, scoped to inspected Volusion markup.
- * MC_PLP_ENFORCER_20260719mahjong1 — cart glyph + Mahjong landing .webp→.jpg remap
+ * MC_PLP_ENFORCER_20260719mahjong2 — cart glyph + Mahjong landing .webp→.jpg remap
  *
  * Thumbnails: .mc-plp-image-box; image element sized to the wrapper, object-fit: contain (no crop).
  */
 (function (global) {
   "use strict";
 
-  var VERSION = "20260719mahjong1";
+  var VERSION = "20260719mahjong2";
 
   function plpVerNum(v) {
     var n = parseInt(String(v || "").replace(/\D/g, ""), 10);
@@ -2063,8 +2063,21 @@
 
   global.document.addEventListener("DOMContentLoaded", repairMahjongLandingImages);
   global.addEventListener("load", repairMahjongLandingImages);
-  [100, 500, 1500].forEach(function (ms) {
+  [50, 100, 350, 500, 900, 1500, 3000].forEach(function (ms) {
     global.setTimeout(repairMahjongLandingImages, ms);
   });
+  try {
+    if (!global.__MC_MAHJONG_LANDING_REPAIR_IV__) {
+      global.__MC_MAHJONG_LANDING_REPAIR_IV__ = global.setInterval(
+        repairMahjongLandingImages,
+        1000
+      );
+      global.setTimeout(function () {
+        try {
+          global.clearInterval(global.__MC_MAHJONG_LANDING_REPAIR_IV__);
+        } catch (eClr) {}
+      }, 12000);
+    }
+  } catch (eIv) {}
   repairMahjongLandingImages();
 })(window);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Public `/mahjong-s/201.htm` is still served with `.webp` refs from Volusion’s DB copy. The JPG lifestyle images are already live at `/v/vspfiles/mahjong/*.jpg`.

This keeps remapping `.webp` → `.jpg` after the page’s inline repair script runs, so the landing hero/category cards show the TMH lifestyle photos.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f782e-2d7f-77bd-ac55-8d037b3bb65d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f782e-2d7f-77bd-ac55-8d037b3bb65d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

