### PR TITLE
Upload Steve Silver dining/game/server photos to Volusion SFTP

### DIFF
--- a/.github/workflows/deploy-plp-photos.yml
+++ b/.github/workflows/deploy-plp-photos.yml
@@ -54,7 +54,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          # Need full history so github.event.before (often many commits back
+          # after a batch push) can resolve for changed-photo detection.
+          fetch-depth: 0
 
       - name: Install lftp and Paramiko
         run: |

--- a/.github/workflows/deploy-ss-bedroom-photos.yml
+++ b/.github/workflows/deploy-ss-bedroom-photos.yml
@@ -18,7 +18,8 @@ concurrency:
 jobs:
   upload:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Game/dining/server import packs can be 1000+ files.
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +44,8 @@ jobs:
             SS-BC900KFB-1.jpg SS-BC900QFB-1.jpg SS-CAS900KFB-1.jpg SS-RV900KFB-1.jpg \
             SS-CONROE-PWR-CHAISE-SECT-1.jpg SS-GATLIN-PWR-SECT-1.jpg SS-DANIEL-PWR-SOFA-1.jpg \
             SS-KEILY-BROWN-86SOFA-1.jpg SS-DENVER-BROWN-PWR-SECT-1.jpg SS-NOAH-GRAY-SLEEPER-SOFA-1.jpg \
-            SS-BC900MR-1T.jpg SS-CAS900M-1T.jpg SS-CONROE-PWR-CHAISE-SECT-1T.jpg; do
+            SS-BC900MR-1T.jpg SS-CAS900M-1T.jpg SS-CONROE-PWR-CHAISE-SECT-1T.jpg \
+            SS-ABR500KSV-1.jpg SS-RL500K-GT-D6PC-1.jpg SS-BUR500NSV-1.jpg SS-VCM420WTN-C5PC-1.jpg; do
             if [ ! -f "vspfiles/photos/$f" ]; then
               echo "skip $f (not in repo)"
               continue

--- a/scripts/upload_steve_silver_bedroom_photos.py
+++ b/scripts/upload_steve_silver_bedroom_photos.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Upload Steve Silver PLP/PDP photos to Volusion SFTP.
 
-Ensures SS-* bedroom and upholstery images reach /v/vspfiles/photos/ even when
-the generic changed-files deploy misses files.
+Ensures SS-* bedroom, upholstery, game, dining, and server images reach
+/v/vspfiles/photos/ even when the generic changed-files deploy misses files.
 """
 from __future__ import annotations
 
@@ -14,6 +14,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 PHOTOS = ROOT / "vspfiles" / "photos"
 PATTERNS = (
+    # Bedroom / upholstery
     "SS-BC*.jpg",
     "SS-CAS*.jpg",
     "SS-HP900*.jpg",
@@ -30,6 +31,19 @@ PATTERNS = (
     "SS-OLSEN*.jpg",
     "SS-KEILY*.jpg",
     "SS-NOAH*.jpg",
+    # Game table sets, dining groups, servers (Volusion import pack)
+    "SS-RL*.jpg",
+    "SS-ABR*.jpg",
+    "SS-COL*.jpg",
+    "SS-MM*.jpg",
+    "SS-NP*.jpg",
+    "SS-GA*.jpg",
+    "SS-TU*.jpg",
+    "SS-RED*.jpg",
+    "SS-JS*.jpg",
+    "SS-CBR*.jpg",
+    "SS-BUR*.jpg",
+    "SS-VCM*.jpg",
 )
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Spreadsheets from the Steve Silver Volusion import pack are already live under `/v/vspfiles/imports/steve-silver-volusion/` (deploy run succeeded).
- Product photos from that pack never reached SFTP (changed-photo detection used a shallow checkout and skipped ~1050 files).
- This expands the Steve Silver SFTP photo sync to include game/dining/server SKU prefixes, raises the fast photo workflow timeout to 90 minutes, and sets PLP photo checkout `fetch-depth: 0` so batch pushes detect photo changes correctly.

## FileZilla paths (after deploy)
- Spreadsheets: `/vspfiles/imports/steve-silver-volusion/` (also `/v/vspfiles/imports/steve-silver-volusion/`)
- Product images: `/vspfiles/photos/`

## Test plan
- [x] Confirm CSVs HTTP 200 on `/v/vspfiles/imports/steve-silver-volusion/`
- [ ] After merge: Deploy Steve Silver photos (fast) succeeds
- [ ] Spot-check live CDN: `SS-ABR500KSV-1.jpg`, `SS-RL500K-GT-D6PC-1.jpg`, `SS-BUR500NSV-1.jpg`, `SS-VCM420WTN-C5PC-1.jpg`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9b4a-fdde-7b71-afd3-b06a09fa9979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9b4a-fdde-7b71-afd3-b06a09fa9979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

