### PR TITLE
Really stop PDP enforcer reinject loop

### DIFF
--- a/vspfiles/js/mc-pdp-auth-cta-form.js
+++ b/vspfiles/js/mc-pdp-auth-cta-form.js
@@ -11,42 +11,16 @@
   var VERSION = "20260725tap4";
   /* Prefer numeric deploy rank so old labels like style1/restore15 cannot
      lexicographically beat a newer fix* VERSION and keep this IIFE from booting. */
-  var DEPLOY_RANK = 20260725040;
+  var DEPLOY_RANK = 20260725041;
   var ALT_VIEW_ROW_VER = "20260725altmatch1";
-  var ENFORCER_WANT = "20260727001fix1";
   try {
     var prevRank = Number(global.__MC_PDP_AUTH_CTA_DEPLOY_RANK__ || 0) || 0;
     if (prevRank >= DEPLOY_RANK) return;
     global.__MC_PDP_AUTH_CTA_DEPLOY_RANK__ = DEPLOY_RANK;
     global.__MC_PDP_AUTH_CTA_MAX_VER__ = VERSION;
   } catch (eMax) {}
-  /* Baked pages load auth-cta with &mcrd= (CDN miss). Use that to also pull a
-     fresh enforcer when the static ?v=form3 URL is still a year-long HIT. */
-  try {
-    var enfDigits = parseInt(String(global.__MC_PLP_ENFORCER_VER__ || "").replace(/\D/g, ""), 10) || 0;
-    var wantDigits = parseInt(String(ENFORCER_WANT).replace(/\D/g, ""), 10) || 0;
-    if (enfDigits < wantDigits && !global.__MC_PLP_ENFORCER_HOTLOAD__) {
-      global.__MC_PLP_ENFORCER_HOTLOAD__ = true;
-      global.document.querySelectorAll('script[src*="mc-plp-enforcer"]').forEach(function (oldEnf) {
-        try { oldEnf.remove(); } catch (eRmEnf) {}
-      });
-      try {
-        delete global.__MC_PLP_ENFORCER__;
-        delete global.__MC_PLP_ENFORCER_VER__;
-        delete global.mcPlpEnforcerRun;
-      } catch (eDelEnf) {}
-      var enfScript = global.document.createElement("script");
-      enfScript.id = "mc-plp-enforcer-js";
-      enfScript.src =
-        "/v/vspfiles/js/mc-plp-enforcer.js?v=" + ENFORCER_WANT + "&mcrd=" + Date.now();
-      enfScript.onload = function () {
-        try {
-          global.mcPlpEnforcerRun && global.mcPlpEnforcerRun();
-        } catch (eEnfRun) {}
-      };
-      (global.document.head || global.document.documentElement).appendChild(enfScript);
-    }
-  } catch (eEnfHot) {}
+  /* Do NOT strip/reinject mc-plp-enforcer from PDP boots — that caused load loops. */
+
   /* Do NOT strip form.js script tags. Baked boots require tag presence and
      __MC_DEPLOY_FP__==="20260725fix3"; stripping caused endless reinject/loading loops. */
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #32: `mc-pdp-auth-cta-form.js` still contained `ENFORCER_WANT` hotload that deletes/reloads `mc-plp-enforcer` on product pages. Removed for real (deploy rank 20260725041).

After merge/deploy, Volusion File Editor → open `template_266.html` (should show `20260727002safe1`) → **Save** once to rebake `/` and PDPs so the old thrashing hotloader is gone from baked HTML.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9b4a-fdde-7b71-afd3-b06a09fa9979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9b4a-fdde-7b71-afd3-b06a09fa9979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

