### PR TITLE
Mahjong landing: CSS fallbacks for TMH lifestyle photos

### DIFF
--- a/vspfiles/css/custom-safe.css
+++ b/vspfiles/css/custom-safe.css
@@ -23802,3 +23802,55 @@ html body .mc-cart-float svg.mc-cart-float__icon {
   height: 0 !important;
 }
 /* END REMOVABLE: mobile cart glyph visible (20260719cart1) */
+
+
+/* BEGIN REMOVABLE: Mahjong landing lifestyle images (20260719mahjong3)
+   Page HTML still points at missing .webp; Volusion HTTP 404s those.
+   Paint live JPG lifestyle photos on the containers instead. */
+#mc-mahjong-page .mc-hero-media {
+  background-image: url("/v/vspfiles/mahjong/hero-community.jpg") !important;
+  background-size: cover !important;
+  background-position: center center !important;
+  background-repeat: no-repeat !important;
+  background-color: #eee !important;
+}
+#mc-mahjong-page .mc-hero-media img.mc-mahjong-landing-image {
+  opacity: 0 !important;
+}
+#mc-mahjong-page a.mc-shop-card[href*="/category-s/202"] .mc-shop-card__image,
+#mc-mahjong-page a.mc-shop-card[href*="category-s/202"] .mc-shop-card__image {
+  background-image: url("/v/vspfiles/mahjong/category-tiles.jpg") !important;
+  background-size: cover !important;
+  background-position: center center !important;
+  background-repeat: no-repeat !important;
+  background-color: #f3f3f3 !important;
+}
+#mc-mahjong-page a.mc-shop-card[href*="Search=travel"] .mc-shop-card__image {
+  background-image: url("/v/vspfiles/mahjong/category-travel.jpg") !important;
+  background-size: cover !important;
+  background-position: center center !important;
+  background-repeat: no-repeat !important;
+  background-color: #f3f3f3 !important;
+}
+#mc-mahjong-page a.mc-shop-card[href*="/category-s/203"] .mc-shop-card__image,
+#mc-mahjong-page a.mc-shop-card[href*="category-s/203"] .mc-shop-card__image {
+  background-image:
+    url("/v/vspfiles/mahjong/category-mat.jpg"),
+    url("/v/vspfiles/mahjong/category-racks.jpg") !important;
+  background-size: 50% 100%, 50% 100% !important;
+  background-position: left center, right center !important;
+  background-repeat: no-repeat, no-repeat !important;
+  background-color: #f3f3f3 !important;
+}
+#mc-mahjong-page a.mc-shop-card[href*="/category-s/204"] .mc-shop-card__image,
+#mc-mahjong-page a.mc-shop-card[href*="category-s/204"] .mc-shop-card__image {
+  background-image: url("/v/vspfiles/mahjong/category-accessories.jpg") !important;
+  background-size: cover !important;
+  background-position: center center !important;
+  background-repeat: no-repeat !important;
+  background-color: #f3f3f3 !important;
+}
+#mc-mahjong-page a.mc-shop-card .mc-shop-card__image img.mc-mahjong-landing-image {
+  opacity: 0 !important;
+}
+/* END REMOVABLE: Mahjong landing lifestyle images (20260719mahjong3) */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The six Mahjong landing images were 404ing (`.webp`). Lifestyle JPGs from themahonghouse.com are already live at `/v/vspfiles/mahjong/*.jpg`, but the public category HTML still points at `.webp`.

This adds `custom-safe.css` background fallbacks on the hero and shop cards so the photos show immediately without waiting on Volusion to rebake `201.htm`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f782e-2d7f-77bd-ac55-8d037b3bb65d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f782e-2d7f-77bd-ac55-8d037b3bb65d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

