### PR TITLE
Fix Barron PDP freeze: single auth boot + skip enforcer on products

### DIFF
--- a/scripts/patch_baked_html_enforcer.py
+++ b/scripts/patch_baked_html_enforcer.py
@@ -1,15 +1,387 @@
 #!/usr/bin/env python3
-"""Disabled: baked-HTML enforcer hotpatching caused PDP freeze loops.
+"""Patch baked Volusion .htm files via SFTP (no Cloudflare needed).
 
-Kept as a no-op so deploy.yml / deploy-volusion.sh can still invoke it safely.
-Restore path = pre-freeze storefront (PR #30 / f05a4f26).
+Goals:
+  - Product pages: do NOT load mc-plp-enforcer (sticky CDN thrash froze Barron/sofas)
+  - Product pages: single stable auth boot (no strip/reinject, no Date.now() double load)
+  - Remove thrashing mc-plp-enforcer-hotload-* injectors from older deploys
+  - Category/home: bump enforcer ?v= only (never re-inject hotloaders)
 """
 from __future__ import annotations
+
+import os
+import re
 import sys
 
+from verify_template_sftp import connect_paramiko_transport
+
+WANT = os.environ.get("MC_ENFORCER_WANT", "20260727009live1").strip() or "20260727009live1"
+AUTH_SRC = (
+    os.environ.get("MC_AUTH_SRC", "").strip()
+    or "/v/vspfiles/js/mc-pdp-auth-cta-form.js?v=20260725live1&mcrd=live1"
+)
+DEPLOY_META = os.environ.get("MC_DEPLOY_META", "20260727009live1").strip() or "20260727009live1"
+
+OLD_VER_RE = re.compile(
+    r'(src=["\'])/v/vspfiles/js/mc-plp-enforcer\.js\?v=[^"\']+(["\'])',
+    re.I,
+)
+HOTLOADER_RE = re.compile(
+    r'<script\b[^>]*\bid=["\']mc-plp-enforcer-hotload-[^"\']+["\'][^>]*>.*?</script>',
+    re.I | re.S,
+)
+STATIC_ENF_RE = re.compile(
+    r'<script\b[^>]*\bid=["\']mc-plp-enforcer-js["\'][^>]*>.*?</script>'
+    r'|<script\b[^>]*\bsrc=["\'][^"\']*mc-plp-enforcer\.js[^"\']*["\'][^>]*>\s*</script>',
+    re.I | re.S,
+)
+BOOT_RE = re.compile(
+    r"<script>\s*\(function\s*\(\s*g\s*,\s*d\s*\)\s*\{.*?"
+    r"function\s+bootFreshCta\s*\(\s*\)\s*\{.*?"
+    r"\}\)\s*\(\s*window\s*,\s*document\s*\)\s*;\s*</script>",
+    re.I | re.S,
+)
+FALLBACK_RE = re.compile(
+    r'<script\b[^>]*\bid=["\']mc-pdp-auth-loader-minimal["\'][^>]*>.*?</script>',
+    re.I | re.S,
+)
+META_RE = re.compile(
+    r'<meta\s+name=["\']mc-deploy-verify["\']\s+content=["\'][^"\']*["\']\s*/?>',
+    re.I,
+)
+
+SAFE_BOOT = f"""<script>
+(function (g, d) {{
+  var FP = "20260725fix3";
+  var AUTH_SRC = "{AUTH_SRC}";
+  function isPdp() {{
+    try {{
+      var p = String(g.location.pathname || "").toLowerCase();
+      if (/\\/product-p\\//.test(p) || /productdetails\\.asp/i.test(p)) return true;
+    }} catch (ePath) {{}}
+    return !!d.getElementById("v65-product-parent");
+  }}
+  function bootFreshCta() {{
+    if (!isPdp()) return;
+    if (String(g.__MC_DEPLOY_FP__ || "") === FP) return;
+    if (d.documentElement.getAttribute("data-mc-pdp-auth-head-boot") === FP) return;
+    if (d.querySelector('script[src*="mc-pdp-auth-cta-form.js"]')) {{
+      d.documentElement.setAttribute("data-mc-pdp-auth-head-boot", FP);
+      return;
+    }}
+    d.documentElement.setAttribute("data-mc-pdp-auth-head-boot", FP);
+    var s = d.createElement("script");
+    s.id = "mc-pdp-auth-cta-form-js";
+    s.src = AUTH_SRC;
+    s.async = false;
+    (d.head || d.documentElement).appendChild(s);
+  }}
+  bootFreshCta();
+  d.addEventListener("DOMContentLoaded", bootFreshCta);
+}})(window, document);
+</script>"""
+
+SAFE_FALLBACK = f"""<script id="mc-pdp-auth-loader-minimal">
+(function () {{
+  var FP = "20260725fix3";
+  var AUTH_SRC = "{AUTH_SRC}";
+  if (String(window.__MC_DEPLOY_FP__ || "") === FP) {{
+  }} else if (
+    document.documentElement.getAttribute("data-mc-pdp-auth-reload") !== FP &&
+    document.documentElement.getAttribute("data-mc-pdp-auth-head-boot") !== FP &&
+    !document.querySelector('script[src*="mc-pdp-auth-cta-form.js"]')
+  ) {{
+    document.documentElement.setAttribute("data-mc-pdp-auth-reload", FP);
+    var s = document.createElement("script");
+    s.id = "mc-pdp-auth-cta-form-js-fallback";
+    s.src = AUTH_SRC;
+    s.async = false;
+    (document.head || document.documentElement).appendChild(s);
+  }}
+  window.openPlannerOverlay = function () {{}};
+  window.mcEnsurePlannerLoginGate = function () {{ return null; }};
+  window.mcSetPlannerLoginGateVisible = function () {{}};
+  window.mcApplyPlannerAtcDisabledState = function () {{}};
+  window.mcOpenWmLeatherModal = function () {{}};
+  window.mcOpenWmLeatherOverlay = function () {{ return false; }};
+  window.mcForceInitWmLeather = function () {{ return false; }};
+  window.mcTryInitWmLeather = function () {{ return false; }};
+  window.mcMountInlineConfig = function () {{}};
+}})();
+</script>"""
+
+PDP_ENF_SKIP = f"""<script id="mc-plp-enforcer-js">
+/* MC_PLP_ENFORCER_STATIC_{WANT} — skip product pages entirely */
+(function (g, d) {{
+  try {{
+    var p = String(g.location.pathname || "").toLowerCase();
+    if (/\\/product-p\\//.test(p) || /productdetails\\.asp/i.test(p)) return;
+    if (d.getElementById("v65-product-parent")) return;
+  }} catch (eSkip) {{}}
+  if (d.getElementById("mc-plp-enforcer-js-src")) return;
+  if (typeof g.mcPlpEnforcerRun === "function" && g.__MC_PLP_ENFORCER_VER__) return;
+  var s = d.createElement("script");
+  s.id = "mc-plp-enforcer-js-src";
+  s.src = "/v/vspfiles/js/mc-plp-enforcer.js?v={WANT}&mcrd=live1";
+  (d.head || d.documentElement).appendChild(s);
+}})(window, document);
+</script>"""
+
+SEARCH_ROOTS = (
+    "/",
+    "/v",
+    "/mahjong-s",
+    "/sofas-s",
+    "/sectionals-s",
+    "/bean-bag-seating-s",
+    "/palliser-theater-seating-s",
+    "/category-s",
+    "/product-p",
+    "/vspfiles",
+    "/v/vspfiles",
+    "/mccabestheaterandliving.com",
+)
+
+
+def _creds() -> tuple[str, int, str, str]:
+    host = (
+        os.environ.get("SFTP_HOST", "").strip()
+        or os.environ.get("FTP_SERVER", "").strip()
+        or os.environ.get("SECRET_FTP_SERVER", "").strip()
+    )
+    port = int(os.environ.get("SFTP_PORT") or os.environ.get("SECRET_FTP_PORT") or "2222")
+    user = os.environ.get("SFTP_USER") or os.environ.get("FTP_USERNAME") or ""
+    password = os.environ.get("SFTP_PASS") or os.environ.get("FTP_PASSWORD") or ""
+    return host, port, user, password
+
+
+def _listdir(sftp, path: str) -> list:
+    try:
+        return sftp.listdir_attr(path)
+    except OSError:
+        return []
+
+
+def _walk_htm(sftp, root: str, limit: int = 2000) -> list[str]:
+    found: list[str] = []
+    stack = [root.rstrip("/") or "/"]
+    seen: set[str] = set()
+    while stack and len(found) < limit:
+        cur = stack.pop()
+        if cur in seen:
+            continue
+        seen.add(cur)
+        for ent in _listdir(sftp, cur):
+            name = ent.filename
+            if name in (".", ".."):
+                continue
+            path = (cur.rstrip("/") + "/" + name) if cur != "/" else "/" + name
+            mode = getattr(ent, "st_mode", 0) or 0
+            is_dir = False
+            try:
+                import stat
+
+                is_dir = stat.S_ISDIR(mode)
+            except Exception:
+                is_dir = name.endswith("-s") or name in (
+                    "v",
+                    "vspfiles",
+                    "category-s",
+                    "product-p",
+                    "mccabestheaterandliving.com",
+                )
+            if is_dir:
+                if name.endswith("-s") or name in (
+                    "v",
+                    "vspfiles",
+                    "category-s",
+                    "product-p",
+                    "mahjong",
+                    "mccabestheaterandliving.com",
+                ):
+                    stack.append(path)
+                continue
+            if name.lower().endswith((".htm", ".html")):
+                found.append(path)
+    return found
+
+
+def _is_product_html(path: str, text: str) -> bool:
+    pl = path.lower()
+    if "/product-p/" in pl or pl.endswith("-p.htm") or pl.endswith("-p.html"):
+        return True
+    if 'id="v65-product-parent"' in text or "id='v65-product-parent'" in text:
+        return True
+    if "bootFreshCta" in text and "mc-pdp-auth-cta-form.js" in text:
+        return True
+    return False
+
+
+def _patch_bytes(path: str, raw: bytes) -> tuple[bytes, bool]:
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        text = raw.decode("latin-1")
+
+    if "mc-plp-enforcer" not in text and "bootFreshCta" not in text and "mc-pdp-auth" not in text:
+        return raw, False
+
+    changed = False
+    is_pdp = _is_product_html(path, text)
+
+    # Always strip thrashing hotloaders from prior deploys.
+    new_text, n_hot = HOTLOADER_RE.subn("", text)
+    if n_hot:
+        changed = True
+        text = new_text
+
+    if is_pdp:
+        new_text, n_boot = BOOT_RE.subn(SAFE_BOOT, text, count=1)
+        if n_boot:
+            changed = True
+            text = new_text
+        new_text, n_fb = FALLBACK_RE.subn(SAFE_FALLBACK, text, count=1)
+        if n_fb:
+            changed = True
+            text = new_text
+        if STATIC_ENF_RE.search(text):
+            new_text, n_enf = STATIC_ENF_RE.subn(PDP_ENF_SKIP, text, count=1)
+            if n_enf:
+                changed = True
+                text = new_text
+        # Remove any remaining static enforcer src tags on PDPs.
+        new_text, n_src = re.subn(
+            r'<script\b[^>]*\bsrc=["\'][^"\']*mc-plp-enforcer\.js[^"\']*["\'][^>]*>\s*</script>',
+            "",
+            text,
+            flags=re.I,
+        )
+        if n_src:
+            changed = True
+            text = new_text
+        new_text, n_meta = META_RE.subn(
+            f'<meta name="mc-deploy-verify" content="{DEPLOY_META}">',
+            text,
+            count=1,
+        )
+        if n_meta:
+            changed = True
+            text = new_text
+    else:
+        new_text, n = OLD_VER_RE.subn(
+            rf'\1/v/vspfiles/js/mc-plp-enforcer.js?v={WANT}&mcrd=live1\2',
+            text,
+        )
+        if n:
+            changed = True
+            text = new_text
+
+    if not changed:
+        return raw, False
+    return text.encode("utf-8"), True
+
+
 def main() -> int:
-    print("::notice::patch_baked_html_enforcer disabled (revert to working storefront)", flush=True)
+    host, port, user, password = _creds()
+    if not host or not user or not password:
+        print("::warning::No SFTP creds — skip baked HTML enforcer patch", flush=True)
+        return 0
+
+    print(
+        f"=== Patch baked HTML (PDP unfreeze + enforcer v={WANT}, no hotloaders) ===",
+        flush=True,
+    )
+    try:
+        transport = connect_paramiko_transport(host, port, user, password)
+    except Exception as exc:  # noqa: BLE001
+        print(f"::warning::SFTP connect failed for HTML patch: {exc}", flush=True)
+        return 0
+
+    import paramiko  # noqa: PLC0415
+
+    patched = 0
+    scanned = 0
+    pdp_patched = 0
+    try:
+        sftp = paramiko.SFTPClient.from_transport(transport)
+        assert sftp is not None
+        priority = [
+            "/product-p/ss-barron-87sofa.htm",
+            "/product-p/ss-barron-65love.htm",
+            "/product-p/ss-barron-recl.htm",
+            "/product-p/ss-luna-ice-pwr-sofa.htm",
+            "product-p/ss-barron-87sofa.htm",
+            "product-p/ss-barron-65love.htm",
+            "product-p/ss-barron-recl.htm",
+            "product-p/ss-luna-ice-pwr-sofa.htm",
+            "/v/product-p/ss-barron-87sofa.htm",
+            "/mccabestheaterandliving.com/product-p/ss-barron-87sofa.htm",
+        ]
+        candidates: list[str] = list(priority)
+        for root in SEARCH_ROOTS:
+            candidates.extend(_walk_htm(sftp, root))
+        seen: set[str] = set()
+        uniq: list[str] = []
+        for p in candidates:
+            if p not in seen:
+                seen.add(p)
+                uniq.append(p)
+
+        print(f"::notice::Found {len(uniq)} .htm/.html candidates to scan", flush=True)
+        for remote in uniq:
+            scanned += 1
+            try:
+                with sftp.open(remote, "rb") as handle:
+                    raw = handle.read()
+            except OSError:
+                continue
+            if (
+                b"mc-plp-enforcer" not in raw
+                and b"bootFreshCta" not in raw
+                and b"mc-pdp-auth" not in raw
+            ):
+                continue
+            new_raw, changed = _patch_bytes(remote, raw)
+            if not changed:
+                continue
+            tmp = remote + ".enf-patch-tmp"
+            try:
+                try:
+                    sftp.remove(tmp)
+                except OSError:
+                    pass
+                with sftp.open(tmp, "wb") as handle:
+                    handle.write(new_raw)
+                try:
+                    sftp.remove(remote)
+                except OSError:
+                    pass
+                sftp.rename(tmp, remote)
+            except OSError as exc:
+                print(f"::warning::Failed to write {remote}: {exc}", flush=True)
+                continue
+            patched += 1
+            if _is_product_html(remote, new_raw.decode("utf-8", errors="ignore")):
+                pdp_patched += 1
+            print(f"::notice::Patched {remote}", flush=True)
+    finally:
+        try:
+            transport.close()
+        except Exception:
+            pass
+
+    print(
+        f"::notice::Baked HTML patch done scanned={scanned} patched={patched} pdp={pdp_patched}",
+        flush=True,
+    )
+    if patched == 0:
+        print(
+            "::warning::No baked .htm files patched on SFTP. "
+            "Do Volusion Design → File Editor → template_266.html → Save to rebake.",
+            flush=True,
+        )
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/template_266.UPLOAD-THIS.html
+++ b/template_266.UPLOAD-THIS.html
@@ -557,7 +557,7 @@ display:none!important;visibility:hidden!important;height:0!important;max-height
 </script>
 <!-- MC_DEPLOY_VERIFY_20260607revertplpmat: reverted gray PLP thumb mats from 7516154 -->
 <!-- MC_CSS_DEPLOY_VERIFY_20260607memberpricing: same token as /v/vspfiles/css/custom-safe.css line 1 -->
-<meta name="mc-deploy-verify" content="20260727007revert1">
+<meta name="mc-deploy-verify" content="20260727009live1">
 <meta name="mc-pdp-cache-buster" content="20260630catnav1">
 <meta name="mc-live-deploy-check" content="20260630-cat-nav-overlap-fix">
 <style type="text/css">@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/cyrillic-ext/wght/normal.woff2);unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/greek/wght/normal.woff2);unicode-range:U+0370-0377,U+037A-037F,U+0384-038A,U+038C,U+038E-03A1,U+03A3-03FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/greek-ext/wght/normal.woff2);unicode-range:U+1F00-1FFF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/latin/wght/normal.woff2);unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/cyrillic/wght/normal.woff2);unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/latin-ext/wght/normal.woff2);unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/vietnamese/wght/normal.woff2);unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/vietnamese/wght/normal.woff2);unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/cyrillic-ext/wght/normal.woff2);unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/cyrillic/wght/normal.woff2);unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/greek/wght/normal.woff2);unicode-range:U+0370-0377,U+037A-037F,U+0384-038A,U+038C,U+038E-03A1,U+03A3-03FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/greek-ext/wght/normal.woff2);unicode-range:U+1F00-1FFF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/latin-ext/wght/normal.woff2);unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/latin/wght/normal.woff2);unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/vietnamese/wght/normal.woff2);unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/greek/wght/normal.woff2);unicode-range:U+0370-0377,U+037A-037F,U+0384-038A,U+038C,U+038E-03A1,U+03A3-03FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/cyrillic-ext/wght/normal.woff2);unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/cyrillic/wght/normal.woff2);unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/greek-ext/wght/normal.woff2);unicode-range:U+1F00-1FFF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/latin/wght/normal.woff2);unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/latin-ext/wght/normal.woff2);unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/greek/wght/normal.woff2);unicode-range:U+0370-0377,U+037A-037F,U+0384-038A,U+038C,U+038E-03A1,U+03A3-03FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/latin/wght/normal.woff2);unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/cyrillic-ext/wght/normal.woff2);unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/cyrillic/wght/normal.woff2);unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/greek-ext/wght/normal.woff2);unicode-range:U+1F00-1FFF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/latin-ext/wght/normal.woff2);unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/vietnamese/wght/normal.woff2);unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-display:swap;}</style>
@@ -1480,20 +1480,32 @@ document.addEventListener("DOMContentLoaded", function () {
  
   <!-- DESIGN TOOLKIT -->
   <script src="v/vspfiles/templates/266/js/min/design-toolkit.min.js?v=20260625plp"></script>
-  <script id="mc-pdp-auth-cta-boot">/* PDP: mc-pdp-auth-cta-fix.js */</script>
+  <script id="mc-pdp-auth-cta-boot">/* PDP: mc-pdp-auth-cta-form.js */</script>
   <script>
 (function (g, d) {
   var FP = "20260725fix3";
+  var AUTH_SRC = "/v/vspfiles/js/mc-pdp-auth-cta-form.js?v=20260725live1&mcrd=live1";
+  function isPdp() {
+    try {
+      var p = String(g.location.pathname || "").toLowerCase();
+      if (/\/product-p\//.test(p) || /productdetails\.asp/i.test(p)) return true;
+    } catch (ePath) {}
+    return !!d.getElementById("v65-product-parent");
+  }
   function bootFreshCta() {
-    if (!d.getElementById("v65-product-parent")) return;
+    if (!isPdp()) return;
     if (String(g.__MC_DEPLOY_FP__ || "") === FP) return;
     if (d.documentElement.getAttribute("data-mc-pdp-auth-head-boot") === FP) return;
+    /* Never strip/reinject an in-flight auth script — that raced the PLP enforcer
+       and froze sofa PDPs while re-parsing ~700KB of JS. */
+    if (d.querySelector('script[src*="mc-pdp-auth-cta-form.js"]')) {
+      d.documentElement.setAttribute("data-mc-pdp-auth-head-boot", FP);
+      return;
+    }
     d.documentElement.setAttribute("data-mc-pdp-auth-head-boot", FP);
-    d.querySelectorAll('script[src*="mc-pdp-auth-cta-form.js"]').forEach(function (old) {
-      try { old.remove(); } catch (eRm) {}
-    });
     var s = d.createElement("script");
-    s.src = "/v/vspfiles/js/mc-pdp-auth-cta-form.js?v=20260725tap4&mcrd=" + Date.now();
+    s.id = "mc-pdp-auth-cta-form-js";
+    s.src = AUTH_SRC;
     s.async = false;
     (d.head || d.documentElement).appendChild(s);
   }
@@ -1696,19 +1708,59 @@ html.mc-mahjong-pdp-init:not(.mc-mahjong-pdp-ready) #mc-pdp-accordion{
 })(window, document);
   </script>
   <script id="mc-plp-enforcer-bridge">
-(function(g,d){var W="20260723restore12",vn=function(v){var n=parseInt(String(v||"").replace(/\D/g,""),10);return isNaN(n)?0:n;};
-
-function cat(){try{var p=String(g.location.pathname||"").toLowerCase();
-var isHome =
-  p === "/" ||
-  /\/default\.asp$/i.test(p) ||
-  /\/default\.html?$/i.test(p) ||
-  /\/index\.html?$/i.test(p);
-
-if (isHome) return false;
-
-if(g.document.body&&g.document.body.classList.contains("productdetails"))return false;if(/shoppingcart|one-page-checkout|checkout|orderconfirm/i.test(p))return false;if((/-s\//.test(p)||/category-s\//.test(p))&&/\.html?/i.test(p))return true;if(/productslist\.asp|searchresults\.asp/.test(p))return true;var r=d.getElementById("content_area");if(r&&r.querySelector(".v-product-grid a.v-product__img, ul.v-product-grid li.v-product"))return true;}catch(e){}return false;}function go(){if(!cat())return;if(vn(g.__MC_PLP_ENFORCER_VER__)>=vn(W)&&typeof g.mcPlpEnforcerRun==="function")return;d.querySelectorAll('script[src*="mc-plp-enforcer"]').forEach(function(s){try{s.remove();}catch(e2){}});delete g.__MC_PLP_ENFORCER__;delete g.__MC_PLP_ENFORCER_VER__;delete g.mcPlpEnforcerRun;var s=d.createElement("script");s.id="mc-plp-enforcer-js";s.src="/v/vspfiles/js/mc-plp-enforcer.js?v="+W+"&mcrd="+Date.now();s.onload=function(){try{g.mcPlpEnforcerRun&&g.mcPlpEnforcerRun();}catch(e3){}};(d.head||d.documentElement).appendChild(s);}if(d.readyState==="loading")d.addEventListener("DOMContentLoaded",go);else go();g.addEventListener("load",go);[0,200,900,2500].forEach(function(t){g.setTimeout(go,t);});})(window,document);
-  </script>
+/* MC_PLP_ENFORCER_BRIDGE_20260727009live1 — home/PLP only; never thrash; PDPs excluded */
+(function (g, d) {
+  var W = "20260727009live1";
+  var vn = function (v) {
+    var n = parseInt(String(v || "").replace(/\D/g, ""), 10);
+    return isNaN(n) ? 0 : n;
+  };
+  function want() {
+    try {
+      var p = String(g.location.pathname || "").toLowerCase();
+      if (/shoppingcart|one-page-checkout|checkout|orderconfirm/i.test(p)) return false;
+      if (/\/product-p\//.test(p) || /productdetails\.asp/i.test(p)) return false;
+      if (g.document.body && g.document.body.classList.contains("productdetails")) return false;
+      if (d.getElementById("v65-product-parent")) return false;
+      var isHome =
+        p === "/" ||
+        /\/default\.asp$/i.test(p) ||
+        /\/default\.html?$/i.test(p) ||
+        /\/index\.html?$/i.test(p) ||
+        (g.document.body && g.document.body.classList.contains("is-home"));
+      /* Home uses its own grid scripts; keep enforcer off home to avoid thrash. */
+      if (isHome) return false;
+      if ((/-s\//.test(p) || /category-s\//.test(p)) && /\.html?/i.test(p)) return true;
+      if (/productslist\.asp|searchresults\.asp/.test(p)) return true;
+      var r = d.getElementById("content_area");
+      if (r && r.querySelector(".v-product-grid a.v-product__img, ul.v-product-grid li.v-product, table.v65-productDisplay"))
+        return true;
+    } catch (e) {}
+    return false;
+  }
+  function go() {
+    if (!want()) return;
+    if (vn(g.__MC_PLP_ENFORCER_VER__) >= vn(W) && typeof g.mcPlpEnforcerRun === "function") {
+      try { g.mcPlpEnforcerRun(); } catch (eRun) {}
+      return;
+    }
+    if (g.__MC_PLP_ENFORCER_LOADING__) return;
+    g.__MC_PLP_ENFORCER_LOADING__ = true;
+    var s = d.createElement("script");
+    s.id = "mc-plp-enforcer-js-bridge";
+    s.src = "/v/vspfiles/js/mc-plp-enforcer.js?v=" + W + "&mcrd=live1";
+    s.onload = function () {
+      g.__MC_PLP_ENFORCER_LOADING__ = false;
+      try { g.mcPlpEnforcerRun && g.mcPlpEnforcerRun(); } catch (e3) {}
+    };
+    s.onerror = function () { g.__MC_PLP_ENFORCER_LOADING__ = false; };
+    (d.head || d.documentElement).appendChild(s);
+  }
+  if (d.readyState === "loading") d.addEventListener("DOMContentLoaded", go);
+  else go();
+  g.addEventListener("load", go);
+})(window, document);
+</script>
 
 
 <script id="mc-hero-logo-fallback">
@@ -2721,17 +2773,18 @@ document.addEventListener("DOMContentLoaded", function () {
 <script id="mc-pdp-auth-loader-minimal">
 (function () {
   var FP = "20260725fix3";
+  var AUTH_SRC = "/v/vspfiles/js/mc-pdp-auth-cta-form.js?v=20260725live1&mcrd=live1";
   if (String(window.__MC_DEPLOY_FP__ || "") === FP) {
   } else if (
     document.documentElement.getAttribute("data-mc-pdp-auth-reload") !== FP &&
     document.documentElement.getAttribute("data-mc-pdp-auth-head-boot") !== FP &&
-    !document.querySelector('script[src*="mc-pdp-auth-cta-form.js"][src*="20260725fix3"]')
+    !document.querySelector('script[src*="mc-pdp-auth-cta-form.js"]')
   ) {
-    /* Fallback only when head boot did not inject the current fingerprint.
-       Always use the versioned URL â€” unversioned CDN still serves stale copies. */
+    /* Fallback only when head boot did not inject. Stable URL — no Date.now() thrash. */
     document.documentElement.setAttribute("data-mc-pdp-auth-reload", FP);
     var s = document.createElement("script");
-    s.src = "/v/vspfiles/js/mc-pdp-auth-cta-form.js?v=20260725tap4&mcrd=" + Date.now();
+    s.id = "mc-pdp-auth-cta-form-js-fallback";
+    s.src = AUTH_SRC;
     s.async = false;
     (document.head || document.documentElement).appendChild(s);
   }
@@ -14777,7 +14830,23 @@ s0.parentNode.insertBefore(s1,s0);
 })();
 </script>
 <!--End of Tawk.to Script-->
-  <script id="mc-plp-enforcer-js" src="/v/vspfiles/js/mc-plp-enforcer.js?v=20260726001home1"></script>
+  <script id="mc-plp-enforcer-js">
+/* MC_PLP_ENFORCER_STATIC_20260727009live1 — skip product pages entirely */
+(function (g, d) {
+  try {
+    var p = String(g.location.pathname || "").toLowerCase();
+    if (/\/product-p\//.test(p) || /productdetails\.asp/i.test(p)) return;
+    if (d.getElementById("v65-product-parent")) return;
+    if (g.document.body && (g.document.body.classList.contains("productdetails") || g.document.body.classList.contains("mc-product-page"))) return;
+  } catch (eSkip) {}
+  if (d.getElementById("mc-plp-enforcer-js-src")) return;
+  if (typeof g.mcPlpEnforcerRun === "function" && g.__MC_PLP_ENFORCER_VER__) return;
+  var s = d.createElement("script");
+  s.id = "mc-plp-enforcer-js-src";
+  s.src = "/v/vspfiles/js/mc-plp-enforcer.js?v=20260727009live1&mcrd=live1";
+  (d.head || d.documentElement).appendChild(s);
+})(window, document);
+  </script>
  
   <script id="mc-my-boards-template-boot">
 (function () {

--- a/template_266.html
+++ b/template_266.html
@@ -557,7 +557,7 @@ display:none!important;visibility:hidden!important;height:0!important;max-height
 </script>
 <!-- MC_DEPLOY_VERIFY_20260607revertplpmat: reverted gray PLP thumb mats from 7516154 -->
 <!-- MC_CSS_DEPLOY_VERIFY_20260607memberpricing: same token as /v/vspfiles/css/custom-safe.css line 1 -->
-<meta name="mc-deploy-verify" content="20260727007revert1">
+<meta name="mc-deploy-verify" content="20260727009live1">
 <meta name="mc-pdp-cache-buster" content="20260630catnav1">
 <meta name="mc-live-deploy-check" content="20260630-cat-nav-overlap-fix">
 <style type="text/css">@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/cyrillic-ext/wght/normal.woff2);unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/greek/wght/normal.woff2);unicode-range:U+0370-0377,U+037A-037F,U+0384-038A,U+038C,U+038E-03A1,U+03A3-03FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/greek-ext/wght/normal.woff2);unicode-range:U+1F00-1FFF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/latin/wght/normal.woff2);unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/cyrillic/wght/normal.woff2);unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/latin-ext/wght/normal.woff2);unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:300;src:url(/cf-fonts/v/inter/5.2.8/vietnamese/wght/normal.woff2);unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/vietnamese/wght/normal.woff2);unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/cyrillic-ext/wght/normal.woff2);unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/cyrillic/wght/normal.woff2);unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/greek/wght/normal.woff2);unicode-range:U+0370-0377,U+037A-037F,U+0384-038A,U+038C,U+038E-03A1,U+03A3-03FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/greek-ext/wght/normal.woff2);unicode-range:U+1F00-1FFF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/latin-ext/wght/normal.woff2);unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:400;src:url(/cf-fonts/v/inter/5.2.8/latin/wght/normal.woff2);unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/vietnamese/wght/normal.woff2);unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/greek/wght/normal.woff2);unicode-range:U+0370-0377,U+037A-037F,U+0384-038A,U+038C,U+038E-03A1,U+03A3-03FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/cyrillic-ext/wght/normal.woff2);unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/cyrillic/wght/normal.woff2);unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/greek-ext/wght/normal.woff2);unicode-range:U+1F00-1FFF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/latin/wght/normal.woff2);unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:600;src:url(/cf-fonts/v/inter/5.2.8/latin-ext/wght/normal.woff2);unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/greek/wght/normal.woff2);unicode-range:U+0370-0377,U+037A-037F,U+0384-038A,U+038C,U+038E-03A1,U+03A3-03FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/latin/wght/normal.woff2);unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/cyrillic-ext/wght/normal.woff2);unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/cyrillic/wght/normal.woff2);unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/greek-ext/wght/normal.woff2);unicode-range:U+1F00-1FFF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/latin-ext/wght/normal.woff2);unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-display:swap;}@font-face {font-family:Inter;font-style:normal;font-weight:700;src:url(/cf-fonts/v/inter/5.2.8/vietnamese/wght/normal.woff2);unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-display:swap;}</style>
@@ -1480,20 +1480,32 @@ document.addEventListener("DOMContentLoaded", function () {
  
   <!-- DESIGN TOOLKIT -->
   <script src="v/vspfiles/templates/266/js/min/design-toolkit.min.js?v=20260625plp"></script>
-  <script id="mc-pdp-auth-cta-boot">/* PDP: mc-pdp-auth-cta-fix.js */</script>
+  <script id="mc-pdp-auth-cta-boot">/* PDP: mc-pdp-auth-cta-form.js */</script>
   <script>
 (function (g, d) {
   var FP = "20260725fix3";
+  var AUTH_SRC = "/v/vspfiles/js/mc-pdp-auth-cta-form.js?v=20260725live1&mcrd=live1";
+  function isPdp() {
+    try {
+      var p = String(g.location.pathname || "").toLowerCase();
+      if (/\/product-p\//.test(p) || /productdetails\.asp/i.test(p)) return true;
+    } catch (ePath) {}
+    return !!d.getElementById("v65-product-parent");
+  }
   function bootFreshCta() {
-    if (!d.getElementById("v65-product-parent")) return;
+    if (!isPdp()) return;
     if (String(g.__MC_DEPLOY_FP__ || "") === FP) return;
     if (d.documentElement.getAttribute("data-mc-pdp-auth-head-boot") === FP) return;
+    /* Never strip/reinject an in-flight auth script — that raced the PLP enforcer
+       and froze sofa PDPs while re-parsing ~700KB of JS. */
+    if (d.querySelector('script[src*="mc-pdp-auth-cta-form.js"]')) {
+      d.documentElement.setAttribute("data-mc-pdp-auth-head-boot", FP);
+      return;
+    }
     d.documentElement.setAttribute("data-mc-pdp-auth-head-boot", FP);
-    d.querySelectorAll('script[src*="mc-pdp-auth-cta-form.js"]').forEach(function (old) {
-      try { old.remove(); } catch (eRm) {}
-    });
     var s = d.createElement("script");
-    s.src = "/v/vspfiles/js/mc-pdp-auth-cta-form.js?v=20260725tap4&mcrd=" + Date.now();
+    s.id = "mc-pdp-auth-cta-form-js";
+    s.src = AUTH_SRC;
     s.async = false;
     (d.head || d.documentElement).appendChild(s);
   }
@@ -1696,19 +1708,59 @@ html.mc-mahjong-pdp-init:not(.mc-mahjong-pdp-ready) #mc-pdp-accordion{
 })(window, document);
   </script>
   <script id="mc-plp-enforcer-bridge">
-(function(g,d){var W="20260723restore12",vn=function(v){var n=parseInt(String(v||"").replace(/\D/g,""),10);return isNaN(n)?0:n;};
-
-function cat(){try{var p=String(g.location.pathname||"").toLowerCase();
-var isHome =
-  p === "/" ||
-  /\/default\.asp$/i.test(p) ||
-  /\/default\.html?$/i.test(p) ||
-  /\/index\.html?$/i.test(p);
-
-if (isHome) return false;
-
-if(g.document.body&&g.document.body.classList.contains("productdetails"))return false;if(/shoppingcart|one-page-checkout|checkout|orderconfirm/i.test(p))return false;if((/-s\//.test(p)||/category-s\//.test(p))&&/\.html?/i.test(p))return true;if(/productslist\.asp|searchresults\.asp/.test(p))return true;var r=d.getElementById("content_area");if(r&&r.querySelector(".v-product-grid a.v-product__img, ul.v-product-grid li.v-product"))return true;}catch(e){}return false;}function go(){if(!cat())return;if(vn(g.__MC_PLP_ENFORCER_VER__)>=vn(W)&&typeof g.mcPlpEnforcerRun==="function")return;d.querySelectorAll('script[src*="mc-plp-enforcer"]').forEach(function(s){try{s.remove();}catch(e2){}});delete g.__MC_PLP_ENFORCER__;delete g.__MC_PLP_ENFORCER_VER__;delete g.mcPlpEnforcerRun;var s=d.createElement("script");s.id="mc-plp-enforcer-js";s.src="/v/vspfiles/js/mc-plp-enforcer.js?v="+W+"&mcrd="+Date.now();s.onload=function(){try{g.mcPlpEnforcerRun&&g.mcPlpEnforcerRun();}catch(e3){}};(d.head||d.documentElement).appendChild(s);}if(d.readyState==="loading")d.addEventListener("DOMContentLoaded",go);else go();g.addEventListener("load",go);[0,200,900,2500].forEach(function(t){g.setTimeout(go,t);});})(window,document);
-  </script>
+/* MC_PLP_ENFORCER_BRIDGE_20260727009live1 — home/PLP only; never thrash; PDPs excluded */
+(function (g, d) {
+  var W = "20260727009live1";
+  var vn = function (v) {
+    var n = parseInt(String(v || "").replace(/\D/g, ""), 10);
+    return isNaN(n) ? 0 : n;
+  };
+  function want() {
+    try {
+      var p = String(g.location.pathname || "").toLowerCase();
+      if (/shoppingcart|one-page-checkout|checkout|orderconfirm/i.test(p)) return false;
+      if (/\/product-p\//.test(p) || /productdetails\.asp/i.test(p)) return false;
+      if (g.document.body && g.document.body.classList.contains("productdetails")) return false;
+      if (d.getElementById("v65-product-parent")) return false;
+      var isHome =
+        p === "/" ||
+        /\/default\.asp$/i.test(p) ||
+        /\/default\.html?$/i.test(p) ||
+        /\/index\.html?$/i.test(p) ||
+        (g.document.body && g.document.body.classList.contains("is-home"));
+      /* Home uses its own grid scripts; keep enforcer off home to avoid thrash. */
+      if (isHome) return false;
+      if ((/-s\//.test(p) || /category-s\//.test(p)) && /\.html?/i.test(p)) return true;
+      if (/productslist\.asp|searchresults\.asp/.test(p)) return true;
+      var r = d.getElementById("content_area");
+      if (r && r.querySelector(".v-product-grid a.v-product__img, ul.v-product-grid li.v-product, table.v65-productDisplay"))
+        return true;
+    } catch (e) {}
+    return false;
+  }
+  function go() {
+    if (!want()) return;
+    if (vn(g.__MC_PLP_ENFORCER_VER__) >= vn(W) && typeof g.mcPlpEnforcerRun === "function") {
+      try { g.mcPlpEnforcerRun(); } catch (eRun) {}
+      return;
+    }
+    if (g.__MC_PLP_ENFORCER_LOADING__) return;
+    g.__MC_PLP_ENFORCER_LOADING__ = true;
+    var s = d.createElement("script");
+    s.id = "mc-plp-enforcer-js-bridge";
+    s.src = "/v/vspfiles/js/mc-plp-enforcer.js?v=" + W + "&mcrd=live1";
+    s.onload = function () {
+      g.__MC_PLP_ENFORCER_LOADING__ = false;
+      try { g.mcPlpEnforcerRun && g.mcPlpEnforcerRun(); } catch (e3) {}
+    };
+    s.onerror = function () { g.__MC_PLP_ENFORCER_LOADING__ = false; };
+    (d.head || d.documentElement).appendChild(s);
+  }
+  if (d.readyState === "loading") d.addEventListener("DOMContentLoaded", go);
+  else go();
+  g.addEventListener("load", go);
+})(window, document);
+</script>
 
 
 <script id="mc-hero-logo-fallback">
@@ -2721,17 +2773,18 @@ document.addEventListener("DOMContentLoaded", function () {
 <script id="mc-pdp-auth-loader-minimal">
 (function () {
   var FP = "20260725fix3";
+  var AUTH_SRC = "/v/vspfiles/js/mc-pdp-auth-cta-form.js?v=20260725live1&mcrd=live1";
   if (String(window.__MC_DEPLOY_FP__ || "") === FP) {
   } else if (
     document.documentElement.getAttribute("data-mc-pdp-auth-reload") !== FP &&
     document.documentElement.getAttribute("data-mc-pdp-auth-head-boot") !== FP &&
-    !document.querySelector('script[src*="mc-pdp-auth-cta-form.js"][src*="20260725fix3"]')
+    !document.querySelector('script[src*="mc-pdp-auth-cta-form.js"]')
   ) {
-    /* Fallback only when head boot did not inject the current fingerprint.
-       Always use the versioned URL â€” unversioned CDN still serves stale copies. */
+    /* Fallback only when head boot did not inject. Stable URL — no Date.now() thrash. */
     document.documentElement.setAttribute("data-mc-pdp-auth-reload", FP);
     var s = document.createElement("script");
-    s.src = "/v/vspfiles/js/mc-pdp-auth-cta-form.js?v=20260725tap4&mcrd=" + Date.now();
+    s.id = "mc-pdp-auth-cta-form-js-fallback";
+    s.src = AUTH_SRC;
     s.async = false;
     (document.head || document.documentElement).appendChild(s);
   }
@@ -14777,7 +14830,23 @@ s0.parentNode.insertBefore(s1,s0);
 })();
 </script>
 <!--End of Tawk.to Script-->
-  <script id="mc-plp-enforcer-js" src="/v/vspfiles/js/mc-plp-enforcer.js?v=20260726001home1"></script>
+  <script id="mc-plp-enforcer-js">
+/* MC_PLP_ENFORCER_STATIC_20260727009live1 — skip product pages entirely */
+(function (g, d) {
+  try {
+    var p = String(g.location.pathname || "").toLowerCase();
+    if (/\/product-p\//.test(p) || /productdetails\.asp/i.test(p)) return;
+    if (d.getElementById("v65-product-parent")) return;
+    if (g.document.body && (g.document.body.classList.contains("productdetails") || g.document.body.classList.contains("mc-product-page"))) return;
+  } catch (eSkip) {}
+  if (d.getElementById("mc-plp-enforcer-js-src")) return;
+  if (typeof g.mcPlpEnforcerRun === "function" && g.__MC_PLP_ENFORCER_VER__) return;
+  var s = d.createElement("script");
+  s.id = "mc-plp-enforcer-js-src";
+  s.src = "/v/vspfiles/js/mc-plp-enforcer.js?v=20260727009live1&mcrd=live1";
+  (d.head || d.documentElement).appendChild(s);
+})(window, document);
+  </script>
  
   <script id="mc-my-boards-template-boot">
 (function () {

--- a/vspfiles/js/mc-pdp-auth-cta-form.js
+++ b/vspfiles/js/mc-pdp-auth-cta-form.js
@@ -8,10 +8,10 @@
 
   // MC_DEPLOY_FINGERPRINT_20260725fix3 — keep boot FP; mobile tap / accordion churn fix
   var MC_DEPLOY_FINGERPRINT = "20260725fix3";
-  var VERSION = "20260725revert1";
+  var VERSION = "20260725live1";
   /* Prefer numeric deploy rank so old labels like style1/restore15 cannot
      lexicographically beat a newer fix* VERSION and keep this IIFE from booting. */
-  var DEPLOY_RANK = 20260725050;
+  var DEPLOY_RANK = 20260725060;
   var ALT_VIEW_ROW_VER = "20260725altmatch1";
   try {
     var prevRank = Number(global.__MC_PDP_AUTH_CTA_DEPLOY_RANK__ || 0) || 0;
@@ -19,6 +19,31 @@
     global.__MC_PDP_AUTH_CTA_DEPLOY_RANK__ = DEPLOY_RANK;
     global.__MC_PDP_AUTH_CTA_MAX_VER__ = VERSION;
   } catch (eMax) {}
+  /* Do NOT strip/reinject mc-plp-enforcer from PDP boots — that caused load loops. */
+
+  /* Barron / SS sofa freeze: baked pages still load sticky mc-plp-enforcer
+     (?mcrd=safe1). Its #content_area price MutationObserver walks the whole
+     tree on every childList mutation. Auth boots with ?mcrd=Date.now(), so
+     neutralize that path here even before template rebake. */
+  try {
+    if (global.document && global.document.getElementById("v65-product-parent")) {
+      global.mcStripPriceZeroCents = function () {};
+      global.mcPlpEnforcerRun = function () {};
+      try {
+        var prevPlp = parseInt(
+          String(global.__MC_PLP_ENFORCER_VER__ || "").replace(/\D/g, ""),
+          10
+        );
+        var wantPlp = 202607270091;
+        if (!(prevPlp >= wantPlp)) {
+          global.__MC_PLP_ENFORCER_VER__ = "20260727009live1";
+        }
+      } catch (ePlpLatch) {
+        global.__MC_PLP_ENFORCER_VER__ = "20260727009live1";
+      }
+    }
+  } catch (eUnfreeze) {}
+
   /* Do NOT strip form.js script tags. Baked boots require tag presence and
      __MC_DEPLOY_FP__==="20260725fix3"; stripping caused endless reinject/loading loops. */
 
@@ -841,7 +866,15 @@
     } catch (eStrip) {}
   }
 
-  global.mcStripPriceZeroCents = stripPriceZeroCents;
+  /* On PDPs, keep this a no-op. mc-plp-enforcer's price MO calls
+     global.mcStripPriceZeroCents when present; a real implementation here
+     would still mutate text and re-trigger that observer (Barron freeze). */
+  global.mcStripPriceZeroCents = function (root) {
+    try {
+      if (global.document.getElementById("v65-product-parent")) return;
+    } catch (ePdpStrip) {}
+    return stripPriceZeroCents(root);
+  };
 
   function authDelay(ms) {
     return new Promise(function (resolve) {

--- a/vspfiles/js/mc-plp-enforcer.js
+++ b/vspfiles/js/mc-plp-enforcer.js
@@ -1,16 +1,16 @@
 ﻿/**
  * PLP fixes â€” DOM-driven, scoped to inspected Volusion markup.
- * MC_PLP_ENFORCER_20260727008revert1 — hard revert to working PR30 storefront
+ * MC_PLP_ENFORCER_20260727009live1 — PDP early-exit; category/home only
  *
  * Thumbnails: .mc-plp-image-box; image element sized to the wrapper, object-fit: contain (no crop).
  */
 (function (global) {
   "use strict";
 
-  /* forceLoveyStyleCta REMOVED 20260722manual4 â€” was unloading CTA and freezing lovey PDPs */
+    /* forceLoveyStyleCta REMOVED 20260722manual4 â€” was unloading CTA and freezing lovey PDPs */
 
   /* Digit string must beat prior live latch 202607259999 or this file no-ops. */
-  var VERSION = "20260727008revert1"; /* REVERT to pre-freeze PR30 storefront */
+  var VERSION = "20260727009live1";
 
   function plpVerNum(v) {
     var n = parseInt(String(v || "").replace(/\D/g, ""), 10);
@@ -28,6 +28,29 @@
   }
   global.__MC_PLP_ENFORCER_VER__ = VERSION;
   global.__MC_PLP_ENFORCER__ = true;
+
+  /* Barron / sofa freeze: sticky CDN enforcer + price MutationObserver on
+     #content_area fought mc-pdp-auth-cta-form.js and froze Steve Silver sofa
+     PDPs. Exit before any observers or reinjectors install. */
+  function isProductDetailPageEarly() {
+    try {
+      var p = String(global.location.pathname || "").toLowerCase();
+      if (/\/product-p\//.test(p) || /productdetails\.asp/i.test(p)) return true;
+      if (global.document && global.document.getElementById("v65-product-parent")) return true;
+      var b = global.document && global.document.body;
+      if (
+        b &&
+        (b.classList.contains("productdetails") || b.classList.contains("mc-product-page"))
+      ) {
+        return true;
+      }
+    } catch (ePdpEarly) {}
+    return false;
+  }
+  if (isProductDetailPageEarly()) {
+    global.mcPlpEnforcerRun = function () {};
+    return;
+  }
 
   function upgradePdpAuthCtaForm() {
     try {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Barron (and other sofa PDPs) freeze on load because baked product HTML still:
1. Runs `bootFreshCta` before `#v65-product-parent` exists (returns without setting the boot flag)
2. Body fallback injects auth, then DOMContentLoaded strips/reinjects → **two ~700KB** `mc-pdp-auth-cta-form.js` loads
3. Sticky CDN `mc-plp-enforcer.js?mcrd=safe1` installs a `#content_area` price `MutationObserver` that thrashs the main thread

## Fix
- Stable auth URL (`?v=20260725live1&mcrd=live1`) — no `Date.now()` double-load
- Path-based PDP detection; **never strip/reinject** an in-flight auth script
- Enforcer early-exits on product pages; template static loader skips PDPs
- Re-enable SFTP baked-HTML patcher so Barron `.htm` files are rewritten on deploy (no Cloudflare required)

## Deploy marker
`mc-deploy-verify=20260727009live1`

## Verify after merge/deploy
Open https://www.mccabestheaterandliving.com/product-p/ss-barron-87sofa.htm
- Page becomes interactive
- Single auth script load
- No sticky `mcrd=safe1` enforcer thrash

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9b4a-fdde-7b71-afd3-b06a09fa9979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9b4a-fdde-7b71-afd3-b06a09fa9979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

