### PR TITLE
Barron loads: skip freezing auth impl on Steve Silver PDPs

### DIFF
--- a/scripts/verify_mc_pdp_js_sftp.py
+++ b/scripts/verify_mc_pdp_js_sftp.py
@@ -10,7 +10,7 @@ import sys
 CANONICAL = {
     "vspfiles/js/mc-pdp-auth-cta-form.js": (
         "/v/vspfiles/js/mc-pdp-auth-cta-form.js",
-        "MC_PDP_AUTH_ONCE_20260727010once1",
+        "MC_PDP_AUTH_ONCE_20260727011once2",
     ),
     "vspfiles/js/mc-pdp-auth-cta-form-impl.js": (
         "/v/vspfiles/js/mc-pdp-auth-cta-form-impl.js",

--- a/vspfiles/js/mc-pdp-auth-cta-form.js
+++ b/vspfiles/js/mc-pdp-auth-cta-form.js
@@ -1,20 +1,20 @@
 /**
  * PDP auth entry — tiny once-loader.
- * Baked Barron/sofa HTML still strip/reinjects this URL with Date.now(), which
- * previously re-parsed ~700KB twice and froze the main thread. This stub is
- * cheap to load twice; the real implementation loads at most once.
- * MC_PDP_AUTH_ONCE_20260727010once1
+ * Baked Barron/sofa HTML still strip/reinjects this URL with Date.now().
+ * The ~700KB impl currently hard-freezes Steve Silver sofa PDPs (main thread
+ * never recovers). Skip impl on those paths so the page can load; other PDPs
+ * still get the full auth script once.
+ * MC_PDP_AUTH_ONCE_20260727011once2
  * mcEnsurePdpPriceStack — provided by mc-pdp-auth-cta-form-impl.js (SFTP verify needle)
  */
 (function (global) {
   "use strict";
 
   try {
-    /* Neutralize sticky CDN mc-plp-enforcer (?mcrd=safe1) before it installs
-       price MutationObservers. Old cached builds early-return when VER is higher. */
+    /* Neutralize sticky CDN mc-plp-enforcer (?mcrd=safe1) before/while it loads. */
     var prevPlp = parseInt(String(global.__MC_PLP_ENFORCER_VER__ || "").replace(/\D/g, ""), 10);
     if (!(prevPlp >= 20269999999)) {
-      global.__MC_PLP_ENFORCER_VER__ = "20269999999once1";
+      global.__MC_PLP_ENFORCER_VER__ = "20269999999once2";
     }
     global.mcPlpEnforcerRun = function () {};
     global.mcStripPriceZeroCents = function () {};
@@ -23,13 +23,35 @@
   if (global.__MC_PDP_AUTH_ONCE_LOADER__) return;
   global.__MC_PDP_AUTH_ONCE_LOADER__ = true;
 
+  function skipHeavyAuthImpl() {
+    try {
+      var p = String((global.location && global.location.pathname) || "").toLowerCase();
+      /* Confirmed freeze: any full auth impl (PR30/sofa5/live1) locks Barron. */
+      if (/\/product-p\/ss-/.test(p)) return true;
+      if (/ss-barron|ss-luna/.test(p)) return true;
+      var pc = global.document && global.document.querySelector(
+        '#v65-product-parent input[name="ProductCode"], input[name="ProductCode"]'
+      );
+      var code = String((pc && pc.value) || "").toUpperCase();
+      if (/^SS-/.test(code)) return true;
+    } catch (eSkip) {}
+    return false;
+  }
+
+  if (skipHeavyAuthImpl()) {
+    try {
+      global.document.documentElement.setAttribute("data-mc-pdp-auth-skip-impl", "ss-unfreeze");
+    } catch (eAttr) {}
+    return;
+  }
+
   try {
     if (global.document && global.document.querySelector('script[src*="mc-pdp-auth-cta-form-impl.js"]')) {
       return;
     }
   } catch (eHas) {}
 
-  var IMPL = "/v/vspfiles/js/mc-pdp-auth-cta-form-impl.js?v=20260725live1&mcrd=once1";
+  var IMPL = "/v/vspfiles/js/mc-pdp-auth-cta-form-impl.js?v=20260725live1&mcrd=once2";
   try {
     var s = global.document.createElement("script");
     s.id = "mc-pdp-auth-cta-form-impl-js";

--- a/vspfiles/js/mc-pdp-price-stack.js
+++ b/vspfiles/js/mc-pdp-price-stack.js
@@ -1,7 +1,20 @@
 
 /* MC_FORCE_LOVEY_STYLE_CTA REMOVED 20260722manual4 */
 
-
+/* Runs before baked mc-plp-enforcer-bridge — latch sticky CDN enforcer so sofa PDPs
+   do not install #content_area price MutationObservers (Barron freeze). */
+(function (g) {
+  "use strict";
+  try {
+    var p = String((g.location && g.location.pathname) || "").toLowerCase();
+    var onPdp = /\/product-p\//.test(p) || /productdetails\.asp/i.test(p);
+    if (!onPdp && !(g.document && g.document.getElementById("v65-product-parent"))) return;
+    var prev = parseInt(String(g.__MC_PLP_ENFORCER_VER__ || "").replace(/\D/g, ""), 10);
+    if (!(prev >= 20269999999)) g.__MC_PLP_ENFORCER_VER__ = "20269999999pricestack";
+    g.mcPlpEnforcerRun = function () {};
+    g.mcStripPriceZeroCents = function () {};
+  } catch (eEarly) {}
+})(window);
 
 /**
  * PDP retail/member/sale stack repair — works without template_266 rebake.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Reality check
Live Barron was still hard-frozen after #39. Playwright proved:
- **Block `mc-pdp-auth-cta-form-impl.js` → Barron loads** (product code + ATC in ~4s)
- **Load any full auth impl (PR30 / revert / sofa5 / live1) → main thread busy 70s+**

Double-load was real, but the remaining freeze is inside the heavy auth script itself on SS PDPs.

## Fix
- Tiny stub skips loading impl on `/product-p/ss-*` (and SS product codes)
- Early enforcer latch in `mc-pdp-price-stack.js` (runs before baked enforcer bridge)
- Local proof: Barron interactive with `data-mc-pdp-auth-skip-impl=ss-unfreeze`

## Tradeoff
Steve Silver PDPs load without the heavy auth/member UI script until that loop is fixed. Page load > broken page.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9b4a-fdde-7b71-afd3-b06a09fa9979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9b4a-fdde-7b71-afd3-b06a09fa9979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

