### PR TITLE
Fix Mahjong trainer discard selection resizing neighbor tiles

### DIFF
--- a/template_266.html
+++ b/template_266.html
@@ -1666,7 +1666,7 @@ html.mc-mahjong-pdp-init:not(.mc-mahjong-pdp-ready) #mc-pdp-accordion{
 })(window, document);
   </script>
   <script id="mc-plp-enforcer-bridge">
-(function(g,d){var W="20260719mahjong2",vn=function(v){var n=parseInt(String(v||"").replace(/\D/g,""),10);return isNaN(n)?0:n;};
+(function(g,d){var W="20260720sel1",vn=function(v){var n=parseInt(String(v||"").replace(/\D/g,""),10);return isNaN(n)?0:n;};
 
 function cat(){try{var p=String(g.location.pathname||"").toLowerCase();
 var isHome =
@@ -14631,7 +14631,7 @@ s0.parentNode.insertBefore(s1,s0);
 })();
 </script>
 <!--End of Tawk.to Script-->
-  <script id="mc-plp-enforcer-js" src="/v/vspfiles/js/mc-plp-enforcer.js?v=20260719mahjong2"></script>
+  <script id="mc-plp-enforcer-js" src="/v/vspfiles/js/mc-plp-enforcer.js?v=20260720sel1"></script>
  
   <script id="mc-my-boards-template-boot">
 (function () {

--- a/vspfiles/css/custom-safe.css
+++ b/vspfiles/css/custom-safe.css
@@ -23854,3 +23854,85 @@ html body .mc-cart-float svg.mc-cart-float__icon {
   opacity: 0 !important;
 }
 /* END REMOVABLE: Mahjong landing lifestyle images (20260719mahjong3) */
+
+
+/* BEGIN REMOVABLE: Mahjong trainer selected-tile size lock (20260720sel1)
+   Selecting a discard rebuilds the rack; fluid grid width:100% tiles then
+   resize as images reload. Lock fixed tile boxes; selection is transform-only. */
+#mc-mahjong-page .mc-live-rack {
+  align-items: flex-end !important;
+}
+#mc-mahjong-page .mc-live-tile,
+#mc-mahjong-page .mc-live-tile:hover,
+#mc-mahjong-page .mc-live-tile:focus,
+#mc-mahjong-page .mc-live-tile:focus-visible,
+#mc-mahjong-page .mc-live-tile:active,
+#mc-mahjong-page .mc-live-tile.is-selected {
+  box-sizing: border-box !important;
+  flex: 0 0 58px !important;
+  width: 58px !important;
+  min-width: 58px !important;
+  max-width: 58px !important;
+  height: 76px !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  border: 0 !important;
+  justify-self: center !important;
+}
+#mc-mahjong-page .mc-live-tile {
+  transform: none;
+  transition: transform 0.14s ease !important;
+}
+#mc-mahjong-page .mc-live-tile.is-selected {
+  transform: translateY(-11px) !important;
+}
+#mc-mahjong-page .mc-live-tile img {
+  display: block !important;
+  width: 58px !important;
+  min-width: 58px !important;
+  max-width: 58px !important;
+  height: 76px !important;
+  aspect-ratio: 86 / 112 !important;
+  object-fit: contain !important;
+}
+@media (max-width: 560px) {
+  #mc-mahjong-page .mc-live-tile,
+  #mc-mahjong-page .mc-live-tile:hover,
+  #mc-mahjong-page .mc-live-tile:focus,
+  #mc-mahjong-page .mc-live-tile:focus-visible,
+  #mc-mahjong-page .mc-live-tile:active,
+  #mc-mahjong-page .mc-live-tile.is-selected {
+    flex: 0 0 49px !important;
+    width: 49px !important;
+    min-width: 49px !important;
+    max-width: 49px !important;
+    height: 64px !important;
+  }
+  #mc-mahjong-page .mc-live-tile img {
+    width: 49px !important;
+    min-width: 49px !important;
+    max-width: 49px !important;
+    height: 64px !important;
+  }
+}
+@media (min-width: 761px) {
+  #mc-mahjong-page .mc-live-tile,
+  #mc-mahjong-page .mc-live-tile:hover,
+  #mc-mahjong-page .mc-live-tile:focus,
+  #mc-mahjong-page .mc-live-tile:focus-visible,
+  #mc-mahjong-page .mc-live-tile:active,
+  #mc-mahjong-page .mc-live-tile.is-selected {
+    flex: 0 0 70px !important;
+    width: 70px !important;
+    min-width: 70px !important;
+    max-width: 70px !important;
+    height: 91px !important;
+  }
+  #mc-mahjong-page .mc-live-tile img {
+    width: 70px !important;
+    min-width: 70px !important;
+    max-width: 70px !important;
+    height: 91px !important;
+  }
+}
+/* END REMOVABLE: Mahjong trainer selected-tile size lock (20260720sel1) */

--- a/vspfiles/js/mc-plp-enforcer.js
+++ b/vspfiles/js/mc-plp-enforcer.js
@@ -1,13 +1,13 @@
 /**
  * PLP fixes — DOM-driven, scoped to inspected Volusion markup.
- * MC_PLP_ENFORCER_20260719mahjong2 — cart glyph + Mahjong landing .webp→.jpg remap
+ * MC_PLP_ENFORCER_20260720sel1 — cart glyph + Mahjong landing remap + trainer tile size lock
  *
  * Thumbnails: .mc-plp-image-box; image element sized to the wrapper, object-fit: contain (no crop).
  */
 (function (global) {
   "use strict";
 
-  var VERSION = "20260719mahjong2";
+  var VERSION = "20260720sel1";
 
   function plpVerNum(v) {
     var n = parseInt(String(v || "").replace(/\D/g, ""), 10);
@@ -2054,6 +2054,162 @@
     }
   }
 
+  /* Inject late so it wins over baked mahjong page style blocks that set
+     width:100% on trainer tiles inside a 5-column 1fr grid. */
+  function stabilizeMahjongTrainerTileSizes() {
+    if (!document.getElementById("mc-mahjong-page")) return;
+    var styleId = "mc-mahjong-trainer-tile-stable-css";
+    var css =
+      "#mc-mahjong-page .mc-live-rack{align-items:flex-end!important}" +
+      "#mc-mahjong-page .mc-live-tile," +
+      "#mc-mahjong-page .mc-live-tile:hover," +
+      "#mc-mahjong-page .mc-live-tile:focus," +
+      "#mc-mahjong-page .mc-live-tile:focus-visible," +
+      "#mc-mahjong-page .mc-live-tile:active," +
+      "#mc-mahjong-page .mc-live-tile.is-selected{" +
+      "box-sizing:border-box!important;flex:0 0 58px!important;" +
+      "width:58px!important;min-width:58px!important;max-width:58px!important;" +
+      "height:76px!important;padding:0!important;margin:0!important;" +
+      "border:0!important;justify-self:center!important}" +
+      "#mc-mahjong-page .mc-live-tile{transform:none;transition:transform .14s ease!important}" +
+      "#mc-mahjong-page .mc-live-tile.is-selected{transform:translateY(-11px)!important}" +
+      "#mc-mahjong-page .mc-live-tile img{" +
+      "display:block!important;width:58px!important;min-width:58px!important;" +
+      "max-width:58px!important;height:76px!important;aspect-ratio:86/112!important;" +
+      "object-fit:contain!important}" +
+      "@media (max-width:560px){" +
+      "#mc-mahjong-page .mc-live-tile," +
+      "#mc-mahjong-page .mc-live-tile:hover," +
+      "#mc-mahjong-page .mc-live-tile:focus," +
+      "#mc-mahjong-page .mc-live-tile:focus-visible," +
+      "#mc-mahjong-page .mc-live-tile:active," +
+      "#mc-mahjong-page .mc-live-tile.is-selected{" +
+      "flex:0 0 49px!important;width:49px!important;min-width:49px!important;" +
+      "max-width:49px!important;height:64px!important}" +
+      "#mc-mahjong-page .mc-live-tile img{" +
+      "width:49px!important;min-width:49px!important;max-width:49px!important;" +
+      "height:64px!important}}" +
+      "@media (min-width:761px){" +
+      "#mc-mahjong-page .mc-live-tile," +
+      "#mc-mahjong-page .mc-live-tile:hover," +
+      "#mc-mahjong-page .mc-live-tile:focus," +
+      "#mc-mahjong-page .mc-live-tile:focus-visible," +
+      "#mc-mahjong-page .mc-live-tile:active," +
+      "#mc-mahjong-page .mc-live-tile.is-selected{" +
+      "flex:0 0 70px!important;width:70px!important;min-width:70px!important;" +
+      "max-width:70px!important;height:91px!important}" +
+      "#mc-mahjong-page .mc-live-tile img{" +
+      "width:70px!important;min-width:70px!important;max-width:70px!important;" +
+      "height:91px!important}}";
+
+    var el = document.getElementById(styleId);
+    if (!el) {
+      el = document.createElement("style");
+      el.id = styleId;
+      el.setAttribute("data-mc", VERSION);
+      (document.body || document.documentElement).appendChild(el);
+    }
+    if (el.textContent !== css) el.textContent = css;
+  }
+
+  /* Selection rebuilds the rack and reloads tile PNGs; restore already-repaired
+     data URIs immediately so neighbors don't briefly pick up different intrinsics. */
+  function cacheMahjongRepairedTileImages() {
+    if (global.__MC_MAHJONG_TILE_SRC_CACHE_OBS__) return;
+    if (!document.getElementById("mc-mahjong-page")) return;
+
+    var cache = global.__MC_MAHJONG_TILE_SRC_CACHE__ || {};
+    global.__MC_MAHJONG_TILE_SRC_CACHE__ = cache;
+
+    function tileKey(src) {
+      if (!src) return "";
+      if (src.indexOf("data:image/") === 0) return "";
+      var m = String(src).match(/tile-[a-z0-9-]+\.png/i);
+      return m ? m[0].toLowerCase() : "";
+    }
+
+    function remember(img) {
+      if (!img || img.tagName !== "IMG") return;
+      var src = img.getAttribute("src") || "";
+      if (src.indexOf("data:image/") !== 0) return;
+      var key = tileKey(img.getAttribute("data-mc-tile-file") || "");
+      if (!key) {
+        /* repaired imgs lose the filename in src; keep last known file on the node */
+        key = img.getAttribute("data-mc-tile-file") || "";
+      }
+      if (key) cache[key] = src;
+    }
+
+    function restore(img) {
+      if (!img || img.tagName !== "IMG") return;
+      var src = img.getAttribute("src") || "";
+      var key = tileKey(src);
+      if (!key) return;
+      img.setAttribute("data-mc-tile-file", key);
+      if (cache[key] && src.indexOf("data:image/") !== 0) {
+        img.setAttribute("src", cache[key]);
+        img.dataset.mcTileRepairState = "done";
+      }
+    }
+
+    function scan(scope) {
+      if (!scope || !scope.querySelectorAll) return;
+      Array.prototype.forEach.call(
+        scope.querySelectorAll(
+          '#mc-live-rack img[src*="mahjong/tiles/tile-"], #mc-live-rack img[src^="data:image/"]'
+        ),
+        function (img) {
+          var src = img.getAttribute("src") || "";
+          if (src.indexOf("data:image/") === 0) {
+            if (!img.getAttribute("data-mc-tile-file")) {
+              /* cannot key anonymous data URIs without a prior file mark */
+              remember(img);
+            } else {
+              cache[img.getAttribute("data-mc-tile-file")] = src;
+            }
+            return;
+          }
+          restore(img);
+        }
+      );
+    }
+
+    scan(document);
+
+    var obs = new MutationObserver(function (mutations) {
+      mutations.forEach(function (mutation) {
+        if (mutation.type === "attributes" && mutation.target.tagName === "IMG") {
+          var src = mutation.target.getAttribute("src") || "";
+          if (src.indexOf("data:image/") === 0) {
+            var key =
+              mutation.target.getAttribute("data-mc-tile-file") ||
+              tileKey(mutation.oldValue || "");
+            if (key) {
+              mutation.target.setAttribute("data-mc-tile-file", key);
+              cache[key] = src;
+            }
+          } else {
+            restore(mutation.target);
+          }
+        }
+        Array.prototype.forEach.call(mutation.addedNodes, function (node) {
+          if (node.nodeType !== 1) return;
+          if (node.tagName === "IMG") restore(node);
+          scan(node);
+        });
+      });
+    });
+
+    obs.observe(document.getElementById("mc-mahjong-page"), {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["src"],
+      attributeOldValue: true
+    });
+    global.__MC_MAHJONG_TILE_SRC_CACHE_OBS__ = obs;
+  }
+
   global.document.addEventListener("DOMContentLoaded", repairCartFloatIcon);
   global.addEventListener("load", repairCartFloatIcon);
   [200, 1000, 3000].forEach(function (ms) {
@@ -2080,4 +2236,24 @@
     }
   } catch (eIv) {}
   repairMahjongLandingImages();
+
+  global.document.addEventListener(
+    "DOMContentLoaded",
+    stabilizeMahjongTrainerTileSizes
+  );
+  global.addEventListener("load", stabilizeMahjongTrainerTileSizes);
+  [0, 50, 200, 800, 2000].forEach(function (ms) {
+    global.setTimeout(stabilizeMahjongTrainerTileSizes, ms);
+  });
+  stabilizeMahjongTrainerTileSizes();
+
+  global.document.addEventListener(
+    "DOMContentLoaded",
+    cacheMahjongRepairedTileImages
+  );
+  global.addEventListener("load", cacheMahjongRepairedTileImages);
+  [100, 500, 1500].forEach(function (ms) {
+    global.setTimeout(cacheMahjongRepairedTileImages, ms);
+  });
+  cacheMahjongRepairedTileImages();
 })(window);

--- a/vspfiles/mahjong/mahjong-s-201.htm
+++ b/vspfiles/mahjong/mahjong-s-201.htm
@@ -3823,7 +3823,7 @@ var SearchParams = 'searching=Y&sort=13&cat=201&show=30&page=1';
 #mc-mahjong-page .mc-live-trainer__disclaimer{margin:16px 0 0!important;color:#7b7168!important;font-size:10px!important;line-height:1.55!important}
 #mc-mahjong-page .mc-section-head--pattern-library{margin-top:38px!important}
 @media(max-width:900px){#mc-mahjong-page .mc-live-suggestions{grid-template-columns:1fr}#mc-mahjong-page .mc-live-advisor__heading{display:block}#mc-mahjong-page .mc-live-advisor__heading>p{margin-top:8px!important;text-align:left}}
-@media(max-width:560px){#mc-mahjong-page .mc-live-trainer{padding:18px 12px}#mc-mahjong-page .mc-live-trainer__head{display:block}#mc-mahjong-page .mc-live-trainer__count{display:inline-block;margin-top:12px}#mc-mahjong-page .mc-live-trainer__controls{display:grid;grid-template-columns:1fr}#mc-mahjong-page .mc-live-trainer__controls button{width:100%}#mc-mahjong-page .mc-live-rack{padding-left:8px;padding-right:8px}#mc-mahjong-page .mc-live-tile,#mc-mahjong-page .mc-live-tile img{width:49px!important;flex-basis:49px}}
+@media(max-width:560px){#mc-mahjong-page .mc-live-trainer{padding:18px 12px}#mc-mahjong-page .mc-live-trainer__head{display:block}#mc-mahjong-page .mc-live-trainer__count{display:inline-block;margin-top:12px}#mc-mahjong-page .mc-live-trainer__controls{display:grid;grid-template-columns:1fr}#mc-mahjong-page .mc-live-trainer__controls button{width:100%}#mc-mahjong-page .mc-live-rack{padding-left:8px;padding-right:8px}#mc-mahjong-page .mc-live-tile,#mc-mahjong-page .mc-live-tile img{width:49px!important;min-width:49px!important;max-width:49px!important;flex:0 0 49px!important;flex-basis:49px;height:64px!important}}
 </style>
 
 
@@ -4594,7 +4594,7 @@ var SearchParams = 'searching=Y&sort=13&cat=201&show=30&page=1';
         tileButton.addEventListener("click",function(){
           if(rack.length!==14)return;
           selectedIndex=(selectedIndex===index?-1:index);
-          renderLiveTrainer();
+          updateSelectionUi();
         });
         rackEl.appendChild(tileButton);
       });
@@ -4622,16 +4622,25 @@ var SearchParams = 'searching=Y&sort=13&cat=201&show=30&page=1';
         suggestionsEl.appendChild(card);
       });
     }
-    function renderLiveTrainer(){
-      countEl.textContent=rack.length+" TILE"+(rack.length===1?"":"S");
-      drawBtn.disabled=rack.length!==13;
+    function updateSelectionUi(){
       discardBtn.disabled=rack.length!==14||selectedIndex<0;
       if(rack.length===13)statusEl.textContent="Your 13-tile rack is ready. Draw one tile, then choose a discard.";
       else if(selectedIndex>=0)statusEl.textContent="Selected "+tileName(rack[selectedIndex])+". Click DISCARD SELECTED to return to 13 tiles.";
       else statusEl.textContent="You drew "+tileName(rack[drawnIndex])+". Click any tile to choose your discard.";
+      Array.prototype.forEach.call(rackEl.children,function(btn,index){
+        var on=index===selectedIndex;
+        btn.classList.toggle("is-selected",on);
+        btn.setAttribute("aria-pressed",on?"true":"false");
+      });
+    }
+    function renderLiveTrainer(){
+      countEl.textContent=rack.length+" TILE"+(rack.length===1?"":"S");
+      drawBtn.disabled=rack.length!==13;
+      updateSelectionUi();
 
       var ranked=rankPatterns(rack);
       renderRack();
+      updateSelectionUi();
       renderSuggestions(ranked);
 
       if(rack.length===14){
@@ -4974,19 +4983,22 @@ var SearchParams = 'searching=Y&sort=13&cat=201&show=30&page=1';
 
   #mc-mahjong-page .mc-live-tile {
     display: block !important;
-    width: 100% !important;
-    min-width: 0 !important;
-    max-width: none !important;
+    width: 58px !important;
+    min-width: 58px !important;
+    max-width: 58px !important;
+    height: 76px !important;
     margin: 0 !important;
-    flex: none !important;
+    flex: 0 0 58px !important;
+    justify-self: center !important;
   }
 
   #mc-mahjong-page .mc-live-tile img {
     display: block !important;
-    width: 100% !important;
-    min-width: 0 !important;
-    max-width: 100% !important;
-    height: auto !important;
+    width: 58px !important;
+    min-width: 58px !important;
+    max-width: 58px !important;
+    height: 76px !important;
+    aspect-ratio: 86 / 112 !important;
     object-fit: contain !important;
   }
 
@@ -5037,6 +5049,11 @@ var SearchParams = 'searching=Y&sort=13&cat=201&show=30&page=1';
 
 #mc-mahjong-page .mc-live-tile.is-selected {
   transform: translateY(-11px) !important;
+  width: 58px !important;
+  min-width: 58px !important;
+  max-width: 58px !important;
+  height: 76px !important;
+  flex: 0 0 58px !important;
 }
 
 #mc-mahjong-page .mc-live-tile img,
@@ -5320,13 +5337,15 @@ var SearchParams = 'searching=Y&sort=13&cat=201&show=30&page=1';
     flex: 0 0 70px !important;
     width: 70px !important;
     min-width: 70px !important;
-    max-width: none !important;
+    max-width: 70px !important;
+    height: 91px !important;
   }
 
   #mc-mahjong-page .mc-live-tile img {
     width: 70px !important;
     min-width: 70px !important;
-    max-width: none !important;
+    max-width: 70px !important;
+    height: 91px !important;
   }
 
   #mc-mahjong-page .mc-tile-strip img {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Selecting a discard in the Mahjong tile trainer was causing surrounding tiles to change size.

**Cause:** Discard selection rebuilt the entire rack. Combined with mobile layout CSS that made tiles `width: 100%` inside a 5-column `1fr` grid, reloaded tile images (and tile-repair reprocessing) made neighbors appear to resize. Selection should only lift the chosen tile.

**Fix:**
- Lock trainer tile button/image to fixed width/height; selection remains `transform: translateY` only
- Inject late CSS via `mc-plp-enforcer.js` so it wins over baked page styles
- Cache repaired tile data-URIs across rack rebuilds
- Update selection UI by toggling `is-selected` without rebuilding the rack (in `mahjong-s-201.htm`)

## Test plan
- [ ] On `/mahjong-s/201.htm`, Auto Deal → Draw
- [ ] Click several tiles to select/deselect discard candidates
- [ ] Confirm only the selected tile lifts; neighbors keep the same size
- [ ] Confirm Discard Selected still works
- [ ] Spot-check mobile width (~390–760px) and desktop
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f782e-2d7f-77bd-ac55-8d037b3bb65d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f782e-2d7f-77bd-ac55-8d037b3bb65d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

