### PR TITLE
Hide CLOSE MENU next to SELECT A CATEGORY on mobile

### DIFF
--- a/template_266.html
+++ b/template_266.html
@@ -5446,12 +5446,9 @@ body.mc-product-page .productnamecolorLARGE.colors_productname {
     if (toggle){
       toggle.classList.toggle('push-menu--open', openNow);
       toggle.classList.toggle('push-menu--closed', !openNow);
-
-      var txt = toggle.querySelector('.menu-toggle__text');
-      if (txt){
-        txt.classList.toggle('push-menu--open', openNow);
-        txt.classList.toggle('push-menu--closed', !openNow);
-      }
+      /* Leave dual .menu-toggle__text spans alone — CSS shows SELECT vs CLOSE
+         from body/html.push-menu-open. Mutating the first span caused both
+         labels to appear at once on mobile. */
     }
 
     var panel = getPanel();

--- a/vspfiles/css/custom-safe.css
+++ b/vspfiles/css/custom-safe.css
@@ -1904,11 +1904,11 @@ a.mc-account-float {
 }
 
 @media (max-width: 991px) {
-  body.push-menu-open.menu-toggle__text.push-menu--closed {
+  body.push-menu-open .menu-toggle__text.push-menu--closed {
     display: none !important;
   }
 
-  body.push-menu-open.menu-toggle__text.push-menu--open {
+  body.push-menu-open .menu-toggle__text.push-menu--open {
     display: inline !important;
   }
 
@@ -19047,12 +19047,31 @@ html body.mc-product-page #mc-pdp-description-below-features.mc-pdp-description-
     box-sizing: border-box !important;
   }
 
-  header.header .menu-toggle__text {
+  /* Only style the closed label here — never force both SELECT + CLOSE visible */
+  header.header .menu-toggle__text.push-menu--closed {
     display: inline-block !important;
     width: 100% !important;
     margin: 0 auto !important;
     text-align: center !important;
     letter-spacing: 0.08em !important;
+  }
+
+  header.header .menu-toggle__text.push-menu--open {
+    display: none !important;
+  }
+
+  body.push-menu-open header.header .menu-toggle__text.push-menu--open,
+  html.push-menu-open header.header .menu-toggle__text.push-menu--open {
+    display: inline-block !important;
+    width: 100% !important;
+    margin: 0 auto !important;
+    text-align: center !important;
+    letter-spacing: 0.08em !important;
+  }
+
+  body.push-menu-open header.header .menu-toggle__text.push-menu--closed,
+  html.push-menu-open header.header .menu-toggle__text.push-menu--closed {
+    display: none !important;
   }
 
   header.header .menu-toggle__icon {
@@ -24034,12 +24053,16 @@ html body .mc-cart-float svg.mc-cart-float__icon {
   }
 
   html.mc-allow-home-hero body.is-home header.header .header__section--bottom .menu-toggle,
-  html.mc-allow-home-hero body.is-home header.header .header__section--bottom .menu-toggle__link,
-  html.mc-allow-home-hero body.is-home header.header .header__section--bottom .menu-toggle__text {
+  html.mc-allow-home-hero body.is-home header.header .header__section--bottom .menu-toggle__link {
     display: flex !important;
     visibility: visible !important;
     opacity: 1 !important;
     pointer-events: auto !important;
+    color: #ffffff !important;
+    -webkit-text-fill-color: #ffffff !important;
+  }
+
+  html.mc-allow-home-hero body.is-home header.header .header__section--bottom .menu-toggle__text {
     color: #ffffff !important;
     -webkit-text-fill-color: #ffffff !important;
   }
@@ -24288,3 +24311,61 @@ html body.mc-saranoni-pdp .v65-product-addtocart button {
   }
 }
 /* END REMOVABLE: Saranoni mobile title/related + PDP category bar (20260720sarmob1) */
+
+/* BEGIN REMOVABLE: hide CLOSE MENU when menu closed (20260720closemenu1) */
+@media (max-width: 991px) {
+  html body:not(.push-menu-open) header.header .menu-toggle__text.push-menu--open,
+  html body:not(.push-menu-open) .menu-toggle .menu-toggle__text.push-menu--open,
+  html:not(.push-menu-open) body header.header .menu-toggle__text.push-menu--open {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    width: 0 !important;
+    max-width: 0 !important;
+    height: 0 !important;
+    overflow: hidden !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    font-size: 0 !important;
+    line-height: 0 !important;
+    pointer-events: none !important;
+  }
+
+  html body.push-menu-open header.header .menu-toggle__text.push-menu--closed,
+  html body.push-menu-open .menu-toggle .menu-toggle__text.push-menu--closed,
+  html.push-menu-open body header.header .menu-toggle__text.push-menu--closed {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    width: 0 !important;
+    max-width: 0 !important;
+    height: 0 !important;
+    overflow: hidden !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    font-size: 0 !important;
+    line-height: 0 !important;
+    pointer-events: none !important;
+  }
+
+  html body.push-menu-open header.header .menu-toggle__text.push-menu--open,
+  html.push-menu-open body header.header .menu-toggle__text.push-menu--open {
+    display: inline-block !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+    width: auto !important;
+    max-width: none !important;
+    height: auto !important;
+    overflow: visible !important;
+    font-size: inherit !important;
+    line-height: inherit !important;
+    pointer-events: auto !important;
+  }
+
+  html body:not(.push-menu-open) header.header .menu-toggle__text.push-menu--closed {
+    display: inline-block !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+  }
+}
+/* END REMOVABLE: hide CLOSE MENU when menu closed (20260720closemenu1) */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
On mobile, the header showed **SELECT A CATEGORY** and **CLOSE MENU** at the same time when the category menu was closed.

## Cause
1. A CSS rule forced `display: inline-block !important` on every `.menu-toggle__text`, so both labels were always visible.
2. Menu JS toggled `push-menu--open` / `push-menu--closed` on only the first label span, which broke the dual-label markup.

## Fix
- Scope mobile header styles so only the closed label is forced visible; hide `.push-menu--open` unless `body`/`html` has `push-menu-open`.
- Add a late override block (`20260720closemenu1`) as a safety net.
- Stop mutating the dual `.menu-toggle__text` spans in `template_266.html`; rely on `body.push-menu-open` for which label shows.

## Files
- `vspfiles/css/custom-safe.css`
- `template_266.html`

After merge, Deploy to Volusion on `main` will publish the CSS/template changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f782e-2d7f-77bd-ac55-8d037b3bb65d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f782e-2d7f-77bd-ac55-8d037b3bb65d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

